### PR TITLE
fix: prevent install.sh from hanging when run via curl | bash

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -93,7 +93,7 @@ for cat in m.get('categories', {}).values():
             seen.add(f)
             print(f)
 " | while read -r sfile; do
-      curl -fsSL "$REPO_BASE/packs/$pack/sounds/$sfile" -o "$INSTALL_DIR/packs/$pack/sounds/$sfile"
+      curl -fsSL "$REPO_BASE/packs/$pack/sounds/$sfile" -o "$INSTALL_DIR/packs/$pack/sounds/$sfile" </dev/null
     done
   done
   if [ "$UPDATING" = false ]; then


### PR DESCRIPTION
## Problem

Running the recommended install command hangs indefinitely at "Downloading from GitHub...":

```bash
curl -fsSL https://raw.githubusercontent.com/tonyyont/peon-ping/main/install.sh | bash
```

## Reproduction

Tested on macOS 15 (Darwin 25.2.0). The command hangs every time at the sound download phase. The process never completes and must be killed manually.

**Workaround that confirms the root cause** — downloading first and then executing works perfectly:

```bash
curl -fsSL https://raw.githubusercontent.com/tonyyont/peon-ping/main/install.sh -o /tmp/peon-install.sh && bash /tmp/peon-install.sh
```

This installs all 105 sound files across the 7 packs without issues, confirming the problem is specific to the `curl | bash` piping pattern.

## Root Cause

The script downloads sound files inside a `while read` loop piped from python3 output. When executed via `curl | bash`, bash's stdin is the pipe from curl (the script content itself). The inner `curl` calls inherit this stdin and consume bytes from the script stream, causing the installer to stall.

This is a [well-known pitfall](https://mywiki.wooledge.org/BashFAQ/024) with `curl | bash` patterns when the script contains commands that read from stdin.

With 105 sound files across 7 packs, the issue is practically guaranteed to occur.

## Fix

Redirect stdin from `/dev/null` for the `curl` calls inside the `while read` loop:

```bash
curl -fsSL "..." -o "..." </dev/null
```

This prevents the inner curl from interfering with the pipe that feeds the loop.