### PR TITLE
feat: add WSL2 (Windows) platform support

### DIFF
--- a/uninstall.sh
+++ b/uninstall.sh
@@ -14,7 +14,7 @@ echo ""
 # --- Remove hook entries from settings.json ---
 if [ -f "$SETTINGS" ]; then
   echo "Removing peon hooks from settings.json..."
-  /usr/bin/python3 -c "
+  python3 -c "
 import json, os
 
 settings_path = '$SETTINGS'
@@ -60,7 +60,7 @@ if [ -f "$NOTIFY_BACKUP" ]; then
   echo
   if [[ ! $REPLY =~ ^[Nn]$ ]]; then
     # Re-register notify.sh for its original events
-    /usr/bin/python3 -c "
+    python3 -c "
 import json
 
 settings_path = '$SETTINGS'


### PR DESCRIPTION
## Summary

Adds WSL2 support to peon-ping so it works on Windows via Windows Subsystem for Linux, while **preserving all existing macOS behavior unchanged**.

- **Platform detection** at script startup (`Darwin` → mac, `/proc/version` containing "microsoft" → wsl)
- **Audio playback on WSL** via PowerShell's WPF `MediaPlayer` (supports WAV + volume control, matching `afplay` functionality)
- **Visual notifications on WSL** via WinForms topmost popup windows — color-coded by event type (blue=complete, red=permission, yellow=idle), shown on all screens, with vertical stacking for concurrent sessions
- **macOS notification** via `osascript` (unchanged, just wrapped in platform branch)
- **Portable python3 path**: `/usr/bin/python3` → `python3` (uses PATH lookup, works on both platforms)

## What this does NOT change

All macOS code paths are functionally identical — they're simply wrapped in `case "$PLATFORM" in mac)` branches. The only cross-platform change is the python3 path, which is more portable and still works on macOS.

## Why WinForms popups instead of native Windows toasts?

WSL2 can't reliably trigger Windows toast notifications (WinRT APIs fail silently from the WSL context). WinForms `TopMost` windows are lightweight, reliable, and provide color coding + multi-screen support out of the box.

## Test plan

- [ ] Verify macOS install + uninstall still works identically
- [ ] Install on WSL2 Ubuntu via `bash install.sh`
- [ ] Verify sound playback works (PowerShell MediaPlayer)
- [ ] Verify popup notifications appear on all screens
- [ ] Test with multiple concurrent Claude Code sessions (popup stacking)
- [ ] Test `peon --status`, `peon --toggle`, `peon --packs`, `peon --pack <name>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)