### PR TITLE
feat: add PermissionRequest hook event support

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -215,7 +215,7 @@ peon_entry = {
 }
 
 # Events to register
-events = ['SessionStart', 'UserPromptSubmit', 'Stop', 'Notification']
+events = ['SessionStart', 'UserPromptSubmit', 'Stop', 'Notification', 'PermissionRequest']
 
 for event in events:
     event_hooks = hooks.get(event, [])

--- a/peon.sh
+++ b/peon.sh
@@ -468,6 +468,14 @@ case "$EVENT" in
       exit 0
     fi
     ;;
+  PermissionRequest)
+    CATEGORY="permission"
+    STATUS="needs approval"
+    MARKER="● "
+    NOTIFY=1
+    NOTIFY_COLOR="red"
+    MSG="$PROJECT  —  A tool is waiting for your permission"
+    ;;
   # PostToolUseFailure — no sound. Claude retries on its own.
   *)
     exit 0

--- a/tests/install.bats
+++ b/tests/install.bats
@@ -47,12 +47,12 @@ teardown() {
 @test "fresh install registers hooks in settings.json" {
   bash "$CLONE_DIR/install.sh"
   [ -f "$TEST_HOME/.claude/settings.json" ]
-  # Check that all four events are registered
+  # Check that all five events are registered
   /usr/bin/python3 -c "
 import json
 s = json.load(open('$TEST_HOME/.claude/settings.json'))
 hooks = s.get('hooks', {})
-for event in ['SessionStart', 'UserPromptSubmit', 'Stop', 'Notification']:
+for event in ['SessionStart', 'UserPromptSubmit', 'Stop', 'Notification', 'PermissionRequest']:
     assert event in hooks, f'{event} not in hooks'
     found = any('peon.sh' in h.get('command','') for entry in hooks[event] for h in entry.get('hooks',[]))
     assert found, f'peon.sh not registered for {event}'

--- a/tests/peon.bats
+++ b/tests/peon.bats
@@ -62,6 +62,14 @@ teardown() {
   ! afplay_was_called
 }
 
+@test "PermissionRequest plays a permission sound" {
+  run_peon '{"hook_event_name":"PermissionRequest","cwd":"/tmp/myproject","session_id":"s1","permission_mode":"default"}'
+  [ "$PEON_EXIT" -eq 0 ]
+  afplay_was_called
+  sound=$(afplay_sound)
+  [[ "$sound" == *"/packs/peon/sounds/Perm"* ]]
+}
+
 # ============================================================
 # Disabled config
 # ============================================================
@@ -321,6 +329,13 @@ JSON
 @test "paused file suppresses notification on permission_prompt" {
   touch "$TEST_DIR/.paused"
   run_peon '{"hook_event_name":"Notification","notification_type":"permission_prompt","cwd":"/tmp/myproject","session_id":"s1","permission_mode":"default"}'
+  [ "$PEON_EXIT" -eq 0 ]
+  ! afplay_was_called
+}
+
+@test "paused file suppresses sound on PermissionRequest" {
+  touch "$TEST_DIR/.paused"
+  run_peon '{"hook_event_name":"PermissionRequest","cwd":"/tmp/myproject","session_id":"s1","permission_mode":"default"}'
   [ "$PEON_EXIT" -eq 0 ]
   ! afplay_was_called
 }


### PR DESCRIPTION
IDE users (VSCode, JetBrains) receive PermissionRequest instead of Notification.permission_prompt. Handle it the same way: play the permission sound, set tab title to "needs approval", and fire a desktop notification.

Closes tonyyont/peon-ping#11