### PR TITLE
fix: scope annoyed timestamps to session_id

### DIFF
--- a/peon.sh
+++ b/peon.sh
@@ -357,6 +357,7 @@ check_annoyed() {
 import json, time, sys, os
 
 state_file = '$STATE'
+session_id = '$SESSION_ID'
 now = time.time()
 window = float('$ANNOYED_WINDOW')
 threshold = int('$ANNOYED_THRESHOLD')
@@ -366,11 +367,15 @@ try:
 except:
     state = {}
 
-timestamps = state.get('prompt_timestamps', [])
+all_timestamps = state.get('prompt_timestamps', {})
+if isinstance(all_timestamps, list):
+    all_timestamps = {}
+timestamps = all_timestamps.get(session_id, [])
 timestamps = [t for t in timestamps if now - t < window]
 timestamps.append(now)
 
-state['prompt_timestamps'] = timestamps
+all_timestamps[session_id] = timestamps
+state['prompt_timestamps'] = all_timestamps
 os.makedirs(os.path.dirname(state_file) or '.', exist_ok=True)
 json.dump(state, open(state_file, 'w'))
 


### PR DESCRIPTION
## Summary
- `prompt_timestamps` were stored as a flat list in `.state.json`, so prompts from different Claude Code sessions were counted together
- This could trigger the annoyed sound when no single session was actually being spammed
- Scopes timestamps per `session_id` (matching how `agent_sessions` already works)
- Gracefully migrates the old list format to the new dict format