### PR TITLE
fix: copy uninstall.sh for local clone installs

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -93,6 +93,7 @@ if [ -n "$SCRIPT_DIR" ]; then
   cp "$SCRIPT_DIR/peon.sh" "$INSTALL_DIR/"
   cp "$SCRIPT_DIR/completions.bash" "$INSTALL_DIR/"
   cp "$SCRIPT_DIR/VERSION" "$INSTALL_DIR/"
+  cp "$SCRIPT_DIR/uninstall.sh" "$INSTALL_DIR/"
   if [ "$UPDATING" = false ]; then
     cp "$SCRIPT_DIR/config.json" "$INSTALL_DIR/"
   fi


### PR DESCRIPTION
## Summary

- Fixed missing `uninstall.sh` when installing from a local clone
- The curl|bash path already included it, but the local clone path did not

Previously, users running `install.sh` from a local clone would not get `uninstall.sh` copied to their installation directory, breaking the uninstall command.