### PR TITLE
feat: add fish shell completions and integration

### DIFF
--- a/completions.fish
+++ b/completions.fish
@@ -1,0 +1,18 @@
+# peon-ping tab completion for fish shell
+
+# Top-level options (no repeated suggestions)
+complete -c peon -f
+complete -c peon -l pause -d "Pause sound notifications"
+complete -c peon -l resume -d "Resume sound notifications"
+complete -c peon -l toggle -d "Toggle sound notifications"
+complete -c peon -l status -d "Show current status"
+complete -c peon -l packs -d "List available sound packs"
+complete -c peon -l pack -d "Switch active sound pack" -r -a "(
+  set -l packs_dir (set -q CLAUDE_PEON_DIR; and echo \$CLAUDE_PEON_DIR; or echo \$HOME/.claude/hooks/peon-ping)/packs
+  if test -d \$packs_dir
+    for manifest in \$packs_dir/*/manifest.json
+      basename (dirname \$manifest)
+    end
+  end
+)"
+complete -c peon -l help -d "Show help message"

--- a/install.sh
+++ b/install.sh
@@ -92,6 +92,7 @@ if [ -n "$SCRIPT_DIR" ]; then
   cp -r "$SCRIPT_DIR/packs/"* "$INSTALL_DIR/packs/"
   cp "$SCRIPT_DIR/peon.sh" "$INSTALL_DIR/"
   cp "$SCRIPT_DIR/completions.bash" "$INSTALL_DIR/"
+  cp "$SCRIPT_DIR/completions.fish" "$INSTALL_DIR/"
   cp "$SCRIPT_DIR/VERSION" "$INSTALL_DIR/"
   cp "$SCRIPT_DIR/uninstall.sh" "$INSTALL_DIR/"
   if [ "$UPDATING" = false ]; then
@@ -102,6 +103,7 @@ else
   echo "Downloading from GitHub..."
   curl -fsSL "$REPO_BASE/peon.sh" -o "$INSTALL_DIR/peon.sh"
   curl -fsSL "$REPO_BASE/completions.bash" -o "$INSTALL_DIR/completions.bash"
+  curl -fsSL "$REPO_BASE/completions.fish" -o "$INSTALL_DIR/completions.fish"
   curl -fsSL "$REPO_BASE/VERSION" -o "$INSTALL_DIR/VERSION"
   curl -fsSL "$REPO_BASE/uninstall.sh" -o "$INSTALL_DIR/uninstall.sh"
   for pack in $PACKS; do
@@ -162,6 +164,24 @@ for rcfile in "$HOME/.zshrc" "$HOME/.bashrc"; do
     echo "Added tab completion to $(basename "$rcfile")"
   fi
 done
+
+# --- Add fish shell function + completions ---
+FISH_CONFIG="$HOME/.config/fish/config.fish"
+if [ -f "$FISH_CONFIG" ]; then
+  FISH_FUNC='function peon; bash ~/.claude/hooks/peon-ping/peon.sh $argv; end'
+  if ! grep -qF 'function peon' "$FISH_CONFIG"; then
+    echo "" >> "$FISH_CONFIG"
+    echo "# peon-ping quick controls" >> "$FISH_CONFIG"
+    echo "$FISH_FUNC" >> "$FISH_CONFIG"
+    echo "Added peon function to config.fish"
+  fi
+fi
+FISH_COMPLETIONS_DIR="$HOME/.config/fish/completions"
+if [ -d "$HOME/.config/fish" ]; then
+  mkdir -p "$FISH_COMPLETIONS_DIR"
+  cp "$INSTALL_DIR/completions.fish" "$FISH_COMPLETIONS_DIR/peon.fish"
+  echo "Installed fish completions to $FISH_COMPLETIONS_DIR/peon.fish"
+fi
 
 # --- Verify sounds are installed ---
 echo ""

--- a/tests/install.bats
+++ b/tests/install.bats
@@ -16,6 +16,7 @@ setup() {
   cp "$(dirname "$BATS_TEST_FILENAME")/../config.json" "$CLONE_DIR/"
   cp "$(dirname "$BATS_TEST_FILENAME")/../VERSION" "$CLONE_DIR/"
   cp "$(dirname "$BATS_TEST_FILENAME")/../completions.bash" "$CLONE_DIR/"
+  cp "$(dirname "$BATS_TEST_FILENAME")/../completions.fish" "$CLONE_DIR/"
   cp "$(dirname "$BATS_TEST_FILENAME")/../uninstall.sh" "$CLONE_DIR/" 2>/dev/null || touch "$CLONE_DIR/uninstall.sh"
   cp -r "$(dirname "$BATS_TEST_FILENAME")/../packs" "$CLONE_DIR/"
 
@@ -97,4 +98,9 @@ print('OK')
   touch "$TEST_HOME/.zshrc"
   bash "$CLONE_DIR/install.sh"
   grep -qF 'peon-ping/completions.bash' "$TEST_HOME/.zshrc"
+}
+
+@test "fresh install copies completions.fish" {
+  bash "$CLONE_DIR/install.sh"
+  [ -f "$INSTALL_DIR/completions.fish" ]
 }

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -102,6 +102,13 @@ print('Restored notify.sh hooks for: SessionStart, UserPromptSubmit, Stop, Notif
   fi
 fi
 
+# --- Remove fish completions ---
+FISH_COMPLETIONS="$HOME/.config/fish/completions/peon.fish"
+if [ -f "$FISH_COMPLETIONS" ]; then
+  rm "$FISH_COMPLETIONS"
+  echo "Removed fish completions"
+fi
+
 # --- Remove install directory ---
 if [ -d "$INSTALL_DIR" ]; then
   echo ""


### PR DESCRIPTION
## Summary
- add fish completion definitions via `completions.fish`
- install fish completions and a `peon` helper function during install
- remove fish completion file during uninstall and cover install copy in tests

## Test plan
- [x] verify `install.sh`, `uninstall.sh`, and `tests/install.bats` changes
- [x] run bats test suite
