### PR TITLE
fix: use native terminal escape sequences for macOS notifications

### DIFF
--- a/peon.sh
+++ b/peon.sh
@@ -54,11 +54,26 @@ send_notification() {
   local msg="$1" title="$2" color="${3:-red}"
   case "$PLATFORM" in
     mac)
-      nohup osascript - "$msg" "$title" >/dev/null 2>&1 <<'APPLESCRIPT' &
+      # Use terminal-native escape sequences where supported (shows terminal icon).
+      # Falls back to osascript which attributes notifications to Script Editor.
+      case "${TERM_PROGRAM:-}" in
+        iTerm.app)
+          # iTerm2 OSC 9 — notification with iTerm2 icon
+          printf '\e]9;%s\007' "$title: $msg" 2>/dev/null
+          ;;
+        kitty)
+          # Kitty OSC 99
+          printf '\e]99;i=peon:d=0;%s\e\\' "$title: $msg" 2>/dev/null
+          ;;
+        *)
+          # Terminal.app, Warp, Ghostty, etc. — no native escape; use osascript
+          nohup osascript - "$msg" "$title" >/dev/null 2>&1 <<'APPLESCRIPT' &
 on run argv
   display notification (item 1 of argv) with title (item 2 of argv)
 end run
 APPLESCRIPT
+          ;;
+      esac
       ;;
     wsl)
       # Map color name to RGB


### PR DESCRIPTION
## Fix: Use native terminal escape sequences for macOS notifications

### Problem

Notifications currently use `osascript` + `display notification`, which attributes every notification to **Script Editor** — you get the wrench icon instead of your terminal's icon. This is confusing because it looks like an unrelated app is sending you alerts.

<img src="https://github.com/user-attachments/assets/758c9cea-22f2-4bf9-9ce9-fb639c15d51a" width="400" />

### Fix

Detect `$TERM_PROGRAM` and use native escape sequences where supported:

- **iTerm2** → `OSC 9` (`\e]9;...\007`)
- **Kitty** → `OSC 99` (`\e]99;...\e\\`)
- **Other terminals** → falls back to existing `osascript` behavior (no breakage)

Zero new dependencies. No `brew install` required.

### Tested on

- macOS + iTerm2 — notifications now show the iTerm2 icon
- Fallback path unchanged for terminals without escape sequence support
