### PR TITLE
Add headphones-only mode to suppress sounds when no headphones detected

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Edit `~/.claude/hooks/peon-ping/config.json`:
 ```json
 {
   "volume": 0.5,
+  "headphones_only": false,
   "categories": {
     "greeting": true,
     "acknowledge": true,
@@ -75,6 +76,7 @@ Edit `~/.claude/hooks/peon-ping/config.json`:
 - **categories**: Toggle individual sound types on/off
 - **annoyed_threshold / annoyed_window_seconds**: How many prompts in N seconds triggers the easter egg
 - **pack_rotation**: Array of pack names (e.g. `["peon", "sc_kerrigan", "peasant"]`). Each Claude Code session randomly gets one pack from the list and keeps it for the whole session. Leave empty `[]` to use `active_pack` instead.
+- **headphones_only**: When `true`, sounds only play when headphones are detected. Desktop notifications and tab titles still work normally. On macOS, detects wired headphones and Bluetooth audio devices (AirPods, etc.). On WSL, detects headphone/headset audio endpoints. Default: `false`.
 
 ## Sound packs
 

--- a/config.json
+++ b/config.json
@@ -13,5 +13,6 @@
   },
   "annoyed_threshold": 3,
   "annoyed_window_seconds": 10,
-  "pack_rotation": []
+  "pack_rotation": [],
+  "headphones_only": false
 }

--- a/tests/setup.bash
+++ b/tests/setup.bash
@@ -141,6 +141,27 @@ fi
 SCRIPT
   chmod +x "$MOCK_BIN/curl"
 
+  # Mock system_profiler — return configurable audio device info
+  cat > "$MOCK_BIN/system_profiler" <<'SCRIPT'
+#!/bin/bash
+if [ "$1" = "SPAudioDataType" ] && [ -f "${CLAUDE_PEON_DIR}/.mock_audio_data" ]; then
+  cat "${CLAUDE_PEON_DIR}/.mock_audio_data"
+else
+  # Default: internal speakers (no headphones)
+  cat <<'EOF'
+Audio:
+
+    Devices:
+
+        Built-in Output:
+
+          Default Output Device: Yes
+          Output Source: Internal Speakers
+EOF
+fi
+SCRIPT
+  chmod +x "$MOCK_BIN/system_profiler"
+
   export PATH="$MOCK_BIN:$PATH"
 
   # Locate peon.sh (relative to this test file)


### PR DESCRIPTION
## Summary
Adds a new `headphones_only` configuration option that suppresses audio playback when no headphones or external audio devices are detected, while still allowing desktop notifications to display.

## Key Changes
- **New `headphones_connected()` function** in `peon.sh` that detects audio output devices:
  - macOS: Parses `system_profiler SPAudioDataType` output to check if headphones or external devices (Bluetooth/USB) are the default output
  - WSL: Uses PowerShell to query audio endpoints for headphone/earphone devices
  - Caches result per invocation to avoid repeated system calls
  
- **Configuration option**: Added `headphones_only` boolean to `config.json` (defaults to `false`)

- **Sound suppression logic**: When `headphones_only=true` and no headphones detected, audio playback is skipped but desktop notifications still display

- **User feedback**: Shows a stderr notice on `SessionStart` when headphones-only mode suppresses sound, informing users why audio didn't play

- **Comprehensive test coverage**: 9 new test cases covering:
  - Default behavior (sounds play normally)
  - Sound suppression when no headphones
  - Sound playback with wired headphones
  - Sound playback with Bluetooth devices as default output
  - Stderr messaging behavior
  - Suppression on multiple event types (SessionStart, Stop)
  - Notification delivery independence from sound suppression

- **Test infrastructure**: Added mock `system_profiler` in test setup to simulate various audio device configurations

## Implementation Details
- The headphone detection uses Python to parse macOS audio data, making it robust to formatting variations
- Caching mechanism (`_HEADPHONES_CHECKED` / `_HEADPHONES_RESULT`) ensures efficient operation
- Sound suppression is independent of notification delivery—notifications still fire even when sounds are suppressed
- Help text updated to document the new configuration option

https://claude.ai/code/session_012kCRRnvPBDCmtrUVjLTgYg