### PR TITLE
Fix zsh completion error by loading bashcompinit before complete

### DIFF
--- a/completions.bash
+++ b/completions.bash
@@ -25,10 +25,9 @@ _peon_completions() {
   return 0
 }
 
-complete -F _peon_completions peon
-
-# zsh compatibility: if running under zsh, enable bashcompinit
+# zsh compatibility: enable bashcompinit first
 if [ -n "$ZSH_VERSION" ]; then
   autoload -Uz bashcompinit 2>/dev/null && bashcompinit
-  complete -F _peon_completions peon
 fi
+
+complete -F _peon_completions peon


### PR DESCRIPTION
Fixes #18

## Summary
- Reordered completions.bash to load `bashcompinit` before running `complete` when in zsh
- Previously, `complete` ran first causing "command not found" errors for zsh users

The fix ensures the `complete` command works in both bash and zsh without requiring users to manually add `bashcompinit` to their `.zshrc`.