### PR TITLE
fix: support CLAUDE_CONFIG_DIR instead of hardcoded ~/.claude

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Pausing mutes sounds and desktop notifications instantly. Persists across sessio
 
 ## Configuration
 
-Edit `~/.claude/hooks/peon-ping/config.json`:
+Edit `$CLAUDE_CONFIG_DIR/hooks/peon-ping/config.json` (default: `~/.claude/hooks/peon-ping/config.json`):
 
 ```json
 {
@@ -97,7 +97,7 @@ peon --pack                       # cycle to the next pack
 peon --packs                      # list all packs
 ```
 
-Or edit `~/.claude/hooks/peon-ping/config.json` directly:
+Or edit the config file directly:
 
 ```json
 { "active_pack": "ra2_soviet_engineer" }
@@ -108,7 +108,7 @@ Want to add your own pack? See [CONTRIBUTING.md](CONTRIBUTING.md).
 ## Uninstall
 
 ```bash
-bash ~/.claude/hooks/peon-ping/uninstall.sh
+bash "${CLAUDE_CONFIG_DIR:-$HOME/.claude}"/hooks/peon-ping/uninstall.sh
 ```
 
 ## Requirements

--- a/completions.bash
+++ b/completions.bash
@@ -12,7 +12,7 @@ _peon_completions() {
 
   if [ "$prev" = "--pack" ]; then
     # Complete pack names by scanning manifest files
-    packs_dir="${CLAUDE_PEON_DIR:-$HOME/.claude/hooks/peon-ping}/packs"
+    packs_dir="${CLAUDE_PEON_DIR:-${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/peon-ping}/packs"
     if [ -d "$packs_dir" ]; then
       local names
       names=$(find "$packs_dir" -maxdepth 2 -name manifest.json -exec dirname {} \; 2>/dev/null | xargs -I{} basename {} | sort)

--- a/install.sh
+++ b/install.sh
@@ -4,8 +4,9 @@
 # Re-running updates core files; sounds are version-controlled in the repo
 set -euo pipefail
 
-INSTALL_DIR="$HOME/.claude/hooks/peon-ping"
-SETTINGS="$HOME/.claude/settings.json"
+CLAUDE_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+INSTALL_DIR="$CLAUDE_DIR/hooks/peon-ping"
+SETTINGS="$CLAUDE_DIR/settings.json"
 REPO_BASE="https://raw.githubusercontent.com/tonyyont/peon-ping/main"
 
 # All available sound packs (add new packs here)
@@ -68,8 +69,8 @@ elif [ "$PLATFORM" = "wsl" ]; then
   fi
 fi
 
-if [ ! -d "$HOME/.claude" ]; then
-  echo "Error: ~/.claude/ not found. Is Claude Code installed?"
+if [ ! -d "$CLAUDE_DIR" ]; then
+  echo "Error: $CLAUDE_DIR not found. Is Claude Code installed?"
   exit 1
 fi
 
@@ -133,7 +134,7 @@ fi
 chmod +x "$INSTALL_DIR/peon.sh"
 
 # --- Install skill (slash command) ---
-SKILL_DIR="$HOME/.claude/skills/peon-ping-toggle"
+SKILL_DIR="$CLAUDE_DIR/skills/peon-ping-toggle"
 mkdir -p "$SKILL_DIR"
 if [ -n "$SCRIPT_DIR" ] && [ -d "$SCRIPT_DIR/skills/peon-ping-toggle" ]; then
   cp "$SCRIPT_DIR/skills/peon-ping-toggle/SKILL.md" "$SKILL_DIR/"
@@ -144,7 +145,7 @@ else
 fi
 
 # --- Add shell alias ---
-ALIAS_LINE='alias peon="bash ~/.claude/hooks/peon-ping/peon.sh"'
+ALIAS_LINE="alias peon=\"bash $INSTALL_DIR/peon.sh\""
 for rcfile in "$HOME/.zshrc" "$HOME/.bashrc"; do
   if [ -f "$rcfile" ] && ! grep -qF 'alias peon=' "$rcfile"; then
     echo "" >> "$rcfile"
@@ -155,7 +156,7 @@ for rcfile in "$HOME/.zshrc" "$HOME/.bashrc"; do
 done
 
 # --- Add tab completion ---
-COMPLETION_LINE='[ -f ~/.claude/hooks/peon-ping/completions.bash ] && source ~/.claude/hooks/peon-ping/completions.bash'
+COMPLETION_LINE="[ -f $INSTALL_DIR/completions.bash ] && source $INSTALL_DIR/completions.bash"
 for rcfile in "$HOME/.zshrc" "$HOME/.bashrc"; do
   if [ -f "$rcfile" ] && ! grep -qF 'peon-ping/completions.bash' "$rcfile"; then
     echo "$COMPLETION_LINE" >> "$rcfile"
@@ -177,7 +178,7 @@ done
 
 # --- Backup existing notify.sh (fresh install only) ---
 if [ "$UPDATING" = false ]; then
-  NOTIFY_SH="$HOME/.claude/hooks/notify.sh"
+  NOTIFY_SH="$CLAUDE_DIR/hooks/notify.sh"
   if [ -f "$NOTIFY_SH" ]; then
     cp "$NOTIFY_SH" "$NOTIFY_SH.backup"
     echo ""
@@ -192,8 +193,8 @@ echo "Updating Claude Code hooks in settings.json..."
 python3 -c "
 import json, os, sys
 
-settings_path = os.path.expanduser('~/.claude/settings.json')
-hook_cmd = os.path.expanduser('~/.claude/hooks/peon-ping/peon.sh')
+settings_path = '$SETTINGS'
+hook_cmd = '$INSTALL_DIR/peon.sh'
 
 # Load existing settings
 if os.path.exists(settings_path):
@@ -251,7 +252,7 @@ echo "Testing sound..."
 ACTIVE_PACK=$(python3 -c "
 import json, os
 try:
-    c = json.load(open(os.path.expanduser('~/.claude/hooks/peon-ping/config.json')))
+    c = json.load(open('$INSTALL_DIR/config.json'))
     print(c.get('active_pack', 'peon'))
 except:
     print('peon')

--- a/peon.sh
+++ b/peon.sh
@@ -18,7 +18,7 @@ detect_platform() {
 }
 PLATFORM=$(detect_platform)
 
-PEON_DIR="${CLAUDE_PEON_DIR:-$HOME/.claude/hooks/peon-ping}"
+PEON_DIR="${CLAUDE_PEON_DIR:-${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/peon-ping}"
 CONFIG="$PEON_DIR/config.json"
 STATE="$PEON_DIR/.state.json"
 

--- a/skills/peon-ping-toggle/SKILL.md
+++ b/skills/peon-ping-toggle/SKILL.md
@@ -11,7 +11,7 @@ Toggle peon-ping sounds on or off.
 Run the following command using the Bash tool:
 
 ```bash
-bash ~/.claude/hooks/peon-ping/peon.sh --toggle
+bash "${CLAUDE_CONFIG_DIR:-$HOME/.claude}"/hooks/peon-ping/peon.sh --toggle
 ```
 
 Report the output to the user. The command will print either:

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -3,10 +3,22 @@
 # Removes peon hooks and optionally restores notify.sh
 set -euo pipefail
 
-INSTALL_DIR="$HOME/.claude/hooks/peon-ping"
-SETTINGS="$HOME/.claude/settings.json"
-NOTIFY_BACKUP="$HOME/.claude/hooks/notify.sh.backup"
-NOTIFY_SH="$HOME/.claude/hooks/notify.sh"
+# Derive CLAUDE_DIR from script location if inside a claude directory hierarchy
+CLAUDE_DIR=""
+if [ -n "${BASH_SOURCE[0]:-}" ] && [ "${BASH_SOURCE[0]}" != "bash" ]; then
+  _script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+  _candidate="$(cd "$_script_dir/../.." 2>/dev/null && pwd)"
+  if [[ "$_script_dir" == */hooks/peon-ping ]] && [ -f "$_candidate/settings.json" ]; then
+    CLAUDE_DIR="$_candidate"
+  fi
+fi
+if [ -z "$CLAUDE_DIR" ]; then
+  CLAUDE_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+fi
+INSTALL_DIR="$CLAUDE_DIR/hooks/peon-ping"
+SETTINGS="$CLAUDE_DIR/settings.json"
+NOTIFY_BACKUP="$CLAUDE_DIR/hooks/notify.sh.backup"
+NOTIFY_SH="$CLAUDE_DIR/hooks/notify.sh"
 
 echo "=== peon-ping uninstaller ==="
 echo ""


### PR DESCRIPTION
Fixes #45

- Replace all hardcoded `$HOME/.claude` paths with `${CLAUDE_CONFIG_DIR:-$HOME/.claude}` across install, uninstall, peon.sh, completions, skill, and README
- The uninstall script derives its base directory from its own filesystem location when running from within the `hooks/peon-ping` hierarchy, falling back to the environment variable or default