### PR TITLE
Fix install: remove references to missing sound files

### DIFF
--- a/packs/acolyte_ru/manifest.json
+++ b/packs/acolyte_ru/manifest.json
@@ -33,8 +33,7 @@
     },
     "error": {
       "sounds": [
-        { "file": "AcolyteDeath1.wav", "line": "Угх." },
-        { "file": "AcolytePissed4.wav", "line": "Чернее чёрного..." }
+        { "file": "AcolyteDeath1.wav", "line": "Угх." }
       ]
     },
     "permission": {

--- a/packs/peon_ru/manifest.json
+++ b/packs/peon_ru/manifest.json
@@ -27,7 +27,6 @@
         { "file": "PeonReady1.wav", "line": "Готов вкалывать!" },
         { "file": "PeonYes1.wav", "line": "Могу сделать." },
         { "file": "PeonYes2.wav", "line": "С радостью." },
-        { "file": "PeonYes3.wav", "line": "Работа, работа." },
         { "file": "PeonYesAttack1.wav", "line": "Ага ." },
         { "file": "PeonYesAttack3.wav", "line": "Попробуем." }
       ]


### PR DESCRIPTION
## Summary

- Remove `AcolytePissed4.wav` from `acolyte_ru/manifest.json` — file doesn't exist in the repo
- Remove `PeonYes3.wav` from `peon_ru/manifest.json` — file doesn't exist in the repo

These missing files cause `curl | bash` installs/updates to abort with a 404 error because the script uses `set -euo pipefail`. The first missing file hit (`AcolytePissed4.wav`) kills the entire install process.

## How to reproduce

```bash
curl -fsSL https://raw.githubusercontent.com/tonyyont/peon-ping/main/install.sh | bash
```

Output:
```
=== peon-ping updater ===

Existing install found. Updating...
Downloading from GitHub...
curl: (56) The requested URL returned error: 404
```

## Test plan

- [ ] Run `curl -fsSL https://raw.githubusercontent.com/tonyyont/peon-ping/main/install.sh | bash` after merge — should complete without errors
- [ ] Verify `acolyte_ru` and `peon_ru` packs still work correctly with remaining sounds

🤖 Generated with [Claude Code](https://claude.com/claude-code)