### PR TITLE
Fix: remove missing sound files that break curl|bash install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -159,7 +159,7 @@ for cat in m.get('categories', {}).values():
             seen.add(f)
             print(f)
 " | while read -r sfile; do
-      curl -fsSL "$REPO_BASE/packs/$pack/sounds/$sfile" -o "$INSTALL_DIR/packs/$pack/sounds/$sfile" </dev/null
+      curl -fsSL "$REPO_BASE/packs/$pack/sounds/$sfile" -o "$INSTALL_DIR/packs/$pack/sounds/$sfile" </dev/null || echo "Warning: could not download $pack/sounds/$sfile (skipping)"
     done
   done
   if [ "$UPDATING" = false ]; then


### PR DESCRIPTION
## Summary

- Make sound file downloads in `install.sh` non-fatal so a missing file prints a warning instead of aborting the entire install

## Context

Running `curl ... | bash` fails partway through because `install.sh` uses `set -euo pipefail` with `curl -f`. When it hits a missing sound file (e.g. one referenced in a manifest but not in the repo), the whole installer aborts after partially downloading.

## Test plan

- [x] All 77 bats tests pass locally
- [x] Run `curl -fsSL .../install.sh | bash` end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)