### PR TITLE
Debounce rapid Stop events to prevent sound spam

### DIFF
--- a/peon.sh
+++ b/peon.sh
@@ -533,6 +533,16 @@ else:
     print('PEON_EXIT=true')
     sys.exit(0)
 
+# --- Debounce rapid Stop events (e.g. background task completions) ---
+if event == 'Stop':
+    now = time.time()
+    last_stop = state.get('last_stop_time', 0)
+    if now - last_stop < 5:
+        category = ''
+        notify = ''
+    state['last_stop_time'] = now
+    state_dirty = True
+
 # --- Check if category is enabled ---
 if category and not cat_enabled.get(category, True):
     category = ''


### PR DESCRIPTION
## Summary

- Add a 5-second cooldown to Stop hook events so rapid background task completions only play one "complete" voice line instead of flooding with sounds

## Context

Each background task completion fires a `Stop` hook event. When Claude runs multiple background commands (or a single one that produces several completion notifications), every Stop plays a "complete" sound — resulting in overlapping voice lines.

The fix tracks `last_stop_time` in the state file. If a Stop fires within 5 seconds of the previous one, sound and notification are skipped but the tab title still updates.

## Test plan

- [x] All 79 bats tests pass (77 existing + 2 new)
- [x] New test: rapid Stop events are debounced (second Stop within cooldown produces no sound)
- [x] New test: Stop plays sound again after cooldown expires

🤖 Generated with [Claude Code](https://claude.com/claude-code)