### PR TITLE
fix: show help when CLI is called with no arguments

### DIFF
--- a/peon.sh
+++ b/peon.sh
@@ -433,6 +433,15 @@ HELPEOF
     echo "Run 'peon --help' for usage." >&2; exit 1 ;;
 esac
 
+# If no CLI arg was given and stdin is a terminal (not a pipe from Claude Code),
+# the user likely ran `peon` bare — show help instead of blocking on cat.
+if [ -t 0 ]; then
+  echo "Usage: peon <command>"
+  echo ""
+  echo "Run 'peon --help' for full command list."
+  exit 0
+fi
+
 INPUT=$(cat)
 
 # Debug log (uncomment to troubleshoot)

--- a/tests/peon.bats
+++ b/tests/peon.bats
@@ -504,6 +504,18 @@ json.dump(c, open('$TEST_DIR/config.json', 'w'), indent=2)
   [[ "$output" == *"peon --help"* ]]
 }
 
+@test "no arguments on a TTY shows usage hint and exits" {
+  # 'script' allocates a pseudo-TTY so stdin is not a pipe
+  if [[ "$(uname)" == "Darwin" ]]; then
+    run script -q /dev/null bash "$PEON_SH"
+  else
+    run script -qc "bash '$PEON_SH'" /dev/null
+  fi
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Usage:"* ]]
+  [[ "$output" == *"--help"* ]]
+}
+
 # ============================================================
 # Pack rotation
 # ============================================================


### PR DESCRIPTION
## Summary

- Running `peon` bare from a terminal hung indefinitely because execution fell through to `INPUT=$(cat)` which blocks on stdin
- Added a `[ -t 0 ]` TTY check so bare invocations print a usage hint and exit immediately
- Piped hook input from Claude Code still works normally since stdin is not a terminal

## Test plan

- [x] New bats test: "no arguments on a TTY shows usage hint and exits" — uses `script` to allocate a pseudo-TTY
- [x] All 69 existing tests still pass
- [x] Manual verification: `bash peon.sh` on TTY shows help; `echo '{}' | bash peon.sh` proceeds to hook logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)