### PR TITLE
feat: add --remove command for uninstalling packs

### DIFF
--- a/completions.bash
+++ b/completions.bash
@@ -8,9 +8,9 @@ _peon_completions() {
   prev="${COMP_WORDS[COMP_CWORD-1]}"
 
   # Top-level options
-  opts="--pause --resume --toggle --status --packs --pack --notifications-on --notifications-off --help"
+  opts="--pause --resume --toggle --status --packs --pack --remove --notifications-on --notifications-off --help"
 
-  if [ "$prev" = "--pack" ]; then
+  if [ "$prev" = "--pack" ] || [ "$prev" = "--remove" ]; then
     # Complete pack names by scanning manifest files
     packs_dir="${CLAUDE_PEON_DIR:-${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/peon-ping}/packs"
     if [ -d "$packs_dir" ]; then

--- a/completions.fish
+++ b/completions.fish
@@ -15,6 +15,14 @@ complete -c peon -l pack -d "Switch active sound pack" -r -a "(
     end
   end
 )"
+complete -c peon -l remove -d "Remove installed packs" -r -a "(
+  set -l packs_dir (set -q CLAUDE_PEON_DIR; and echo \$CLAUDE_PEON_DIR; or echo \$HOME/.claude/hooks/peon-ping)/packs
+  if test -d \$packs_dir
+    for manifest in \$packs_dir/*/manifest.json
+      basename (dirname \$manifest)
+    end
+  end
+)"
 complete -c peon -l notifications-on -d "Enable desktop notifications"
 complete -c peon -l notifications-off -d "Disable desktop notifications"
 complete -c peon -l help -d "Show help message"


### PR DESCRIPTION
## Summary
- Adds `peon --remove <pack1,pack2,...>` to uninstall sound packs
- Validates: cannot remove the active pack or the last remaining pack
- Cleans `pack_rotation` in config after removal
- Includes bash/fish shell completions and BATS tests

## Test plan
- [ ] `peon --remove <pack>` removes the pack directory
- [ ] Removing the active pack shows an error
- [ ] Removing a nonexistent pack shows an error
- [ ] Removing multiple packs at once works
- [ ] `pack_rotation` is cleaned in config after removal
- [ ] Tab completions list installed packs for `--remove`
- [ ] `bats tests/peon.bats` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)