### PR TITLE
refactor: subcommand-style CLI (peon packs list, etc.)

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,22 +59,23 @@ Need to mute sounds and notifications during a meeting or pairing session? Two o
 | Method | Command | When |
 |---|---|---|
 | **Slash command** | `/peon-ping-toggle` | While working in Claude Code |
-| **CLI** | `peon --toggle` | From any terminal tab |
+| **CLI** | `peon toggle` | From any terminal tab |
 
 Other CLI commands:
 
 ```bash
-peon --pause              # Mute sounds
-peon --resume             # Unmute sounds
-peon --status             # Check if paused or active
-peon --packs              # List available sound packs
-peon --pack <name>        # Switch to a specific pack
-peon --pack               # Cycle to the next pack
-peon --notifications-on   # Enable desktop notifications
-peon --notifications-off  # Disable desktop notifications
+peon pause                # Mute sounds
+peon resume               # Unmute sounds
+peon status               # Check if paused or active
+peon packs list           # List installed sound packs
+peon packs use <name>     # Switch to a specific pack
+peon packs next           # Cycle to the next pack
+peon packs remove <p1,p2> # Remove specific packs
+peon notifications on     # Enable desktop notifications
+peon notifications off    # Disable desktop notifications
 ```
 
-Tab completion is supported — type `peon --pack <TAB>` to see available pack names.
+Tab completion is supported — type `peon packs use <TAB>` to see available pack names.
 
 Pausing mutes sounds and desktop notifications instantly. Persists across sessions until you resume. Tab titles remain active when paused.
 
@@ -139,9 +140,9 @@ peon-ping works with any agentic IDE that supports hooks. Adapters translate IDE
 Install all with `--all`, or switch packs anytime:
 
 ```bash
-peon --pack glados                # switch to a specific pack
-peon --pack                       # cycle to the next pack
-peon --packs                      # list all installed packs
+peon packs use glados             # switch to a specific pack
+peon packs next                   # cycle to the next pack
+peon packs list                   # list all installed packs
 ```
 
 Want to add your own pack? See the [full guide at openpeon.com/create](https://openpeon.com/create) or [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/completions.bash
+++ b/completions.bash
@@ -2,26 +2,40 @@
 # peon-ping tab completion for bash and zsh
 
 _peon_completions() {
-  local cur prev opts packs_dir
+  local cur prev words cword packs_dir
   COMPREPLY=()
   cur="${COMP_WORDS[COMP_CWORD]}"
   prev="${COMP_WORDS[COMP_CWORD-1]}"
+  words=("${COMP_WORDS[@]}")
+  cword=$COMP_CWORD
 
-  # Top-level options
-  opts="--pause --resume --toggle --status --packs --pack --remove --notifications-on --notifications-off --help"
-
-  if [ "$prev" = "--pack" ] || [ "$prev" = "--remove" ]; then
-    # Complete pack names by scanning manifest files
-    packs_dir="${CLAUDE_PEON_DIR:-${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/peon-ping}/packs"
-    if [ -d "$packs_dir" ]; then
-      local names
-      names=$(find "$packs_dir" -maxdepth 2 -name manifest.json -exec dirname {} \; 2>/dev/null | xargs -I{} basename {} | sort)
-      COMPREPLY=( $(compgen -W "$names" -- "$cur") )
-    fi
+  # Second-level completions
+  if [ "$cword" -ge 2 ]; then
+    local subcmd="${words[1]}"
+    case "$subcmd" in
+      packs)
+        if [ "$cword" -eq 2 ]; then
+          COMPREPLY=( $(compgen -W "list use next remove" -- "$cur") )
+        elif [ "$cword" -eq 3 ] && { [ "$prev" = "use" ] || [ "$prev" = "remove" ]; }; then
+          packs_dir="${CLAUDE_PEON_DIR:-${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/peon-ping}/packs"
+          if [ -d "$packs_dir" ]; then
+            local names
+            names=$(find "$packs_dir" -maxdepth 2 -name manifest.json -exec dirname {} \; 2>/dev/null | xargs -I{} basename {} | sort)
+            COMPREPLY=( $(compgen -W "$names" -- "$cur") )
+          fi
+        fi
+        return 0 ;;
+      notifications)
+        if [ "$cword" -eq 2 ]; then
+          COMPREPLY=( $(compgen -W "on off" -- "$cur") )
+        fi
+        return 0 ;;
+    esac
     return 0
   fi
 
-  COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
+  # Top-level commands
+  COMPREPLY=( $(compgen -W "pause resume toggle status packs notifications help" -- "$cur") )
   return 0
 }
 

--- a/completions.fish
+++ b/completions.fish
@@ -1,13 +1,43 @@
 # peon-ping tab completion for fish shell
 
-# Top-level options (no repeated suggestions)
+# Helper: true when no subcommand has been given yet
+function __peon_no_subcommand
+  set -l cmd (commandline -opc)
+  test (count $cmd) -eq 1
+end
+
+# Helper: true when the given subcommand is active
+function __peon_using_subcommand
+  set -l cmd (commandline -opc)
+  test (count $cmd) -ge 2; and test $cmd[2] = $argv[1]
+end
+
+# Helper: true when packs subcommand is active and second arg matches
+function __peon_packs_subcommand
+  set -l cmd (commandline -opc)
+  test (count $cmd) -ge 3; and test $cmd[2] = packs; and test $cmd[3] = $argv[1]
+end
+
+# Disable file completions
 complete -c peon -f
-complete -c peon -l pause -d "Pause sound notifications"
-complete -c peon -l resume -d "Resume sound notifications"
-complete -c peon -l toggle -d "Toggle sound notifications"
-complete -c peon -l status -d "Show current status"
-complete -c peon -l packs -d "List available sound packs"
-complete -c peon -l pack -d "Switch active sound pack" -r -a "(
+
+# Top-level commands (only when no subcommand given)
+complete -c peon -n __peon_no_subcommand -a pause -d "Mute sounds"
+complete -c peon -n __peon_no_subcommand -a resume -d "Unmute sounds"
+complete -c peon -n __peon_no_subcommand -a toggle -d "Toggle mute on/off"
+complete -c peon -n __peon_no_subcommand -a status -d "Show current status"
+complete -c peon -n __peon_no_subcommand -a packs -d "Manage sound packs"
+complete -c peon -n __peon_no_subcommand -a notifications -d "Control desktop notifications"
+complete -c peon -n __peon_no_subcommand -a help -d "Show help message"
+
+# packs subcommands
+complete -c peon -n "__peon_using_subcommand packs" -a list -d "List installed sound packs"
+complete -c peon -n "__peon_using_subcommand packs" -a use -d "Switch to a specific pack"
+complete -c peon -n "__peon_using_subcommand packs" -a next -d "Cycle to the next pack"
+complete -c peon -n "__peon_using_subcommand packs" -a remove -d "Remove specific packs"
+
+# Pack name completions for 'packs use' and 'packs remove'
+complete -c peon -n "__peon_packs_subcommand use" -a "(
   set -l packs_dir (set -q CLAUDE_PEON_DIR; and echo \$CLAUDE_PEON_DIR; or echo \$HOME/.claude/hooks/peon-ping)/packs
   if test -d \$packs_dir
     for manifest in \$packs_dir/*/manifest.json
@@ -15,7 +45,7 @@ complete -c peon -l pack -d "Switch active sound pack" -r -a "(
     end
   end
 )"
-complete -c peon -l remove -d "Remove installed packs" -r -a "(
+complete -c peon -n "__peon_packs_subcommand remove" -a "(
   set -l packs_dir (set -q CLAUDE_PEON_DIR; and echo \$CLAUDE_PEON_DIR; or echo \$HOME/.claude/hooks/peon-ping)/packs
   if test -d \$packs_dir
     for manifest in \$packs_dir/*/manifest.json
@@ -23,6 +53,7 @@ complete -c peon -l remove -d "Remove installed packs" -r -a "(
     end
   end
 )"
-complete -c peon -l notifications-on -d "Enable desktop notifications"
-complete -c peon -l notifications-off -d "Disable desktop notifications"
-complete -c peon -l help -d "Show help message"
+
+# notifications subcommands
+complete -c peon -n "__peon_using_subcommand notifications" -a on -d "Enable desktop notifications"
+complete -c peon -n "__peon_using_subcommand notifications" -a off -d "Disable desktop notifications"

--- a/docs/index.html
+++ b/docs/index.html
@@ -1371,7 +1371,7 @@ html { scrollbar-width: thin; scrollbar-color: var(--wc3-card-border) var(--wc3-
 
   <div class="contribute-cta">
     <p><strong><span class="pack-count">40+</span> packs and counting!</strong> You're only seeing a few above &mdash; there are many more including GLaDOS, StarCraft Terran units, Czech, Spanish &amp; Russian &amp; Polish Warcraft packs, and others.</p>
-    <p>Run <code>peon --packs</code> to see them all, or <a href="https://openpeon.com/packs">browse the full catalog at openpeon.com</a>.</p>
+    <p>Run <code>peon packs list</code> to see them all, or <a href="https://openpeon.com/packs">browse the full catalog at openpeon.com</a>.</p>
     <p class="contribute-ideas"><strong>Want to add your own?</strong> Any game, any character &mdash; create a GitHub repo with your sounds, register it, and it's available to everyone. <a href="https://openpeon.com/create">Create a pack &rarr;</a></p>
   </div>
 </div>

--- a/install.sh
+++ b/install.sh
@@ -493,8 +493,8 @@ echo ""
 echo "Quick controls:"
 echo "  /peon-ping-toggle  — toggle sounds in Claude Code"
 if [ "$LOCAL_MODE" = false ]; then
-  echo "  peon --toggle      — toggle sounds from any terminal"
-  echo "  peon --status      — check if sounds are paused"
+  echo "  peon toggle        — toggle sounds from any terminal"
+  echo "  peon status        — check if sounds are paused"
 fi
 echo ""
 echo "Ready to work!"

--- a/skills/peon-ping-config/SKILL.md
+++ b/skills/peon-ping-config/SKILL.md
@@ -36,5 +36,5 @@ The config file is at `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/peon-ping/confi
 To show available packs, run:
 
 ```bash
-bash "${CLAUDE_CONFIG_DIR:-$HOME/.claude}"/hooks/peon-ping/peon.sh --packs
+bash "${CLAUDE_CONFIG_DIR:-$HOME/.claude}"/hooks/peon-ping/peon.sh packs list
 ```

--- a/skills/peon-ping-toggle/SKILL.md
+++ b/skills/peon-ping-toggle/SKILL.md
@@ -13,7 +13,7 @@ Toggle peon-ping sounds on or off. Also handles any peon-ping configuration chan
 Run the following command using the Bash tool:
 
 ```bash
-bash "${CLAUDE_CONFIG_DIR:-$HOME/.claude}"/hooks/peon-ping/peon.sh --toggle
+bash "${CLAUDE_CONFIG_DIR:-$HOME/.claude}"/hooks/peon-ping/peon.sh toggle
 ```
 
 Report the output to the user. The command will print either:

--- a/tests/peon.bats
+++ b/tests/peon.bats
@@ -397,46 +397,46 @@ JSON
 # Pause / mute feature
 # ============================================================
 
-@test "--toggle creates .paused file and prints paused message" {
-  run bash "$PEON_SH" --toggle
+@test "toggle creates .paused file and prints paused message" {
+  run bash "$PEON_SH" toggle
   [ "$status" -eq 0 ]
   [[ "$output" == *"sounds paused"* ]]
   [ -f "$TEST_DIR/.paused" ]
 }
 
-@test "--toggle removes .paused file when already paused" {
+@test "toggle removes .paused file when already paused" {
   touch "$TEST_DIR/.paused"
-  run bash "$PEON_SH" --toggle
+  run bash "$PEON_SH" toggle
   [ "$status" -eq 0 ]
   [[ "$output" == *"sounds resumed"* ]]
   [ ! -f "$TEST_DIR/.paused" ]
 }
 
-@test "--pause creates .paused file" {
-  run bash "$PEON_SH" --pause
+@test "pause creates .paused file" {
+  run bash "$PEON_SH" pause
   [ "$status" -eq 0 ]
   [[ "$output" == *"sounds paused"* ]]
   [ -f "$TEST_DIR/.paused" ]
 }
 
-@test "--resume removes .paused file" {
+@test "resume removes .paused file" {
   touch "$TEST_DIR/.paused"
-  run bash "$PEON_SH" --resume
+  run bash "$PEON_SH" resume
   [ "$status" -eq 0 ]
   [[ "$output" == *"sounds resumed"* ]]
   [ ! -f "$TEST_DIR/.paused" ]
 }
 
-@test "--status reports paused when .paused exists" {
+@test "status reports paused when .paused exists" {
   touch "$TEST_DIR/.paused"
-  run bash "$PEON_SH" --status
+  run bash "$PEON_SH" status
   [ "$status" -eq 0 ]
   [[ "$output" == *"paused"* ]]
 }
 
-@test "--status reports active when not paused" {
+@test "status reports active when not paused" {
   rm -f "$TEST_DIR/.paused"
-  run bash "$PEON_SH" --status
+  run bash "$PEON_SH" status
   [ "$status" -eq 0 ]
   [[ "$output" == *"active"* ]]
 }
@@ -482,8 +482,8 @@ json.dump(c, open('$TEST_DIR/config.json', 'w'), indent=2)
   [ "$val" = "False" ]
 }
 
-@test "--notifications-off updates config" {
-  run bash "$PEON_SH" --notifications-off
+@test "notifications off updates config" {
+  run bash "$PEON_SH" notifications off
   [ "$status" -eq 0 ]
   [[ "$output" == *"desktop notifications off"* ]]
   # Verify config was updated
@@ -491,11 +491,11 @@ json.dump(c, open('$TEST_DIR/config.json', 'w'), indent=2)
   [ "$val" = "False" ]
 }
 
-@test "--notifications-on updates config" {
+@test "notifications on updates config" {
   # First turn off
-  bash "$PEON_SH" --notifications-off
+  bash "$PEON_SH" notifications off
   # Then turn on
-  run bash "$PEON_SH" --notifications-on
+  run bash "$PEON_SH" notifications on
   [ "$status" -eq 0 ]
   [[ "$output" == *"desktop notifications on"* ]]
   val=$(/usr/bin/python3 -c "import json; print(json.load(open('$TEST_DIR/config.json')).get('desktop_notifications', True))")
@@ -503,18 +503,18 @@ json.dump(c, open('$TEST_DIR/config.json', 'w'), indent=2)
 }
 
 # ============================================================
-# --packs (list packs)
+# packs list
 # ============================================================
 
-@test "--packs lists all available packs" {
-  run bash "$PEON_SH" --packs
+@test "packs list shows all available packs" {
+  run bash "$PEON_SH" packs list
   [ "$status" -eq 0 ]
   [[ "$output" == *"peon"* ]]
   [[ "$output" == *"sc_kerrigan"* ]]
 }
 
-@test "--packs marks the active pack with *" {
-  run bash "$PEON_SH" --packs
+@test "packs list marks the active pack with *" {
+  run bash "$PEON_SH" packs list
   [ "$status" -eq 0 ]
   [[ "$output" == *"Orc Peon *"* ]]
   # sc_kerrigan should NOT be marked
@@ -522,19 +522,19 @@ json.dump(c, open('$TEST_DIR/config.json', 'w'), indent=2)
   [[ "$line" != *"*"* ]]
 }
 
-@test "--packs marks correct pack after switch" {
-  bash "$PEON_SH" --pack sc_kerrigan
-  run bash "$PEON_SH" --packs
+@test "packs list marks correct pack after switch" {
+  bash "$PEON_SH" packs use sc_kerrigan
+  run bash "$PEON_SH" packs list
   [ "$status" -eq 0 ]
   [[ "$output" == *"Sarah Kerrigan (StarCraft) *"* ]]
 }
 
 # ============================================================
-# --pack <name> (set specific pack)
+# packs use <name> (set specific pack)
 # ============================================================
 
-@test "--pack <name> switches to valid pack" {
-  run bash "$PEON_SH" --pack sc_kerrigan
+@test "packs use <name> switches to valid pack" {
+  run bash "$PEON_SH" packs use sc_kerrigan
   [ "$status" -eq 0 ]
   [[ "$output" == *"switched to sc_kerrigan"* ]]
   [[ "$output" == *"Sarah Kerrigan"* ]]
@@ -543,66 +543,73 @@ json.dump(c, open('$TEST_DIR/config.json', 'w'), indent=2)
   [ "$active" = "sc_kerrigan" ]
 }
 
-@test "--pack <name> preserves other config fields" {
-  bash "$PEON_SH" --pack sc_kerrigan
+@test "packs use <name> preserves other config fields" {
+  bash "$PEON_SH" packs use sc_kerrigan
   volume=$(/usr/bin/python3 -c "import json; print(json.load(open('$TEST_DIR/config.json'))['volume'])")
   [ "$volume" = "0.5" ]
 }
 
-@test "--pack <name> errors on nonexistent pack" {
-  run bash "$PEON_SH" --pack nonexistent
+@test "packs use <name> errors on nonexistent pack" {
+  run bash "$PEON_SH" packs use nonexistent
   [ "$status" -ne 0 ]
   [[ "$output" == *"not found"* ]]
   [[ "$output" == *"Available packs"* ]]
 }
 
-@test "--pack <name> does not modify config on invalid pack" {
-  bash "$PEON_SH" --pack nonexistent || true
+@test "packs use <name> does not modify config on invalid pack" {
+  bash "$PEON_SH" packs use nonexistent || true
   active=$(/usr/bin/python3 -c "import json; print(json.load(open('$TEST_DIR/config.json'))['active_pack'])")
   [ "$active" = "peon" ]
 }
 
 # ============================================================
-# --pack (cycle, no argument)
+# packs next (cycle, no argument)
 # ============================================================
 
-@test "--pack cycles to next pack alphabetically" {
+@test "packs next cycles to next pack alphabetically" {
   # Active is peon, next alphabetically is sc_kerrigan
-  run bash "$PEON_SH" --pack
+  run bash "$PEON_SH" packs next
   [ "$status" -eq 0 ]
   [[ "$output" == *"switched to sc_kerrigan"* ]]
 }
 
-@test "--pack cycle wraps around from last to first" {
+@test "packs next wraps around from last to first" {
   # Set to sc_kerrigan (last alphabetically), should wrap to peon
-  bash "$PEON_SH" --pack sc_kerrigan
-  run bash "$PEON_SH" --pack
+  bash "$PEON_SH" packs use sc_kerrigan
+  run bash "$PEON_SH" packs next
   [ "$status" -eq 0 ]
   [[ "$output" == *"switched to peon"* ]]
 }
 
-@test "--pack cycle updates config correctly" {
-  bash "$PEON_SH" --pack
+@test "packs next updates config correctly" {
+  bash "$PEON_SH" packs next
   active=$(/usr/bin/python3 -c "import json; print(json.load(open('$TEST_DIR/config.json'))['active_pack'])")
   [ "$active" = "sc_kerrigan" ]
 }
 
 # ============================================================
-# --help (updated)
+# help
 # ============================================================
 
-@test "--help shows pack commands" {
-  run bash "$PEON_SH" --help
+@test "help shows pack commands" {
+  run bash "$PEON_SH" help
   [ "$status" -eq 0 ]
-  [[ "$output" == *"--packs"* ]]
-  [[ "$output" == *"--pack"* ]]
+  [[ "$output" == *"packs list"* ]]
+  [[ "$output" == *"packs use"* ]]
 }
 
 @test "unknown option shows helpful error" {
   run bash "$PEON_SH" --foobar
   [ "$status" -ne 0 ]
   [[ "$output" == *"Unknown option"* ]]
-  [[ "$output" == *"peon --help"* ]]
+  [[ "$output" == *"peon help"* ]]
+}
+
+@test "unknown command shows helpful error" {
+  run bash "$PEON_SH" foobar
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Unknown command"* ]]
+  [[ "$output" == *"peon help"* ]]
 }
 
 @test "no arguments on a TTY shows usage hint and exits" {
@@ -614,26 +621,26 @@ json.dump(c, open('$TEST_DIR/config.json', 'w'), indent=2)
   fi
   [ "$status" -eq 0 ]
   [[ "$output" == *"Usage:"* ]]
-  [[ "$output" == *"--help"* ]]
+  [[ "$output" == *"help"* ]]
 }
 
 # ============================================================
-# --remove (non-interactive pack removal)
+# packs remove (non-interactive pack removal)
 # ============================================================
 
-@test "--remove <name> removes pack directory" {
+@test "packs remove <name> removes pack directory" {
   [ -d "$TEST_DIR/packs/sc_kerrigan" ]
-  echo "y" | bash "$PEON_SH" --remove sc_kerrigan
+  echo "y" | bash "$PEON_SH" packs remove sc_kerrigan
   [ ! -d "$TEST_DIR/packs/sc_kerrigan" ]
 }
 
-@test "--remove <name> prints confirmation" {
-  run bash -c 'echo "y" | bash "$0" --remove sc_kerrigan' "$PEON_SH"
+@test "packs remove <name> prints confirmation" {
+  run bash -c 'echo "y" | bash "$0" packs remove sc_kerrigan' "$PEON_SH"
   [ "$status" -eq 0 ]
   [[ "$output" == *"Removed sc_kerrigan"* ]]
 }
 
-@test "--remove <name> cleans pack_rotation in config" {
+@test "packs remove <name> cleans pack_rotation in config" {
   cat > "$TEST_DIR/config.json" <<'JSON'
 {
   "active_pack": "peon", "volume": 0.5, "enabled": true,
@@ -641,36 +648,36 @@ json.dump(c, open('$TEST_DIR/config.json', 'w'), indent=2)
   "pack_rotation": ["peon", "sc_kerrigan"]
 }
 JSON
-  echo "y" | bash "$PEON_SH" --remove sc_kerrigan
+  echo "y" | bash "$PEON_SH" packs remove sc_kerrigan
   rotation=$(/usr/bin/python3 -c "import json; print(json.load(open('$TEST_DIR/config.json')).get('pack_rotation', []))")
   [[ "$rotation" == *"peon"* ]]
   [[ "$rotation" != *"sc_kerrigan"* ]]
 }
 
-@test "--remove active pack errors" {
-  run bash "$PEON_SH" --remove peon
+@test "packs remove active pack errors" {
+  run bash "$PEON_SH" packs remove peon
   [ "$status" -ne 0 ]
   [[ "$output" == *"active pack"* ]]
   # Pack should still exist
   [ -d "$TEST_DIR/packs/peon" ]
 }
 
-@test "--remove nonexistent pack errors" {
-  run bash "$PEON_SH" --remove nonexistent
+@test "packs remove nonexistent pack errors" {
+  run bash "$PEON_SH" packs remove nonexistent
   [ "$status" -ne 0 ]
   [[ "$output" == *"not found"* ]]
 }
 
-@test "--remove last remaining pack errors" {
+@test "packs remove last remaining pack errors" {
   # Remove sc_kerrigan first so only peon remains
   rm -rf "$TEST_DIR/packs/sc_kerrigan"
-  run bash "$PEON_SH" --remove peon
+  run bash "$PEON_SH" packs remove peon
   [ "$status" -ne 0 ]
   # Should error either because it's active or because it's the last one
   [ -d "$TEST_DIR/packs/peon" ]
 }
 
-@test "--remove multiple packs at once" {
+@test "packs remove multiple packs at once" {
   # Add a third pack so we can remove two and still have one left
   mkdir -p "$TEST_DIR/packs/glados/sounds"
   cat > "$TEST_DIR/packs/glados/manifest.json" <<'JSON'
@@ -684,17 +691,17 @@ JSON
 JSON
   touch "$TEST_DIR/packs/glados/sounds/Hello1.wav"
 
-  echo "y" | bash "$PEON_SH" --remove sc_kerrigan,glados
+  echo "y" | bash "$PEON_SH" packs remove sc_kerrigan,glados
   [ ! -d "$TEST_DIR/packs/sc_kerrigan" ]
   [ ! -d "$TEST_DIR/packs/glados" ]
   # Active pack still present
   [ -d "$TEST_DIR/packs/peon" ]
 }
 
-@test "--help shows --remove command" {
-  run bash "$PEON_SH" --help
+@test "help shows packs remove command" {
+  run bash "$PEON_SH" help
   [ "$status" -eq 0 ]
-  [[ "$output" == *"--remove"* ]]
+  [[ "$output" == *"packs remove"* ]]
 }
 
 # ============================================================


### PR DESCRIPTION
## Summary

- Replace flat `--flag` CLI with nested subcommand routing: `peon packs <list|use|next|remove>`, `peon notifications <on|off>`, and bare `peon pause/resume/toggle/status/help`
- Rewrite bash and fish tab completions for two-level subcommand support
- Update all tests (84 pass), docs, install messages, skills, and website references

## New CLI structure

| Old | New |
|-----|-----|
| `peon --pause` | `peon pause` |
| `peon --resume` | `peon resume` |
| `peon --toggle` | `peon toggle` |
| `peon --status` | `peon status` |
| `peon --packs` | `peon packs list` |
| `peon --pack <name>` | `peon packs use <name>` |
| `peon --pack` (no arg) | `peon packs next` |
| `peon --remove <p1,p2>` | `peon packs remove <p1,p2>` |
| `peon --notifications-on` | `peon notifications on` |
| `peon --notifications-off` | `peon notifications off` |
| `peon --help` | `peon help` (also keeps `--help`/`-h`) |

## Test plan

- [x] `bats tests/peon.bats` — all 84 tests pass
- [ ] Manual: `peon packs list`, `peon packs use <name>`, `peon packs next`, `peon packs remove <name>`
- [ ] Manual: `peon help` shows new command layout
- [ ] Manual: tab completion works (`source completions.bash && peon packs <TAB>`)
- [ ] Bare `peon packs` / `peon notifications` show sub-usage errors
- [ ] Unknown commands (`peon foobar`) show helpful error

🤖 Generated with [Claude Code](https://claude.com/claude-code)