### PR TITLE
feat: show active pack, pack count, and IDE status in `peon status`

### DIFF
--- a/peon.sh
+++ b/peon.sh
@@ -337,13 +337,79 @@ case "${1:-}" in
   status)
     [ -f "$PAUSED_FILE" ] && echo "peon-ping: paused" || echo "peon-ping: active"
     python3 -c "
-import json
+import json, os
+
+config_path = '$CONFIG'
+peon_dir = '$PEON_DIR'
+
+# --- Config ---
 try:
-    c = json.load(open('$CONFIG'))
-    dn = c.get('desktop_notifications', True)
-    print('peon-ping: desktop notifications ' + ('on' if dn else 'off'))
+    c = json.load(open(config_path))
 except:
-    print('peon-ping: desktop notifications on')
+    c = {}
+
+dn = c.get('desktop_notifications', True)
+print('peon-ping: desktop notifications ' + ('on' if dn else 'off'))
+
+# --- Active pack ---
+active = c.get('active_pack', 'peon')
+packs_dir = os.path.join(peon_dir, 'packs')
+display_name = active
+pack_count = 0
+if os.path.isdir(packs_dir):
+    for d in os.listdir(packs_dir):
+        dpath = os.path.join(packs_dir, d)
+        if not os.path.isdir(dpath):
+            continue
+        has_manifest = (
+            os.path.exists(os.path.join(dpath, 'openpeon.json')) or
+            os.path.exists(os.path.join(dpath, 'manifest.json'))
+        )
+        if has_manifest:
+            pack_count += 1
+            if d == active:
+                for mname in ('openpeon.json', 'manifest.json'):
+                    mpath = os.path.join(dpath, mname)
+                    if os.path.exists(mpath):
+                        try:
+                            display_name = json.load(open(mpath)).get('display_name', active)
+                        except:
+                            pass
+                        break
+print(f'peon-ping: active pack: {active} ({display_name})')
+print(f'peon-ping: {pack_count} pack(s) installed')
+
+# --- IDE detection ---
+home = os.path.expanduser('~')
+claude_dir = os.environ.get('CLAUDE_CONFIG_DIR', os.path.join(home, '.claude'))
+xdg_config = os.environ.get('XDG_CONFIG_HOME', os.path.join(home, '.config'))
+opencode_dir = os.path.join(xdg_config, 'opencode')
+
+ides = []
+
+# Claude Code: check if hooks are registered
+claude_hooks_dir = os.path.join(claude_dir, 'hooks', 'peon-ping')
+if os.path.isdir(claude_dir):
+    if os.path.exists(os.path.join(claude_hooks_dir, 'peon.sh')):
+        ides.append(('Claude Code', claude_dir, 'installed'))
+    else:
+        ides.append(('Claude Code', claude_dir, 'detected (not set up)'))
+
+# OpenCode: check if plugin is installed
+opencode_plugin = os.path.join(opencode_dir, 'plugins', 'peon-ping.ts')
+if os.path.isdir(opencode_dir):
+    if os.path.exists(opencode_plugin):
+        ides.append(('OpenCode', opencode_dir, 'installed'))
+    else:
+        ides.append(('OpenCode', opencode_dir, 'detected (not set up)'))
+
+if ides:
+    print('peon-ping: IDEs')
+    for name, path, status in ides:
+        marker = '[x]' if 'installed' == status else '[ ]'
+        print(f'  {marker} {name:12s} {path} ({status})')
+else:
+    print('peon-ping: no supported IDEs detected')
 "
     exit 0 ;;
   notifications)


### PR DESCRIPTION
## Summary

Enhances `peon status` to show richer diagnostic information beyond just paused/active state:

- **Active pack** — name and display name from manifest
- **Pack count** — number of installed packs
- **IDE detection** — scans for Claude Code (`~/.claude/`) and OpenCode (`~/.config/opencode/`) and shows setup status

## Example output

```
peon-ping: active
peon-ping: desktop notifications on
peon-ping: active pack: peon (Warcraft III Peon)
peon-ping: 10 pack(s) installed
peon-ping: IDEs
  [x] Claude Code  ~/.claude/ (installed)
  [x] OpenCode     ~/.config/opencode/ (installed)
```

## Details

- Respects `$CLAUDE_CONFIG_DIR` and `$XDG_CONFIG_HOME` environment variables
- Claude Code: checks for `~/.claude/hooks/peon-ping/peon.sh`
- OpenCode: checks for `~/.config/opencode/plugins/peon-ping.ts`
- Uses CESP manifest lookup (`openpeon.json` or `manifest.json`) for display names
- No new dependencies

## Note

This branch was created before the devcontainer support commit landed on `main`. There may be a merge conflict in `peon.sh` — happy to rebase if needed.