### PR TITLE
fix: correct Ghostty process name casing in focus detection

### DIFF
--- a/adapters/opencode/peon-ping.ts
+++ b/adapters/opencode/peon-ping.ts
@@ -152,7 +152,7 @@ const TERMINAL_APPS = [
   "Alacritty",
   "kitty",
   "WezTerm",
-  "Ghostty",
+  "ghostty",
   "Hyper",
 ]
 

--- a/peon.sh
+++ b/peon.sh
@@ -328,7 +328,7 @@ terminal_is_focused() {
       local frontmost
       frontmost=$(osascript -e 'tell application "System Events" to get name of first process whose frontmost is true' 2>/dev/null)
       case "$frontmost" in
-        Terminal|iTerm2|Warp|Alacritty|kitty|WezTerm|Ghostty) return 0 ;;
+        Terminal|iTerm2|Warp|Alacritty|kitty|WezTerm|ghostty) return 0 ;;
         *) return 1 ;;
       esac
       ;;


### PR DESCRIPTION
macOS System Events reports the Ghostty process name as `ghostty` (lowercase), but the focus check matched `Ghostty`. This caused `terminal_is_focused()` to always return false on Ghostty, so notifications and sounds were never suppressed when the terminal was in the foreground.

Fixed in `peon.sh` and the OpenCode adapter.

`bats tests/` passes (113 tests).