### PR TITLE
fix: pack_rotation_mode 'off' ignored + duplicate permission sounds

### DIFF
--- a/peon.sh
+++ b/peon.sh
@@ -1020,7 +1020,7 @@ elif session_id in agent_sessions:
     sys.exit(0)
 
 # --- Pack rotation: pin a pack per session ---
-if pack_rotation:
+if pack_rotation and cfg.get('pack_rotation_mode', 'random') != 'off':
     session_packs = state.get('session_packs', {})
     if session_id in session_packs and session_packs[session_id] in pack_rotation:
         active_pack = session_packs[session_id]
@@ -1093,12 +1093,9 @@ elif event == 'Stop':
         category = ''
 elif event == 'Notification':
     if ntype == 'permission_prompt':
-        category = 'input.required'
+        # Sound is handled by the PermissionRequest event; only set tab title here
         status = 'needs approval'
         marker = '\u25cf '
-        notify = '1'
-        notify_color = 'red'
-        msg = project + '  \u2014  Permission needed'
     elif ntype == 'idle_prompt':
         status = 'done'
         marker = '\u25cf '


### PR DESCRIPTION
## Summary
- **pack_rotation_mode 'off' ignored**: The rotation block only checked if the `pack_rotation` list was non-empty, so setting mode to `"off"` fell through to the `else` branch and picked a random pack anyway. Fix: check `pack_rotation_mode != 'off'` before entering the rotation block.
- **Duplicate permission sounds**: Both `Notification(permission_prompt)` and `PermissionRequest` hooks mapped to `input.required`, causing two sounds on every tool approval. Fix: `Notification(permission_prompt)` now only sets the tab title; sound + desktop notification are handled exclusively by `PermissionRequest`.

## Test plan
- Set `pack_rotation_mode: "off"` with a non-empty `pack_rotation` list → verify `active_pack` is used
- Trigger a permission prompt → verify only one `input.required` sound plays