### PR TITLE
fix: duplicate sound on permission prompts

### DIFF
--- a/peon.sh
+++ b/peon.sh
@@ -1093,12 +1093,9 @@ elif event == 'Stop':
         category = ''
 elif event == 'Notification':
     if ntype == 'permission_prompt':
-        category = 'input.required'
+        # Sound is handled by the PermissionRequest event; only set tab title here
         status = 'needs approval'
         marker = '\u25cf '
-        notify = '1'
-        notify_color = 'red'
-        msg = project + '  \u2014  Permission needed'
     elif ntype == 'idle_prompt':
         status = 'done'
         marker = '\u25cf '


### PR DESCRIPTION
## Summary
Both `Notification(permission_prompt)` and `PermissionRequest` hooks map to `input.required`, causing two sounds on every tool approval. The installer registers peon.sh on both events (line 592), so both fire for the same prompt.

Fix: `Notification(permission_prompt)` now only sets the tab title/marker. The sound and desktop notification are handled exclusively by `PermissionRequest`.

## Test plan
- Trigger a permission prompt (e.g. a Bash command) → verify only one `input.required` sound plays instead of two