### PR TITLE
docs(codex): update notify config format to argv array

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ peon-ping works with any agentic IDE that supports hooks. Adapters translate IDE
 | IDE | Status | Setup |
 |---|---|---|
 | **Claude Code** | Built-in | `curl \| bash` install handles everything |
-| **OpenAI Codex** | Adapter | Add `command = "bash ~/.claude/hooks/peon-ping/adapters/codex.sh"` to `~/.codex/config.toml` under `[notify]` |
+| **OpenAI Codex** | Adapter | Add `notify = ["bash", "/absolute/path/to/.claude/hooks/peon-ping/adapters/codex.sh"]` to `~/.codex/config.toml` |
 | **Cursor** | Adapter | Add hook entries to `~/.cursor/hooks.json` pointing to `adapters/cursor.sh` |
 | **OpenCode** | Adapter | `curl -fsSL https://raw.githubusercontent.com/PeonPing/peon-ping/main/adapters/opencode.sh \| bash` |
 | **Google Antigravity** | Adapter | `bash ~/.claude/hooks/peon-ping/adapters/antigravity.sh` (requires `fswatch`: `brew install fswatch`) |

--- a/adapters/codex.sh
+++ b/adapters/codex.sh
@@ -3,11 +3,10 @@
 # Translates Codex notify events into peon.sh stdin JSON
 #
 # Setup: Add to ~/.codex/config.toml:
-#   [notify]
-#   command = "bash ~/.claude/hooks/peon-ping/adapters/codex.sh"
+#   notify = ["bash", "/absolute/path/to/.claude/hooks/peon-ping/adapters/codex.sh"]
 #
 # Or if installed locally:
-#   command = "bash .claude/hooks/peon-ping/adapters/codex.sh"
+#   notify = ["bash", "/absolute/path/to/peon-ping/adapters/codex.sh"]
 
 set -euo pipefail
 


### PR DESCRIPTION
- Updates Codex setup docs to match the correct `config.toml` format, per https://developers.openai.com/codex/config-reference.
- `notify` is an argv array, not a shell command string. Codex executes it directly and appends the JSON payload as the final argument, so ~ is not shell-expanded. (code reference: https://github.com/openai/codex/blob/abeafbdca17f6102099ac5b792761b6883c52d35/codex-rs/hooks/src/user_notification.rs#L54)