### PR TITLE
feat: add Kiro CLI adapter

### DIFF
--- a/adapters/kiro.sh
+++ b/adapters/kiro.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+# peon-ping adapter for Kiro CLI (Amazon)
+# Translates Kiro hook events into peon.sh stdin JSON
+#
+# Kiro CLI has a hook system that pipes JSON to hooks via stdin,
+# nearly identical to Claude Code. This adapter remaps the few
+# differing event names and forwards to peon.sh.
+#
+# Setup: Create ~/.kiro/agents/peon-ping.json with:
+#
+#   {
+#     "hooks": {
+#       "agentSpawn": [
+#         { "command": "bash ~/.claude/hooks/peon-ping/adapters/kiro.sh" }
+#       ],
+#       "userPromptSubmit": [
+#         { "command": "bash ~/.claude/hooks/peon-ping/adapters/kiro.sh" }
+#       ],
+#       "stop": [
+#         { "command": "bash ~/.claude/hooks/peon-ping/adapters/kiro.sh" }
+#       ]
+#     }
+#   }
+#
+# Note: preToolUse and postToolUse are intentionally excluded — they
+# fire on every tool call (not just permission prompts) and would be
+# extremely noisy.
+
+set -euo pipefail
+
+PEON_DIR="${CLAUDE_PEON_DIR:-${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/peon-ping}"
+
+# Read Kiro's event JSON from stdin and remap event names
+MAPPED_JSON=$(python3 -c "
+import sys, json, os
+
+data = json.load(sys.stdin)
+event = data.get('hook_event_name', 'stop')
+
+# Kiro uses camelCase events; peon.sh expects PascalCase (Claude Code format)
+remap = {
+    'agentSpawn': 'SessionStart',
+    'userPromptSubmit': 'UserPromptSubmit',
+    'stop': 'Stop',
+}
+
+mapped = remap.get(event)
+if mapped is None:
+    # Unknown or intentionally skipped events (preToolUse, postToolUse)
+    sys.exit(0)
+
+sid = data.get('session_id', str(os.getpid()))
+cwd = data.get('cwd', os.getcwd())
+
+print(json.dumps({
+    'hook_event_name': mapped,
+    'notification_type': '',
+    'cwd': cwd,
+    'session_id': 'kiro-' + str(sid),
+    'permission_mode': data.get('permission_mode', ''),
+}))
+")
+
+# Only forward to peon.sh if python3 produced a mapped event
+if [ -n "$MAPPED_JSON" ]; then
+  echo "$MAPPED_JSON" | bash "$PEON_DIR/peon.sh"
+fi

--- a/tests/kiro.bats
+++ b/tests/kiro.bats
@@ -1,0 +1,153 @@
+#!/usr/bin/env bats
+
+load setup.bash
+
+setup() {
+  setup_test_env
+
+  # Derive repo root from PEON_SH (set by setup.bash using its own BASH_SOURCE)
+  KIRO_SH="${PEON_SH%/peon.sh}/adapters/kiro.sh"
+
+  # Adapter resolves peon.sh via CLAUDE_PEON_DIR — symlink it into the test dir
+  ln -sf "$PEON_SH" "$TEST_DIR/peon.sh"
+}
+
+teardown() {
+  teardown_test_env
+}
+
+# Helper: run kiro adapter with a JSON event
+run_kiro() {
+  local json="$1"
+  export PEON_TEST=1
+  echo "$json" | bash "$KIRO_SH" 2>"$TEST_DIR/stderr.log"
+  KIRO_EXIT=$?
+  KIRO_STDERR=$(cat "$TEST_DIR/stderr.log" 2>/dev/null)
+}
+
+# ============================================================
+# Event mapping
+# ============================================================
+
+@test "agentSpawn maps to SessionStart and plays greeting" {
+  run_kiro '{"hook_event_name":"agentSpawn","cwd":"/tmp/myproject","session_id":"k1"}'
+  [ "$KIRO_EXIT" -eq 0 ]
+  afplay_was_called
+  sound=$(afplay_sound)
+  [[ "$sound" == *"/packs/peon/sounds/Hello"* ]]
+}
+
+@test "userPromptSubmit maps to UserPromptSubmit" {
+  run_kiro '{"hook_event_name":"userPromptSubmit","cwd":"/tmp/myproject","session_id":"k1"}'
+  [ "$KIRO_EXIT" -eq 0 ]
+  # UserPromptSubmit does not play sound normally (only on spam)
+  ! afplay_was_called
+}
+
+@test "stop maps to Stop and plays completion sound" {
+  run_kiro '{"hook_event_name":"stop","cwd":"/tmp/myproject","session_id":"k1"}'
+  [ "$KIRO_EXIT" -eq 0 ]
+  afplay_was_called
+  sound=$(afplay_sound)
+  [[ "$sound" == *"/packs/peon/sounds/Done"* ]]
+}
+
+# ============================================================
+# Skipped events
+# ============================================================
+
+@test "preToolUse is skipped (too noisy)" {
+  run_kiro '{"hook_event_name":"preToolUse","cwd":"/tmp/myproject","session_id":"k1","tool_name":"execute_bash"}'
+  [ "$KIRO_EXIT" -eq 0 ]
+  ! afplay_was_called
+}
+
+@test "postToolUse is skipped (too noisy)" {
+  run_kiro '{"hook_event_name":"postToolUse","cwd":"/tmp/myproject","session_id":"k1","tool_name":"fs_write"}'
+  [ "$KIRO_EXIT" -eq 0 ]
+  ! afplay_was_called
+}
+
+@test "unknown event is skipped gracefully" {
+  run_kiro '{"hook_event_name":"someNewEvent","cwd":"/tmp/myproject","session_id":"k1"}'
+  [ "$KIRO_EXIT" -eq 0 ]
+  ! afplay_was_called
+}
+
+# ============================================================
+# Session ID prefixing
+# ============================================================
+
+@test "session_id is prefixed with kiro-" {
+  # Verify the adapter passes kiro-prefixed session_id to peon.sh
+  # by checking that debounce works across calls (same session = same debounce)
+  run_kiro '{"hook_event_name":"stop","cwd":"/tmp/myproject","session_id":"k1"}'
+  [ "$KIRO_EXIT" -eq 0 ]
+  count1=$(afplay_call_count)
+  [ "$count1" = "1" ]
+
+  # Second stop within debounce window should be suppressed
+  run_kiro '{"hook_event_name":"stop","cwd":"/tmp/myproject","session_id":"k1"}'
+  [ "$KIRO_EXIT" -eq 0 ]
+  count2=$(afplay_call_count)
+  [ "$count2" = "1" ]
+}
+
+# ============================================================
+# Config passthrough
+# ============================================================
+
+@test "paused state suppresses Kiro sounds" {
+  touch "$TEST_DIR/.paused"
+  run_kiro '{"hook_event_name":"agentSpawn","cwd":"/tmp/myproject","session_id":"k1"}'
+  [ "$KIRO_EXIT" -eq 0 ]
+  ! afplay_was_called
+}
+
+@test "enabled=false suppresses Kiro sounds" {
+  cat > "$TEST_DIR/config.json" <<'JSON'
+{ "enabled": false, "active_pack": "peon", "volume": 0.5, "categories": {} }
+JSON
+  run_kiro '{"hook_event_name":"agentSpawn","cwd":"/tmp/myproject","session_id":"k1"}'
+  [ "$KIRO_EXIT" -eq 0 ]
+  ! afplay_was_called
+}
+
+@test "volume from config is passed through" {
+  cat > "$TEST_DIR/config.json" <<'JSON'
+{ "active_pack": "peon", "volume": 0.3, "enabled": true, "categories": {} }
+JSON
+  run_kiro '{"hook_event_name":"agentSpawn","cwd":"/tmp/myproject","session_id":"k1"}'
+  afplay_was_called
+  log_line=$(tail -1 "$TEST_DIR/afplay.log")
+  [[ "$log_line" == *"-v 0.3"* ]]
+}
+
+# ============================================================
+# Spam detection
+# ============================================================
+
+@test "rapid Kiro prompts trigger annoyed sound" {
+  for i in $(seq 1 3); do
+    run_kiro '{"hook_event_name":"userPromptSubmit","cwd":"/tmp/myproject","session_id":"k1"}'
+  done
+  afplay_was_called
+  sound=$(afplay_sound)
+  [[ "$sound" == *"Angry1.wav" ]]
+}
+
+# ============================================================
+# Missing fields handled gracefully
+# ============================================================
+
+@test "minimal JSON (only hook_event_name) works" {
+  run_kiro '{"hook_event_name":"stop"}'
+  [ "$KIRO_EXIT" -eq 0 ]
+  afplay_was_called
+}
+
+@test "extra Kiro-specific fields are ignored gracefully" {
+  run_kiro '{"hook_event_name":"stop","cwd":"/tmp/p","session_id":"k1","tool_name":"execute_bash","tool_input":{"command":"ls"},"tool_response":"files..."}'
+  [ "$KIRO_EXIT" -eq 0 ]
+  afplay_was_called
+}


### PR DESCRIPTION
## Summary
- Adds `adapters/kiro.sh` for Kiro CLI (Amazon's agentic coding CLI)
- Kiro's hook system is nearly identical to Claude Code — JSON via stdin, same lifecycle events — so the adapter is just a thin event-name remap
- `preToolUse`/`postToolUse` intentionally skipped (fires on every tool call — your peon would never shut up)
- 13 bats tests, all 116 existing tests still passing

## Setup

Create `~/.kiro/agents/peon-ping.json`:

```json
{
  "hooks": {
    "agentSpawn": [
      { "command": "bash ~/.claude/hooks/peon-ping/adapters/kiro.sh" }
    ],
    "userPromptSubmit": [
      { "command": "bash ~/.claude/hooks/peon-ping/adapters/kiro.sh" }
    ],
    "stop": [
      { "command": "bash ~/.claude/hooks/peon-ping/adapters/kiro.sh" }
    ]
  }
}
```

## Test plan
- [x] 13 new kiro.bats tests pass
- [x] 116 existing peon.bats tests pass
- [x] Manual testing with Kiro CLI

Zug zug.