### PR TITLE
feat: add `peon preview [category]` CLI command

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ peon notifications on     # Enable desktop notifications
 peon notifications off    # Disable desktop notifications
 peon preview              # Play all sounds from session.start
 peon preview <category>   # Play all sounds from a specific category
+peon preview --list       # List all categories in the active pack
 peon mobile ntfy <topic>  # Set up phone notifications (free)
 peon mobile off           # Disable phone notifications
 peon mobile test          # Send a test notification

--- a/tests/peon.bats
+++ b/tests/peon.bats
@@ -1313,3 +1313,13 @@ assert mn['service'] == 'ntfy', 'service should be preserved'
   output=$(bash "$PEON_SH" help)
   [[ "$output" == *"preview"* ]]
 }
+
+@test "preview --list shows all categories with sound counts" {
+  run bash "$PEON_SH" preview --list
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"categories in"* ]]
+  [[ "$output" == *"session.start"* ]]
+  [[ "$output" == *"task.complete"* ]]
+  [[ "$output" == *"user.spam"* ]]
+  [[ "$output" == *"sounds"* ]]
+}


### PR DESCRIPTION
## Summary

- Add `peon preview [category]` CLI command that plays all sounds from a CESP category in the active pack sequentially, defaulting to `session.start` if no category is specified
- Add `peon preview --list` to display all available categories and their sound counts in the active pack
- Shows each sound's label as it plays, and reports available categories on invalid input
- List all CESP categories in `peon help` output and update README with preview usage

## Usage

```bash
peon preview                # Play all session.start sounds from active pack
peon preview task.complete  # Play all task.complete sounds
peon preview user.spam      # Play all user.spam sounds
peon preview --list         # List all categories in the active pack
```

Output examples:

```
$ peon preview
peon-ping: previewing [session.start] from Orc Peon

  ▶ Ready to work?
  ▶ Yes?
```

```
$ peon preview --list
peon-ping: categories in Orc Peon

  input.required           2 sounds
  session.start            2 sounds
  task.acknowledge         1 sound
  task.complete            2 sounds
  task.error               1 sound
  user.spam                1 sound
```

## Test plan

- [x] `preview` with no arg plays all `session.start` sounds
- [x] `preview` with explicit category plays those sounds
- [x] `preview` with single-sound category plays one sound
- [x] `preview` with invalid category shows error and available categories
- [x] `preview --list` shows all categories with sound counts
- [x] `help` output includes preview command
- [x] All existing tests still pass (test #2 `Notification permission_prompt` failure is pre-existing on main)