### PR TITLE
feat(opencode): rich desktop notifications with terminal-notifier support

### DIFF
--- a/adapters/opencode/peon-ping.ts
+++ b/adapters/opencode/peon-ping.ts
@@ -462,6 +462,13 @@ interface NotifyOptions {
 /**
  * Detect whether terminal-notifier is available.
  * Cached at plugin init for performance.
+ *
+ * TODO: terminal-notifier (github.com/julienXX/terminal-notifier) is unmaintained
+ * (last commit 2021) and uses the deprecated NSUserNotification API. Consider
+ * migrating to jamf/Notifier (github.com/jamf/Notifier) which uses the modern
+ * UserNotifications framework and has built-in --rebrand support for custom icons.
+ * Migrate when jamf/Notifier is published to Homebrew or when terminal-notifier
+ * breaks on a future macOS release.
  */
 function detectTerminalNotifier(): string | null {
   try {
@@ -507,6 +514,7 @@ function sendNotification(opts: NotifyOptions, terminalNotifierPath: string | nu
 
   if (platform === "darwin") {
     // Prefer terminal-notifier for rich notifications (custom icon, grouping)
+    // TODO: Replace with jamf/Notifier when available via Homebrew — see detectTerminalNotifier()
     if (terminalNotifierPath) {
       try {
         const args = [


### PR DESCRIPTION
## Summary

Enhances the OpenCode adapter's desktop notification system with rich, informative notifications using `terminal-notifier` on macOS.

<p align="center">
<img width="487" height="217" alt="Screenshot 2026-02-13 at 12 39 35" src="https://github.com/user-attachments/assets/e433f9d1-2782-44af-a176-71875f3f532c" />
</p>

### Changes

- **`NotifyOptions` interface**: Structured notification data with `title`, `subtitle`, `body`, `group`, and `iconPath`
- **`detectTerminalNotifier()`**: Finds `terminal-notifier` binary at plugin init (cached for performance)
- **`resolveIconPath()`**: Locates `peon-icon.png` from Homebrew libexec, Claude hooks dir, or plugin dir
- **`escapeAppleScript()`**: Proper string escaping for osascript fallback (prevents injection)
- **Rich notification content**:
  - **Title**: Event description (e.g. "myproject — Task complete")
  - **Subtitle**: Pack display name (e.g. "Peon")
  - **Body**: Picked sound label (e.g. `🗣 "Work work"`)
  - **Grouping**: Per-project notification coalescing via `-group`
- **Graceful fallback**: When `terminal-notifier` is unavailable, uses `osascript` with `subtitle` parameter
- **Linux**: `notify-send` now supports custom icon via `-i` flag

### Notification flow

```
emitCESP("task.complete") 
  → pickSound() → { file: "sounds/peon_complete1.wav", label: "Job's done!" }
  → sendNotification({
      title: "myproject — Task complete",
      subtitle: "Peon",           // manifest.display_name
      body: '🗣 "Job\'s done!"',  // picked sound label
      group: "peon-ping-myproject",
    }, "/opt/homebrew/bin/terminal-notifier")
```

### Custom notification icon

The `-appIcon` flag in `terminal-notifier` uses a private API that **modern macOS ignores**. To get the peon icon on notifications, replace terminal-notifier's built-in icon:

```bash
# Generate .icns from peon-icon.png
ICON_SRC="$HOME/.config/opencode/peon-ping/peon-icon.png"
# Or from Homebrew install: /opt/homebrew/opt/peon-ping/libexec/docs/peon-icon.png
mkdir -p /tmp/peon.iconset
for size in 16 32 64 128 256 512; do
  sips -z $size $size "$ICON_SRC" --out "/tmp/peon.iconset/icon_${size}x${size}.png" 2>/dev/null
  sips -z $((size*2)) $((size*2)) "$ICON_SRC" --out "/tmp/peon.iconset/icon_${size}x${size}@2x.png" 2>/dev/null
done
iconutil -c icns /tmp/peon.iconset -o /tmp/peon.icns

# Replace terminal-notifier's icon (backup original)
ICNS="/opt/homebrew/opt/terminal-notifier/terminal-notifier.app/Contents/Resources/Terminal.icns"
cp "$ICNS" "${ICNS}.backup"
cp /tmp/peon.icns "$ICNS"
touch /opt/homebrew/opt/terminal-notifier/terminal-notifier.app
```

> **Note**: This must be re-done after `brew upgrade terminal-notifier`.

### Dependencies

- `terminal-notifier` (optional, `brew install terminal-notifier`) — for rich notifications
- `peon-icon.png` from `docs/` — used for icon replacement above

Tested locally on macOS with both `terminal-notifier` and `osascript` fallback.