### PR TITLE
fix(relay): prevent osascript command injection in /notify endpoint

### DIFF
--- a/relay.sh
+++ b/relay.sh
@@ -191,9 +191,13 @@ def play_sound_on_host(path, volume):
 def send_notification_on_host(title, message, color="red"):
     """Send a desktop notification using the host's native notification system."""
     if HOST_PLATFORM == "mac":
+        # Pass title/message as arguments to avoid AppleScript injection
         subprocess.Popen(
             ["osascript", "-e",
-             f'display notification "{message}" with title "{title}"'],
+             'on run argv\n'
+             '  display notification (item 1 of argv) with title (item 2 of argv)\n'
+             'end run',
+             "--", message, title],
             stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
         )
     elif HOST_PLATFORM == "linux":


### PR DESCRIPTION
## Summary
- Pass notification title/message as `argv` arguments to `osascript` instead of interpolating them into a double-quoted AppleScript string
- This prevents crafted POST payloads to the relay's `/notify` endpoint from breaking out of the string and executing arbitrary AppleScript/shell commands
- Uses the same safe `on run argv` pattern already used in `peon.sh` for direct desktop notifications

## Test plan
- [ ] Start relay with `peon relay` on macOS
- [ ] Send a normal notification: `curl -X POST -H 'Content-Type: application/json' -d '{"title":"test","message":"hello"}' http://localhost:19998/notify` — should display normally
- [ ] Send a malicious payload: `curl -X POST -H 'Content-Type: application/json' -d '{"title":"x","message":"\" & do shell script \"echo pwned > /tmp/pwned\" & \""}' http://localhost:19998/notify` — should display the raw string, not execute the command

🤖 Generated with [Claude Code](https://claude.com/claude-code)