### PR TITLE
refactor(opencode): remove Claude Code paths from icon resolution

### DIFF
--- a/adapters/opencode/peon-ping.ts
+++ b/adapters/opencode/peon-ping.ts
@@ -484,15 +484,13 @@ function detectTerminalNotifier(): string | null {
 
 /**
  * Resolve the peon-ping icon path for notifications.
- * Checks Homebrew libexec, then Claude hooks dir, then pack dir.
+ * Checks Homebrew libexec, then OpenCode plugin dir.
  */
 function resolveIconPath(): string | null {
   const candidates = [
     // Homebrew-installed icon (via formula)
     "/opt/homebrew/opt/peon-ping/libexec/docs/peon-icon.png",
     "/usr/local/opt/peon-ping/libexec/docs/peon-icon.png",
-    // Claude hooks install
-    path.join(os.homedir(), ".claude", "hooks", "peon-ping", "docs", "peon-icon.png"),
     // Plugin dir
     path.join(PLUGIN_DIR, "peon-icon.png"),
   ]

--- a/adapters/opencode/setup-icon.sh
+++ b/adapters/opencode/setup-icon.sh
@@ -24,7 +24,6 @@ BREW_PREFIX="$(brew --prefix 2>/dev/null || echo "")"
 for path in \
   "${BREW_PREFIX:+$BREW_PREFIX/lib/peon-ping/docs/peon-icon.png}" \
   "$HOME/.config/opencode/peon-ping/peon-icon.png" \
-  "$HOME/.claude/hooks/peon-ping/docs/peon-icon.png" \
   "$(cd "$(dirname "$0")/../.." 2>/dev/null && pwd)/docs/peon-icon.png"; do
   [ -n "$path" ] && [ -f "$path" ] && ICON="$path" && break
 done


### PR DESCRIPTION
## Summary

- Remove `~/.claude/hooks/peon-ping/docs/peon-icon.png` from `setup-icon.sh` icon search path
- Remove the same Claude hooks path from `resolveIconPath()` in `peon-ping.ts`
- Update JSDoc comment to reflect remaining search order

## Why

`setup-icon.sh` and `peon-ping.ts` are OpenCode-specific adapter files — they should not reference Claude Code's `~/.claude/hooks/...` directory structure. The icon search order is now:

1. Homebrew prefix (`/opt/homebrew/...` or `/usr/local/...`)
2. OpenCode plugin dir (`~/.config/opencode/peon-ping/`)
3. Repo-relative path (`../../docs/peon-icon.png`)

Claude Code users get their icon from `peon.sh` (the main hook script), which has its own icon resolution logic.