### PR TITLE
Fix pw-play silent on non-English locales

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -814,7 +814,7 @@ except:
       " 2>/dev/null
     elif [ "$PLATFORM" = "linux" ]; then
       if command -v pw-play &>/dev/null; then
-        pw-play --volume=0.3 "$TEST_SOUND" 2>/dev/null
+        LC_ALL=C pw-play --volume=0.3 "$TEST_SOUND" 2>/dev/null
       elif command -v paplay &>/dev/null; then
         paplay --volume="$(python3 -c "print(int(0.3 * 65536))")" "$TEST_SOUND" 2>/dev/null
       elif command -v ffplay &>/dev/null; then

--- a/peon.sh
+++ b/peon.sh
@@ -86,9 +86,9 @@ play_linux_sound() {
     pw-play)
       # pw-play (PipeWire) expects volume as float 0.0-1.0 (unlike paplay 0-65536, ffplay/mpv 0-100)
       if [ "$use_bg" = true ]; then
-        nohup pw-play --volume "$vol" "$file" >/dev/null 2>&1 &
+        nohup env LC_ALL=C pw-play --volume "$vol" "$file" >/dev/null 2>&1 &
       else
-        pw-play --volume "$vol" "$file" >/dev/null 2>&1
+        LC_ALL=C pw-play --volume "$vol" "$file" >/dev/null 2>&1
       fi
       ;;
     paplay)

--- a/relay.sh
+++ b/relay.sh
@@ -180,9 +180,13 @@ def play_sound_on_host(path, volume):
         ]
         for cmd_args, name in players:
             if shutil.which(name):
+                env = os.environ.copy()
+                if name == "pw-play":
+                    env["LC_ALL"] = "C"
                 subprocess.Popen(
                     cmd_args,
                     stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+                    env=env,
                 )
                 return
         print(f"  WARNING: no audio backend found on host", file=sys.stderr)


### PR DESCRIPTION
## Summary

- Force `LC_ALL=C` on all `pw-play` invocations so the `--volume` decimal point is always `.` regardless of user locale
- Fixes the issue where locales using comma as decimal separator (e.g. `de_DE.UTF-8`) cause `pw-play --volume 0.5` to be silently ignored
- Applied to `peon.sh`, `relay.sh`, and `install.sh`

Fixes #110