### PR TITLE
fix(opencode): remove existing symlink before curl download

### DIFF
--- a/adapters/opencode.sh
+++ b/adapters/opencode.sh
@@ -89,6 +89,10 @@ esac
 # --- Install plugin ---
 mkdir -p "$OPENCODE_PLUGINS_DIR"
 
+# Remove existing file/symlink — curl -o can't write through a broken symlink
+# (e.g. leftover from Homebrew cellar path after an upgrade)
+rm -f "$OPENCODE_PLUGINS_DIR/peon-ping.ts"
+
 info "Downloading peon-ping.ts plugin..."
 curl -fsSL "$PLUGIN_URL" -o "$OPENCODE_PLUGINS_DIR/peon-ping.ts"
 info "Plugin installed to $OPENCODE_PLUGINS_DIR/peon-ping.ts"


### PR DESCRIPTION
## Problem

`curl -fsSL .../adapters/opencode.sh | bash` crashes with:

```
curl: (56) Failure writing output to destination, passed 1369 returned 4294967295
```

This happens when `~/.config/opencode/plugins/peon-ping.ts` is a broken symlink — for example, a leftover from a previous Homebrew install pointing to an old Cellar path like `/opt/homebrew/Cellar/peon-ping/1.7.1/libexec/adapters/opencode/peon-ping.ts` that no longer exists after an upgrade.

`curl -o` cannot write through a broken symlink and returns error 56 (write callback failure).

## Fix

Add `rm -f` before the `curl -o` download to remove any existing file or symlink at the destination, ensuring a clean write target.

## Repro

```bash
# Create a broken symlink at the plugin path
ln -sf /nonexistent ~/.config/opencode/plugins/peon-ping.ts
# Run the installer — crashes without this fix
curl -fsSL .../adapters/opencode.sh | bash
```