### PR TITLE
Fix Telegram API call in peon.sh

### DIFF
--- a/peon.sh
+++ b/peon.sh
@@ -7,7 +7,7 @@ set -uo pipefail
 detect_platform() {
   case "$(uname -s)" in
     Darwin)
-      if [ -n "${SSH_CONNECTION:-}" ] || [ -n "${SSH_CLIENT:-}" ]; thentele
+      if [ -n "${SSH_CONNECTION:-}" ] || [ -n "${SSH_CLIENT:-}" ]; then
         echo "ssh"
       else
         echo "mac"


### PR DESCRIPTION
The existing curl command does not properly create a valid url resulting in curl failing.  Using the proposed change works.

The change uses the identical approach as pushover just a few lines above.

Tested on mac only.