### PR TITLE
feat: add Kilo CLI adapter

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,7 @@ IDE triggers hook → `peon.sh` reads JSON stdin → single Python call maps eve
 - **`adapters/cursor.sh`** — Translates Cursor events to CESP JSON
 - **`adapters/opencode.sh`** — Installer for OpenCode adapter
 - **`adapters/opencode/peon-ping.ts`** — Full TypeScript CESP plugin for OpenCode IDE
+- **`adapters/kilo.sh`** — Installer for Kilo CLI adapter (downloads and patches the OpenCode plugin)
 - **`adapters/kiro.sh`** — Translates Kiro CLI (Amazon) events to CESP JSON
 - **`adapters/antigravity.sh`** — Filesystem watcher for Google Antigravity agent events
 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 ![macOS](https://img.shields.io/badge/macOS-blue) ![WSL2](https://img.shields.io/badge/WSL2-blue) ![Linux](https://img.shields.io/badge/Linux-blue) ![SSH](https://img.shields.io/badge/SSH-blue)
 ![License](https://img.shields.io/badge/license-MIT-green)
-![Claude Code](https://img.shields.io/badge/Claude_Code-hook-ffab01) ![Codex](https://img.shields.io/badge/Codex-adapter-ffab01) ![Cursor](https://img.shields.io/badge/Cursor-adapter-ffab01) ![OpenCode](https://img.shields.io/badge/OpenCode-adapter-ffab01) ![Kiro](https://img.shields.io/badge/Kiro-adapter-ffab01) ![Antigravity](https://img.shields.io/badge/Antigravity-adapter-ffab01)
+![Claude Code](https://img.shields.io/badge/Claude_Code-hook-ffab01) ![Codex](https://img.shields.io/badge/Codex-adapter-ffab01) ![Cursor](https://img.shields.io/badge/Cursor-adapter-ffab01) ![OpenCode](https://img.shields.io/badge/OpenCode-adapter-ffab01) ![Kilo CLI](https://img.shields.io/badge/Kilo_CLI-adapter-ffab01) ![Kiro](https://img.shields.io/badge/Kiro-adapter-ffab01) ![Antigravity](https://img.shields.io/badge/Antigravity-adapter-ffab01)
 
 **Game character voice lines when your AI coding agent needs attention.**
 
-AI coding agents don't notify you when they finish or need permission. You tab away, lose focus, and waste 15 minutes getting back into flow. peon-ping fixes this with voice lines from Warcraft, StarCraft, Portal, Zelda, and more — works with **Claude Code**, **Codex**, **Cursor**, **OpenCode**, **Kiro**, and **Google Antigravity**.
+AI coding agents don't notify you when they finish or need permission. You tab away, lose focus, and waste 15 minutes getting back into flow. peon-ping fixes this with voice lines from Warcraft, StarCraft, Portal, Zelda, and more — works with **Claude Code**, **Codex**, **Cursor**, **OpenCode**, **Kilo CLI**, **Kiro**, and **Google Antigravity**.
 
 **See it in action** &rarr; [peonping.com](https://peonping.com/)
 
@@ -147,6 +147,7 @@ peon-ping works with any agentic IDE that supports hooks. Adapters translate IDE
 | **OpenAI Codex** | Adapter | Add `notify = ["bash", "/absolute/path/to/.claude/hooks/peon-ping/adapters/codex.sh"]` to `~/.codex/config.toml` |
 | **Cursor** | Adapter | Add hook entries to `~/.cursor/hooks.json` pointing to `adapters/cursor.sh` |
 | **OpenCode** | Adapter | `curl -fsSL https://raw.githubusercontent.com/PeonPing/peon-ping/main/adapters/opencode.sh \| bash` ([setup](#opencode-setup)) |
+| **Kilo CLI** | Adapter | `curl -fsSL https://raw.githubusercontent.com/PeonPing/peon-ping/main/adapters/kilo.sh \| bash` ([setup](#kilo-cli-setup)) |
 | **Kiro** | Adapter | Add hook entries to `~/.kiro/agents/peon-ping.json` pointing to `adapters/kiro.sh` ([setup](#kiro-setup)) |
 | **Google Antigravity** | Adapter | `bash ~/.claude/hooks/peon-ping/adapters/antigravity.sh` (requires `fswatch`: `brew install fswatch`) |
 
@@ -202,6 +203,20 @@ The script auto-finds the peon icon (Homebrew libexec, OpenCode config, or Claud
 > **Future:** When [jamf/Notifier](https://github.com/jamf/Notifier) ships to Homebrew ([#32](https://github.com/jamf/Notifier/issues/32)), the plugin will migrate to it — Notifier has built-in `--rebrand` support, no icon hacks needed.
 
 </details>
+
+### Kilo CLI setup
+
+A native TypeScript plugin for [Kilo CLI](https://github.com/kilocode/cli) with full [CESP v1.0](https://github.com/PeonPing/openpeon) conformance. Kilo CLI is a fork of OpenCode and uses the same plugin system — this installer downloads the OpenCode plugin and patches it for Kilo.
+
+**Quick install:**
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/PeonPing/peon-ping/main/adapters/kilo.sh | bash
+```
+
+The installer copies `peon-ping.ts` to `~/.config/kilo/plugins/` and creates a config at `~/.config/kilo/peon-ping/config.json`. Packs are stored at the shared CESP path (`~/.openpeon/packs/`).
+
+**Features:** Same as the [OpenCode adapter](#opencode-setup) — sound playback, CESP event mapping, desktop notifications, terminal focus detection, tab titles, pack switching, no-repeat logic, and spam detection.
 
 ### Kiro setup
 

--- a/adapters/kilo.sh
+++ b/adapters/kilo.sh
@@ -1,0 +1,201 @@
+#!/bin/bash
+# peon-ping adapter for Kilo CLI
+# Installs the peon-ping CESP v1.0 TypeScript plugin for Kilo CLI
+#
+# Kilo CLI is a fork of OpenCode and uses the same TypeScript plugin system.
+# This installer downloads the OpenCode plugin and patches the import path
+# and config directories for Kilo.
+#
+# Install:
+#   bash adapters/kilo.sh
+#
+# Or directly:
+#   curl -fsSL https://raw.githubusercontent.com/PeonPing/peon-ping/main/adapters/kilo.sh | bash
+#
+# Uninstall:
+#   bash adapters/kilo.sh --uninstall
+
+set -euo pipefail
+
+# --- Config ---
+PLUGIN_URL="https://raw.githubusercontent.com/PeonPing/peon-ping/main/adapters/opencode/peon-ping.ts"
+REGISTRY_URL="https://peonping.github.io/registry/index.json"
+DEFAULT_PACK="peon"
+
+KILO_PLUGINS_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/kilo/plugins"
+PEON_CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/kilo/peon-ping"
+PACKS_DIR="$HOME/.openpeon/packs"
+
+is_safe_source_repo() {
+  [[ "$1" =~ ^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$ ]]
+}
+
+is_safe_source_ref() {
+  [[ "$1" =~ ^[A-Za-z0-9._/-]+$ ]] && [[ "$1" != *".."* ]] && [[ "$1" != /* ]]
+}
+
+is_safe_source_path() {
+  [[ "$1" =~ ^[A-Za-z0-9._/-]+$ ]] && [[ "$1" != *".."* ]] && [[ "$1" != /* ]]
+}
+
+# --- Colors ---
+BOLD=$'\033[1m' DIM=$'\033[2m' RED=$'\033[31m' GREEN=$'\033[32m' YELLOW=$'\033[33m' RESET=$'\033[0m'
+
+info()  { printf "%s>%s %s\n" "$GREEN" "$RESET" "$*"; }
+warn()  { printf "%s!%s %s\n" "$YELLOW" "$RESET" "$*"; }
+error() { printf "%sx%s %s\n" "$RED" "$RESET" "$*" >&2; }
+
+# --- Uninstall ---
+if [ "${1:-}" = "--uninstall" ]; then
+  info "Uninstalling peon-ping from Kilo CLI..."
+  rm -f "$KILO_PLUGINS_DIR/peon-ping.ts"
+  rm -rf "$PEON_CONFIG_DIR"
+  info "Plugin and config removed."
+  info "Sound packs in $PACKS_DIR were preserved (shared with other adapters)."
+  info "To remove packs too: rm -rf $PACKS_DIR"
+  exit 0
+fi
+
+# --- Preflight ---
+info "Installing peon-ping for Kilo CLI..."
+
+if ! command -v curl &>/dev/null; then
+  error "curl is required but not found."
+  exit 1
+fi
+
+# Check for afplay (macOS), paplay (Linux), or powershell (WSL)
+PLATFORM="unknown"
+case "$(uname -s)" in
+  Darwin) PLATFORM="mac" ;;
+  Linux)
+    if grep -qi microsoft /proc/version 2>/dev/null; then
+      PLATFORM="wsl"
+    else
+      PLATFORM="linux"
+    fi ;;
+esac
+
+case "$PLATFORM" in
+  mac)
+    command -v afplay &>/dev/null || warn "afplay not found — sounds may not play" ;;
+  wsl)
+    command -v powershell.exe &>/dev/null || warn "powershell.exe not found — sounds may not play" ;;
+  linux)
+    if ! command -v paplay &>/dev/null && ! command -v aplay &>/dev/null; then
+      warn "No audio player found (paplay/aplay) — sounds may not play"
+    fi ;;
+esac
+
+# --- Install plugin ---
+mkdir -p "$KILO_PLUGINS_DIR"
+
+info "Downloading OpenCode plugin and patching for Kilo CLI..."
+curl -fsSL "$PLUGIN_URL" \
+  | sed \
+    -e 's|"@opencode-ai/plugin"|"@kilocode/plugin"|g' \
+    -e 's|".config", "opencode", "peon-ping"|".config", "kilo", "peon-ping"|g' \
+    -e 's|`oc-\${Date.now()}`|`kilo-${Date.now()}`|g' \
+    -e 's|) || "opencode"|) || "kilo"|g' \
+    -e 's|peon-ping for OpenCode|peon-ping for Kilo CLI|g' \
+    -e 's|A CESP.*player for OpenCode\.|A CESP (Coding Event Sound Pack Specification) player for Kilo CLI.|g' \
+    -e 's|Maps OpenCode events|Maps Kilo events|g' \
+    -e 's|~/.config/opencode/plugins/peon-ping.ts|~/.config/kilo/plugins/peon-ping.ts|g' \
+    -e 's|Restart OpenCode|Restart Kilo CLI|g' \
+    -e 's|OpenCode Event|Kilo Event|g' \
+    -e 's|OpenCode -> CESP|Kilo CLI -> CESP|g' \
+    -e 's|Return OpenCode event hooks|Return Kilo event hooks|g' \
+  > "$KILO_PLUGINS_DIR/peon-ping.ts"
+info "Plugin installed to $KILO_PLUGINS_DIR/peon-ping.ts"
+
+# --- Create default config ---
+mkdir -p "$PEON_CONFIG_DIR"
+
+if [ ! -f "$PEON_CONFIG_DIR/config.json" ]; then
+  cat > "$PEON_CONFIG_DIR/config.json" << 'CONFIGEOF'
+{
+  "active_pack": "peon",
+  "volume": 0.5,
+  "enabled": true,
+  "categories": {
+    "session.start": true,
+    "session.end": true,
+    "task.acknowledge": true,
+    "task.complete": true,
+    "task.error": true,
+    "task.progress": true,
+    "input.required": true,
+    "resource.limit": true,
+    "user.spam": true
+  },
+  "spam_threshold": 3,
+  "spam_window_seconds": 10,
+  "pack_rotation": [],
+  "debounce_ms": 500
+}
+CONFIGEOF
+  info "Config created at $PEON_CONFIG_DIR/config.json"
+else
+  info "Config already exists, preserved."
+fi
+
+# --- Install default sound pack from registry ---
+mkdir -p "$PACKS_DIR"
+
+if [ ! -d "$PACKS_DIR/$DEFAULT_PACK" ]; then
+  info "Installing default sound pack '$DEFAULT_PACK' from registry..."
+
+  REGISTRY_JSON=$(curl -fsSL "$REGISTRY_URL" 2>/dev/null || true)
+  PACK_INFO=$(PACK_NAME="$DEFAULT_PACK" python3 -c "
+import sys, json
+reg = json.load(sys.stdin)
+for p in reg.get('packs', []):
+    if p.get('name') == __import__('os').environ.get('PACK_NAME'):
+        print(p.get('source_repo', ''))
+        print(p.get('source_ref', ''))
+        print(p.get('source_path', ''))
+        break
+" <<< "$REGISTRY_JSON" 2>/dev/null || echo "")
+
+  SOURCE_REPO=$(echo "$PACK_INFO" | sed -n '1p')
+  SOURCE_REF=$(echo "$PACK_INFO" | sed -n '2p')
+  SOURCE_PATH=$(echo "$PACK_INFO" | sed -n '3p')
+
+  if is_safe_source_repo "$SOURCE_REPO" && is_safe_source_ref "$SOURCE_REF" && is_safe_source_path "$SOURCE_PATH"; then
+    TMPDIR_PACK=$(mktemp -d)
+    TARBALL_URL="https://github.com/${SOURCE_REPO}/archive/refs/tags/${SOURCE_REF}.tar.gz"
+    if curl -fsSL "$TARBALL_URL" -o "$TMPDIR_PACK/pack.tar.gz" 2>/dev/null; then
+      if tar tzf "$TMPDIR_PACK/pack.tar.gz" | grep -Eq '(^/|(^|/)\.\.(/|$))'; then
+        warn "Pack archive contains unsafe paths; skipping extraction."
+      else
+        tar xzf "$TMPDIR_PACK/pack.tar.gz" -C "$TMPDIR_PACK" 2>/dev/null
+        EXTRACTED=$(find "$TMPDIR_PACK" -maxdepth 1 -type d ! -path "$TMPDIR_PACK" | head -1)
+        if [ -n "$EXTRACTED" ] && [ -d "$EXTRACTED/${SOURCE_PATH}" ]; then
+          mkdir -p "$PACKS_DIR/$DEFAULT_PACK"
+          cp -r "$EXTRACTED/${SOURCE_PATH}/"* "$PACKS_DIR/$DEFAULT_PACK/"
+          info "Pack '$DEFAULT_PACK' installed to $PACKS_DIR/$DEFAULT_PACK"
+        else
+          warn "Could not find pack in downloaded archive."
+        fi
+      fi
+    else
+      warn "Could not download pack from registry. You can install packs manually later."
+    fi
+    rm -rf "$TMPDIR_PACK"
+  else
+    warn "Could not find '$DEFAULT_PACK' in registry. You can install packs manually later."
+  fi
+else
+  info "Pack '$DEFAULT_PACK' already installed."
+fi
+
+# --- Done ---
+echo ""
+info "${BOLD}peon-ping installed for Kilo CLI!${RESET}"
+echo ""
+printf "  %sPlugin:%s  %s\n" "$DIM" "$RESET" "$KILO_PLUGINS_DIR/peon-ping.ts"
+printf "  %sConfig:%s  %s\n" "$DIM" "$RESET" "$PEON_CONFIG_DIR/config.json"
+printf "  %sPacks:%s   %s\n" "$DIM" "$RESET" "$PACKS_DIR/"
+echo ""
+info "Restart Kilo CLI to activate. Your Peon awaits."
+info "Install more packs: https://openpeon.com/packs"


### PR DESCRIPTION
## Summary

- Adds `adapters/kilo.sh` installer for Kilo CLI (a fork of OpenCode with the same TypeScript plugin system)
- Installer downloads the existing OpenCode plugin and patches it for Kilo at install time — no duplicate TypeScript source file
- Updates README with Kilo CLI badge, Multi-IDE table entry, and setup section
- Updates CLAUDE.md adapter list