### PR TITLE
Add bats tests for OpenCode adapter scripts

### DIFF
--- a/tests/opencode-setup-icon.bats
+++ b/tests/opencode-setup-icon.bats
@@ -1,0 +1,214 @@
+#!/usr/bin/env bats
+
+# Tests for adapters/opencode/setup-icon.sh — replaces terminal-notifier's
+# icon with the peon icon.  macOS-only (sips, iconutil, brew).
+# All external commands are mocked.
+
+setup() {
+  TEST_HOME="$(mktemp -d)"
+  export HOME="$TEST_HOME"
+
+  REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+  SETUP_ICON_SH="$REPO_ROOT/adapters/opencode/setup-icon.sh"
+
+  # --- Create fake peon icon ---
+  mkdir -p "$TEST_HOME/.config/opencode/peon-ping"
+  printf '\x89PNG\r\n' > "$TEST_HOME/.config/opencode/peon-ping/peon-icon.png"
+
+  # --- Create fake terminal-notifier app bundle ---
+  APP_DIR="$TEST_HOME/terminal-notifier.app"
+  mkdir -p "$APP_DIR/Contents/MacOS"
+  mkdir -p "$APP_DIR/Contents/Resources"
+  echo "original-icns" > "$APP_DIR/Contents/Resources/Terminal.icns"
+  cat > "$APP_DIR/Contents/MacOS/terminal-notifier" <<'SCRIPT'
+#!/bin/bash
+echo "terminal-notifier stub"
+SCRIPT
+  chmod +x "$APP_DIR/Contents/MacOS/terminal-notifier"
+
+  # --- Mock bin directory ---
+  MOCK_BIN="$(mktemp -d)"
+
+  # Mock brew --prefix
+  cat > "$MOCK_BIN/brew" <<SCRIPT
+#!/bin/bash
+if [ "\$1" = "--prefix" ]; then
+  echo "$TEST_HOME/brew-prefix"
+fi
+SCRIPT
+  chmod +x "$MOCK_BIN/brew"
+
+  # Mock terminal-notifier
+  cat > "$MOCK_BIN/terminal-notifier" <<SCRIPT
+#!/bin/bash
+echo "terminal-notifier stub"
+SCRIPT
+  chmod +x "$MOCK_BIN/terminal-notifier"
+
+  # Mock readlink -f
+  cat > "$MOCK_BIN/readlink" <<SCRIPT
+#!/bin/bash
+echo "$APP_DIR/Contents/MacOS/terminal-notifier"
+SCRIPT
+  chmod +x "$MOCK_BIN/readlink"
+
+  # Mock realpath
+  cat > "$MOCK_BIN/realpath" <<SCRIPT
+#!/bin/bash
+echo "$APP_DIR/Contents/MacOS/terminal-notifier"
+SCRIPT
+  chmod +x "$MOCK_BIN/realpath"
+
+  # Mock sips
+  cat > "$MOCK_BIN/sips" <<'SCRIPT'
+#!/bin/bash
+out=""
+args=("$@")
+for ((i=0; i<${#args[@]}; i++)); do
+  case "${args[$i]}" in
+    --out) out="${args[$((i+1))]}" ;;
+  esac
+done
+if [ -n "$out" ]; then
+  printf 'PNG-RESIZED' > "$out"
+fi
+SCRIPT
+  chmod +x "$MOCK_BIN/sips"
+
+  # Mock iconutil
+  cat > "$MOCK_BIN/iconutil" <<'SCRIPT'
+#!/bin/bash
+out=""
+args=("$@")
+for ((i=0; i<${#args[@]}; i++)); do
+  case "${args[$i]}" in
+    -o) out="${args[$((i+1))]}" ;;
+  esac
+done
+if [ -n "$out" ]; then
+  echo "FAKE-ICNS" > "$out"
+fi
+exit 0
+SCRIPT
+  chmod +x "$MOCK_BIN/iconutil"
+
+  export PATH="$MOCK_BIN:$PATH"
+}
+
+teardown() {
+  rm -rf "$TEST_HOME" "$MOCK_BIN"
+}
+
+# ============================================================
+# Syntax
+# ============================================================
+
+@test "setup-icon script has valid bash syntax" {
+  run bash -n "$SETUP_ICON_SH"
+  [ "$status" -eq 0 ]
+}
+
+# ============================================================
+# Icon discovery
+# ============================================================
+
+@test "finds peon icon in opencode config dir" {
+  run bash "$SETUP_ICON_SH"
+  [ "$status" -eq 0 ]
+}
+
+@test "finds peon icon via brew prefix" {
+  rm -f "$TEST_HOME/.config/opencode/peon-ping/peon-icon.png"
+  mkdir -p "$TEST_HOME/brew-prefix/lib/peon-ping/docs"
+  printf '\x89PNG\r\n' > "$TEST_HOME/brew-prefix/lib/peon-ping/docs/peon-icon.png"
+
+  run bash "$SETUP_ICON_SH"
+  [ "$status" -eq 0 ]
+}
+
+@test "fails when peon icon is not found anywhere" {
+  rm -f "$TEST_HOME/.config/opencode/peon-ping/peon-icon.png"
+
+  # Copy script to isolated dir so dirname fallback doesn't find repo icon
+  ISOLATED_DIR="$(mktemp -d)"
+  cp "$SETUP_ICON_SH" "$ISOLATED_DIR/setup-icon.sh"
+
+  run bash "$ISOLATED_DIR/setup-icon.sh"
+  [ "$status" -eq 1 ]
+  rm -rf "$ISOLATED_DIR"
+}
+
+# ============================================================
+# Dependency checks
+# ============================================================
+
+@test "fails when terminal-notifier is not found" {
+  rm -f "$MOCK_BIN/terminal-notifier"
+  export PATH="$MOCK_BIN:/bin:/usr/bin"
+
+  run bash "$SETUP_ICON_SH"
+  [ "$status" -eq 1 ]
+}
+
+# ============================================================
+# Icon replacement and backup
+# ============================================================
+
+@test "replaces Terminal.icns and creates backup" {
+  bash "$SETUP_ICON_SH"
+  icns_content=$(cat "$APP_DIR/Contents/Resources/Terminal.icns")
+  [[ "$icns_content" == "FAKE-ICNS" ]]
+  [ -f "$APP_DIR/Contents/Resources/Terminal.icns.backup" ]
+  backup_content=$(cat "$APP_DIR/Contents/Resources/Terminal.icns.backup")
+  [[ "$backup_content" == "original-icns" ]]
+}
+
+@test "does not overwrite existing backup" {
+  echo "old-backup" > "$APP_DIR/Contents/Resources/Terminal.icns.backup"
+  bash "$SETUP_ICON_SH"
+  backup_content=$(cat "$APP_DIR/Contents/Resources/Terminal.icns.backup")
+  [[ "$backup_content" == "old-backup" ]]
+}
+
+# ============================================================
+# Failure modes
+# ============================================================
+
+@test "exits with error when iconutil fails" {
+  cat > "$MOCK_BIN/iconutil" <<'SCRIPT'
+#!/bin/bash
+exit 1
+SCRIPT
+  chmod +x "$MOCK_BIN/iconutil"
+
+  run bash "$SETUP_ICON_SH"
+  [ "$status" -eq 1 ]
+}
+
+@test "fails gracefully when app bundle cannot be found" {
+  cat > "$MOCK_BIN/readlink" <<'SCRIPT'
+#!/bin/bash
+echo "/nonexistent/path/terminal-notifier"
+SCRIPT
+  chmod +x "$MOCK_BIN/readlink"
+
+  cat > "$MOCK_BIN/realpath" <<'SCRIPT'
+#!/bin/bash
+echo "/nonexistent/path/terminal-notifier"
+SCRIPT
+  chmod +x "$MOCK_BIN/realpath"
+
+  run bash "$SETUP_ICON_SH"
+  [ "$status" -eq 1 ]
+}
+
+# ============================================================
+# Idempotency
+# ============================================================
+
+@test "running twice succeeds (idempotent)" {
+  run bash "$SETUP_ICON_SH"
+  [ "$status" -eq 0 ]
+  run bash "$SETUP_ICON_SH"
+  [ "$status" -eq 0 ]
+}

--- a/tests/opencode.bats
+++ b/tests/opencode.bats
@@ -1,0 +1,271 @@
+#!/usr/bin/env bats
+
+# Tests for adapters/opencode.sh — the OpenCode adapter install script.
+# Covers: install, uninstall, idempotency, broken-symlink fix, XDG support,
+# curl dependency, and registry failure graceful handling.
+
+setup() {
+  TEST_HOME="$(mktemp -d)"
+  export HOME="$TEST_HOME"
+
+  REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+  OPENCODE_SH="$REPO_ROOT/adapters/opencode.sh"
+
+  unset XDG_CONFIG_HOME
+  PLUGINS_DIR="$TEST_HOME/.config/opencode/plugins"
+  CONFIG_DIR="$TEST_HOME/.config/opencode/peon-ping"
+  PACKS_DIR="$TEST_HOME/.openpeon/packs"
+
+  # --- Mock bin directory ---
+  MOCK_BIN="$(mktemp -d)"
+
+  # Mock curl — simulate downloading peon-ping.ts and registry
+  MOCK_REGISTRY='{"packs":[{"name":"peon","display_name":"Orc Peon","source_repo":"PeonPing/og-packs","source_ref":"v1.0.0","source_path":"peon"}]}'
+
+  cat > "$MOCK_BIN/curl" <<MOCK_CURL
+#!/bin/bash
+url=""
+output=""
+args=("\$@")
+for ((i=0; i<\${#args[@]}; i++)); do
+  case "\${args[\$i]}" in
+    -o) output="\${args[\$((i+1))]}" ;;
+    http*) url="\${args[\$i]}" ;;
+  esac
+done
+
+case "\$url" in
+  *peon-ping.ts)
+    if [ -n "\$output" ]; then
+      echo '// peon-ping plugin for OpenCode' > "\$output"
+    fi
+    ;;
+  *index.json)
+    if [ -n "\$output" ]; then
+      echo '$MOCK_REGISTRY' > "\$output"
+    else
+      echo '$MOCK_REGISTRY'
+    fi
+    ;;
+  *tar.gz)
+    tmppack=\$(mktemp -d)
+    mkdir -p "\$tmppack/og-packs-1.0.0/peon/sounds"
+    echo '{"name":"peon"}' > "\$tmppack/og-packs-1.0.0/peon/manifest.json"
+    printf 'RIFF' > "\$tmppack/og-packs-1.0.0/peon/sounds/Hello1.wav"
+    if [ -n "\$output" ]; then
+      tar czf "\$output" -C "\$tmppack" og-packs-1.0.0
+    fi
+    rm -rf "\$tmppack"
+    ;;
+  *)
+    if [ -n "\$output" ]; then
+      echo "mock" > "\$output"
+    fi
+    ;;
+esac
+exit 0
+MOCK_CURL
+  chmod +x "$MOCK_BIN/curl"
+
+  # Mock python3 — simulate registry JSON parser output
+  cat > "$MOCK_BIN/python3" <<'MOCK_PYTHON'
+#!/bin/bash
+echo "PeonPing/og-packs"
+echo "v1.0.0"
+echo "peon"
+MOCK_PYTHON
+  chmod +x "$MOCK_BIN/python3"
+
+  # Mock uname — report Darwin
+  cat > "$MOCK_BIN/uname" <<'SCRIPT'
+#!/bin/bash
+echo "Darwin"
+SCRIPT
+  chmod +x "$MOCK_BIN/uname"
+
+  # Mock afplay — prevent actual sound playback
+  cat > "$MOCK_BIN/afplay" <<'SCRIPT'
+#!/bin/bash
+exit 0
+SCRIPT
+  chmod +x "$MOCK_BIN/afplay"
+
+  export PATH="$MOCK_BIN:$PATH"
+}
+
+teardown() {
+  rm -rf "$TEST_HOME" "$MOCK_BIN"
+}
+
+# ============================================================
+# Syntax
+# ============================================================
+
+@test "adapter script has valid bash syntax" {
+  run bash -n "$OPENCODE_SH"
+  [ "$status" -eq 0 ]
+}
+
+# ============================================================
+# Fresh install
+# ============================================================
+
+@test "fresh install creates plugin, config, and pack" {
+  bash "$OPENCODE_SH"
+  [ -f "$PLUGINS_DIR/peon-ping.ts" ]
+  [ -f "$CONFIG_DIR/config.json" ]
+  [ -d "$PACKS_DIR/peon" ]
+}
+
+@test "config.json has correct defaults and all CESP categories" {
+  bash "$OPENCODE_SH"
+  /usr/bin/python3 -c "
+import json
+c = json.load(open('$CONFIG_DIR/config.json'))
+assert c['active_pack'] == 'peon'
+assert c['volume'] == 0.5
+assert c['enabled'] == True
+assert c['spam_threshold'] == 3
+assert c['debounce_ms'] == 500
+expected = [
+  'session.start', 'session.end', 'task.acknowledge',
+  'task.complete', 'task.error', 'task.progress',
+  'input.required', 'resource.limit', 'user.spam'
+]
+for cat in expected:
+    assert cat in c['categories'], f'Missing: {cat}'
+    assert c['categories'][cat] == True
+"
+}
+
+# ============================================================
+# Idempotency / re-install
+# ============================================================
+
+@test "re-install preserves existing config" {
+  bash "$OPENCODE_SH"
+  /usr/bin/python3 -c "
+import json
+c = json.load(open('$CONFIG_DIR/config.json'))
+c['volume'] = 0.9
+json.dump(c, open('$CONFIG_DIR/config.json', 'w'))
+"
+  bash "$OPENCODE_SH"
+  volume=$(/usr/bin/python3 -c "import json; print(json.load(open('$CONFIG_DIR/config.json'))['volume'])")
+  [ "$volume" = "0.9" ]
+}
+
+@test "re-install overwrites plugin file" {
+  bash "$OPENCODE_SH"
+  echo "// old plugin" > "$PLUGINS_DIR/peon-ping.ts"
+  bash "$OPENCODE_SH"
+  content=$(cat "$PLUGINS_DIR/peon-ping.ts")
+  [[ "$content" == *"peon-ping plugin"* ]]
+}
+
+@test "re-install skips pack if already installed" {
+  bash "$OPENCODE_SH"
+  echo "marker" > "$PACKS_DIR/peon/marker.txt"
+  bash "$OPENCODE_SH"
+  [ -f "$PACKS_DIR/peon/marker.txt" ]
+}
+
+# ============================================================
+# Broken symlink fix (fix-curl-symlink)
+# ============================================================
+
+@test "install removes broken symlink before downloading plugin" {
+  mkdir -p "$PLUGINS_DIR"
+  ln -sf /nonexistent/path "$PLUGINS_DIR/peon-ping.ts"
+  [ -L "$PLUGINS_DIR/peon-ping.ts" ]
+
+  bash "$OPENCODE_SH"
+  [ -f "$PLUGINS_DIR/peon-ping.ts" ]
+  [ ! -L "$PLUGINS_DIR/peon-ping.ts" ]
+}
+
+# ============================================================
+# Uninstall
+# ============================================================
+
+@test "uninstall removes plugin and config but preserves packs" {
+  bash "$OPENCODE_SH"
+  [ -f "$PLUGINS_DIR/peon-ping.ts" ]
+  [ -d "$CONFIG_DIR" ]
+  [ -d "$PACKS_DIR" ]
+
+  run bash "$OPENCODE_SH" --uninstall
+  [ "$status" -eq 0 ]
+  [ ! -f "$PLUGINS_DIR/peon-ping.ts" ]
+  [ ! -d "$CONFIG_DIR" ]
+  [ -d "$PACKS_DIR" ]
+}
+
+# ============================================================
+# XDG_CONFIG_HOME support
+# ============================================================
+
+@test "XDG_CONFIG_HOME overrides default config path" {
+  export XDG_CONFIG_HOME="$TEST_HOME/custom-config"
+  bash "$OPENCODE_SH"
+  [ -f "$TEST_HOME/custom-config/opencode/plugins/peon-ping.ts" ]
+  [ -f "$TEST_HOME/custom-config/opencode/peon-ping/config.json" ]
+}
+
+# ============================================================
+# Curl dependency
+# ============================================================
+
+@test "install fails if curl is not available" {
+  rm -f "$MOCK_BIN/curl"
+  for cmd in printf uname grep env sed find head; do
+    [ -x "/usr/bin/$cmd" ] && ln -sf "/usr/bin/$cmd" "$MOCK_BIN/$cmd" 2>/dev/null || true
+  done
+  export PATH="$MOCK_BIN:/bin"
+  run bash "$OPENCODE_SH"
+  [ "$status" -ne 0 ]
+}
+
+# ============================================================
+# Registry failure graceful handling
+# ============================================================
+
+@test "install succeeds even if registry is unreachable" {
+  cat > "$MOCK_BIN/curl" <<'MOCK_CURL'
+#!/bin/bash
+url=""
+output=""
+args=("$@")
+for ((i=0; i<${#args[@]}; i++)); do
+  case "${args[$i]}" in
+    -o) output="${args[$((i+1))]}" ;;
+    http*) url="${args[$i]}" ;;
+  esac
+done
+case "$url" in
+  *peon-ping.ts)
+    echo '// plugin' > "$output"
+    exit 0
+    ;;
+  *index.json)
+    exit 1
+    ;;
+  *)
+    if [ -n "$output" ]; then echo "mock" > "$output"; fi
+    exit 0
+    ;;
+esac
+MOCK_CURL
+  chmod +x "$MOCK_BIN/curl"
+
+  cat > "$MOCK_BIN/python3" <<'MOCK_PYTHON'
+#!/bin/bash
+exit 1
+MOCK_PYTHON
+  chmod +x "$MOCK_BIN/python3"
+
+  run bash "$OPENCODE_SH"
+  [ "$status" -eq 0 ]
+  [ -f "$PLUGINS_DIR/peon-ping.ts" ]
+  [ -f "$CONFIG_DIR/config.json" ]
+}


### PR DESCRIPTION
## Summary

- Add 21 focused bats tests for the two OpenCode adapter scripts (`adapters/opencode.sh` and `adapters/opencode/setup-icon.sh`)
- All external commands (curl, python3, sips, iconutil, brew, terminal-notifier, afplay) are fully mocked — tests never hit the network or modify real files
- Tests use isolated temp directories with `$HOME` overridden, consistent with existing test patterns

## Test coverage

**`tests/opencode.bats`** (11 tests):
- Syntax validation
- Fresh install (plugin + config + pack creation)
- Config defaults and CESP category completeness
- Idempotency (config preserved, plugin overwritten, pack skipped)
- Broken symlink removal before curl download (fix-curl-symlink)
- Uninstall (removes plugin/config, preserves shared packs)
- `XDG_CONFIG_HOME` override
- curl dependency check
- Graceful handling when registry is unreachable

**`tests/opencode-setup-icon.bats`** (10 tests):
- Syntax validation
- Icon discovery (config dir, brew prefix, not-found failure)
- terminal-notifier dependency check
- Icon replacement + backup creation
- Backup preservation on re-run
- iconutil failure handling
- App bundle resolution failure
- Idempotency