### PR TITLE
fix: eliminate test race conditions and fix local uninstall

### DIFF
--- a/tests/install.bats
+++ b/tests/install.bats
@@ -204,14 +204,28 @@ print('OK')
   ! grep -qF 'peon-ping/completions.bash' "$TEST_HOME/.zshrc"
 }
 
-@test "--local uninstall removes install directory and skills" {
+@test "--local uninstall removes hooks and files" {
   cd "$PROJECT_DIR"
   bash "$CLONE_DIR/install.sh" --local
   [ -f "$LOCAL_INSTALL_DIR/peon.sh" ]
+  # Hooks are in global settings
+  [ -f "$TEST_HOME/.claude/settings.json" ]
+  [ -d "$PROJECT_DIR/.claude/skills/peon-ping-toggle" ]
 
   # Run uninstall (non-interactive — no notify.sh restore prompt for local)
   bash "$LOCAL_INSTALL_DIR/uninstall.sh"
 
+  # Hook entries removed from global settings.json
+  /usr/bin/python3 -c "
+import json
+s = json.load(open('$TEST_HOME/.claude/settings.json'))
+hooks = s.get('hooks', {})
+for event, entries in hooks.items():
+    for entry in entries:
+        for h in entry.get('hooks', []):
+            assert 'peon.sh' not in h.get('command', ''), f'peon.sh still in {event}'
+print('OK')
+"
   # Install and skill directories removed
   [ ! -d "$LOCAL_INSTALL_DIR" ]
   [ ! -d "$PROJECT_DIR/.claude/skills/peon-ping-toggle" ]

--- a/tests/setup.bash
+++ b/tests/setup.bash
@@ -197,8 +197,6 @@ run_peon() {
   echo "$json" | bash "$PEON_SH" 2>"$TEST_DIR/stderr.log"
   PEON_EXIT=$?
   PEON_STDERR=$(cat "$TEST_DIR/stderr.log" 2>/dev/null)
-  # Wait for background nohup afplay to write its log
-  sleep 0.3
 }
 
 # Helper: check if afplay was called


### PR DESCRIPTION
## Summary

Fixes the root cause of flaky tests introduced by backgrounded `nohup` processes, replacing the `sleep 0.3` workaround from #132 with proper `PEON_TEST` guards. Also fixes a bug where `uninstall.sh` failed to clean hooks from global settings during local uninstalls.

## Changes

### `peon.sh` — Fix race conditions at the source
- **`play_sound()` mac case**: Added `PEON_TEST` guard so `afplay` runs synchronously during tests instead of via `nohup ... &`. This is the same pattern already used by `play_linux_sound()`.
- **`send_mobile_notification()`**: Added `PEON_TEST` guard with `use_bg` pattern for all 3 services (ntfy, pushover, telegram) so `curl` runs synchronously during tests.

### `tests/setup.bash` — Remove workaround
- Removed `sleep 0.3` from `run_peon()` — no longer needed since background processes now run synchronously in test mode.

### `uninstall.sh` — Fix local uninstall bug
- `install.sh` always writes hooks to global `$HOME/.claude/settings.json` (by design — hooks need absolute paths). But `uninstall.sh` derived its settings path from its own location, so a local uninstall only cleaned `$PROJECT/.claude/settings.json` where no hooks existed.
- Refactored hook removal into `_remove_peon_hooks()` function and added logic to also clean global settings when uninstalling a local install.

### `tests/install.bats` — Strengthen uninstall test
- Enhanced `--local uninstall` test to verify hooks are actually removed from global `settings.json`, not just that directories are cleaned up.

## Testing

All 195 non-kiro tests pass (122 peon + 19 install + 21 opencode + 20 relay + 13 windsurf). The 7 failing kiro tests are pre-existing and unrelated.