### PR TITLE
fix: add CESP shared path (~/.openpeon/packs) to PEON_DIR fallback

### DIFF
--- a/completions.bash
+++ b/completions.bash
@@ -18,9 +18,10 @@ _peon_completions() {
           COMPREPLY=( $(compgen -W "list use next remove" -- "$cur") )
         elif [ "$cword" -eq 3 ] && { [ "$prev" = "use" ] || [ "$prev" = "remove" ]; }; then
           packs_dir="${CLAUDE_PEON_DIR:-${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/peon-ping}/packs"
+          [ ! -d "$packs_dir" ] && [ -d "$HOME/.openpeon/packs" ] && packs_dir="$HOME/.openpeon/packs"
           if [ -d "$packs_dir" ]; then
             local names
-            names=$(find "$packs_dir" -maxdepth 2 -name manifest.json -exec dirname {} \; 2>/dev/null | xargs -I{} basename {} | sort)
+            names=$(find "$packs_dir" -maxdepth 2 \( -name manifest.json -o -name openpeon.json \) -exec dirname {} \; 2>/dev/null | xargs -I{} basename {} | sort)
             COMPREPLY=( $(compgen -W "$names" -- "$cur") )
           fi
         fi

--- a/completions.fish
+++ b/completions.fish
@@ -41,16 +41,22 @@ complete -c peon -n "__peon_using_subcommand packs" -a remove -d "Remove specifi
 # Pack name completions for 'packs use' and 'packs remove'
 complete -c peon -n "__peon_packs_subcommand use" -a "(
   set -l packs_dir (set -q CLAUDE_PEON_DIR; and echo \$CLAUDE_PEON_DIR; or echo \$HOME/.claude/hooks/peon-ping)/packs
+  if not test -d \$packs_dir; and test -d \$HOME/.openpeon/packs
+    set packs_dir \$HOME/.openpeon/packs
+  end
   if test -d \$packs_dir
-    for manifest in \$packs_dir/*/manifest.json
+    for manifest in \$packs_dir/*/manifest.json \$packs_dir/*/openpeon.json
       basename (dirname \$manifest)
     end
   end
 )"
 complete -c peon -n "__peon_packs_subcommand remove" -a "(
   set -l packs_dir (set -q CLAUDE_PEON_DIR; and echo \$CLAUDE_PEON_DIR; or echo \$HOME/.claude/hooks/peon-ping)/packs
+  if not test -d \$packs_dir; and test -d \$HOME/.openpeon/packs
+    set packs_dir \$HOME/.openpeon/packs
+  end
   if test -d \$packs_dir
-    for manifest in \$packs_dir/*/manifest.json
+    for manifest in \$packs_dir/*/manifest.json \$packs_dir/*/openpeon.json
       basename (dirname \$manifest)
     end
   end

--- a/peon.sh
+++ b/peon.sh
@@ -28,11 +28,17 @@ detect_platform() {
 PLATFORM=${PLATFORM:-$(detect_platform)}
 
 PEON_DIR="${CLAUDE_PEON_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
-# Homebrew installs: script lives in Cellar but packs/config are in hooks dir
+# Homebrew/adapter installs: script lives in Cellar but packs/config are elsewhere
 if [ ! -d "$PEON_DIR/packs" ]; then
-  _hooks_dir="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/peon-ping"
-  [ -d "$_hooks_dir/packs" ] && PEON_DIR="$_hooks_dir"
-  unset _hooks_dir
+  # Check CESP shared path (used by peon-ping-setup and standalone adapters)
+  if [ -d "$HOME/.openpeon/packs" ]; then
+    PEON_DIR="$HOME/.openpeon"
+  else
+    # Fall back to Claude Code hooks dir
+    _hooks_dir="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/peon-ping"
+    [ -d "$_hooks_dir/packs" ] && PEON_DIR="$_hooks_dir"
+    unset _hooks_dir
+  fi
 fi
 CONFIG="$PEON_DIR/config.json"
 STATE="$PEON_DIR/.state.json"

--- a/relay.sh
+++ b/relay.sh
@@ -18,6 +18,10 @@ set -uo pipefail
 # --- Configuration (env vars or CLI flags) ---
 RELAY_PORT="${PEON_RELAY_PORT:-19998}"
 PEON_DIR="${CLAUDE_PEON_DIR:-${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/peon-ping}"
+# CESP shared path fallback (used by peon-ping-setup and standalone adapters)
+if [ ! -d "$PEON_DIR/packs" ] && [ -d "$HOME/.openpeon/packs" ]; then
+  PEON_DIR="$HOME/.openpeon"
+fi
 BIND_ADDR="${PEON_RELAY_BIND:-127.0.0.1}"
 DAEMON_MODE=false
 DAEMON_ACTION=""


### PR DESCRIPTION
## Summary

- Adds `~/.openpeon/packs` (CESP shared path) to the PEON_DIR fallback chain, checked before the Claude Code hooks dir
- Fixes `peon packs list` crash on Homebrew installs configured with `peon-ping-setup` or standalone adapters

## Problem

When installed via Homebrew and configured with `peon-ping-setup`, packs are stored at `~/.openpeon/packs/` (the CESP v1.0 shared path). However, `peon.sh` line 30 resolves `PEON_DIR` to the Cellar libexec path via `BASH_SOURCE[0]`, and the fallback (lines 32-35) only checks `~/.claude/hooks/peon-ping/packs`.

This causes every `peon` CLI command that touches packs — `peon packs list`, `peon packs use`, `peon packs next`, `peon packs remove`, `peon preview` — to crash:

```
FileNotFoundError: [Errno 2] No such file or directory: '/opt/homebrew/Cellar/peon-ping/1.8.1/libexec/packs'
```

## Changes

| File | Change |
|---|---|
| `peon.sh` | Add `~/.openpeon/packs` check before Claude hooks dir fallback |
| `relay.sh` | Add same CESP fallback for relay pack resolution |
| `completions.bash` | Add CESP fallback + `openpeon.json` manifest glob |
| `completions.fish` | Add CESP fallback + `openpeon.json` manifest glob |
| `tests/peon.bats` | +2 tests: CESP fallback discovery, CESP priority over Claude hooks dir |

## Testing

All 232 tests pass (230 existing + 2 new).