### PR TITLE
Fix install.ps1 crash when run via Invoke-Expression one-liner

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -181,10 +181,10 @@ if (-not $Updating) {
 $scriptsDir = Join-Path $InstallDir "scripts"
 New-Item -ItemType Directory -Path $scriptsDir -Force | Out-Null
 
-$winPlaySource = Join-Path $PSScriptRoot "scripts\win-play.ps1"
 $winPlayTarget = Join-Path $scriptsDir "win-play.ps1"
+$winPlaySource = if ($PSScriptRoot) { Join-Path $PSScriptRoot "scripts\win-play.ps1" } else { $null }
 
-if (Test-Path $winPlaySource) {
+if ($winPlaySource -and (Test-Path $winPlaySource)) {
     # Local install: copy from repo
     Copy-Item -Path $winPlaySource -Destination $winPlayTarget -Force
 } else {
@@ -609,13 +609,13 @@ Write-Host "  Hooks registered for: $($events -join ', ')" -ForegroundColor Gree
 Write-Host ""
 Write-Host "Installing skills..."
 
-$skillsSourceDir = Join-Path $PSScriptRoot "skills"
+$skillsSourceDir = if ($PSScriptRoot) { Join-Path $PSScriptRoot "skills" } else { $null }
 $skillsTargetDir = Join-Path $ClaudeDir "skills"
 New-Item -ItemType Directory -Path $skillsTargetDir -Force | Out-Null
 
 $skillNames = @("peon-ping-toggle", "peon-ping-config")
 
-if (Test-Path $skillsSourceDir) {
+if ($skillsSourceDir -and (Test-Path $skillsSourceDir)) {
     # Local install: copy from repo
     foreach ($skillName in $skillNames) {
         $skillSource = Join-Path $skillsSourceDir $skillName
@@ -648,10 +648,10 @@ if (Test-Path $skillsSourceDir) {
 }
 
 # --- Install uninstall script ---
-$uninstallSource = Join-Path $PSScriptRoot "uninstall.ps1"
+$uninstallSource = if ($PSScriptRoot) { Join-Path $PSScriptRoot "uninstall.ps1" } else { $null }
 $uninstallTarget = Join-Path $InstallDir "uninstall.ps1"
 
-if (Test-Path $uninstallSource) {
+if ($uninstallSource -and (Test-Path $uninstallSource)) {
     # Local install: copy from repo
     Copy-Item -Path $uninstallSource -Destination $uninstallTarget -Force
 } else {


### PR DESCRIPTION
## Problem

When `install.ps1` is run via the recommended one-liner:

```powershell
Invoke-WebRequest -Uri "https://raw.githubusercontent.com/PeonPing/peon-ping/main/install.ps1" -UseBasicParsing | Invoke-Expression
```

`$PSScriptRoot` is an empty string because the script is not executing from a file on disk. `Join-Path` throws a terminating error when its `-Path` parameter is empty:

> Cannot bind argument to parameter 'Path' because it is an empty string

Since `$ErrorActionPreference = "Stop"`, this kills the installer at line 184 (`$winPlaySource = Join-Path $PSScriptRoot "scripts\win-play.ps1"`).

The sound packs download successfully (they run before line 184), so the user ends up with a **partial installation**: sounds present, but `peon.ps1`, `scripts/win-play.ps1`, `settings.json` hooks, and skills are all missing.

## Fix

Guard all three `$PSScriptRoot` usages with a null check so the existing download-from-GitHub fallback branches (the `else` paths) are actually reached:

- Line 184: `win-play.ps1` source path
- Line 612: `skills` source directory
- Line 651: `uninstall.ps1` source path

Each location already had the correct fallback logic (download from `$RepoBase`), it was just unreachable due to the crash.

## Testing

- Verified on Windows 10 (PowerShell 5.1) via `Invoke-WebRequest ... | Invoke-Expression`
- Local clone install (`powershell -File install.ps1`) is unaffected since `$PSScriptRoot` is populated when running from a file