### PR TITLE
docs: improve README readability and fix formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ The installer copies `peon-ping.ts` to `~/.config/opencode/plugins/` and creates
 - **Spam detection** — detects 3+ rapid prompts within 10 seconds, triggers `user.spam` voice lines
 
 <details>
-<summary>Screenshot: desktop notifications with custom peon icon</summary>
+<summary>🖼️ Screenshot: desktop notifications with custom peon icon</summary>
 
 ![peon-ping OpenCode notifications](https://github.com/user-attachments/assets/e433f9d1-2782-44af-a176-71875f3f532c)
 
@@ -214,7 +214,7 @@ The installer copies `peon-ping.ts` to `~/.config/opencode/plugins/` and creates
 > **Tip:** Install `terminal-notifier` (`brew install terminal-notifier`) for richer notifications with subtitle and grouping support.
 
 <details>
-<summary>Optional: custom peon icon for notifications</summary>
+<summary>🎨 Optional: custom peon icon for notifications</summary>
 
 By default, `terminal-notifier` shows a generic Terminal icon. The included script replaces it with the peon icon using built-in macOS tools (`sips` + `iconutil`) — no extra dependencies.
 


### PR DESCRIPTION
## Summary

- Fix duplicate "Option 3" numbering (clone section is now Option 4)
- Add table of contents with anchor links for quick navigation
- Split badge wall into two rows: platform badges + IDE adapter badges
- Add missing Windows platform badge
- Add `/peon-ping-config` slash command to Configuration section (was only showing `/peon-ping-toggle`)
- Break "Requirements" from a single dense line into per-platform bullet list
- Break "How it works" wall-of-text paragraph into a numbered step list
- Capitalize "Windows" in install option heading
- Remove extra blank line after PowerShell install block