### PR TITLE
feat: handle SessionEnd event for state cleanup

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -708,7 +708,7 @@ peon_entry = {
 }
 
 # Events to register
-events = ['SessionStart', 'UserPromptSubmit', 'Stop', 'Notification', 'PermissionRequest']
+events = ['SessionStart', 'SessionEnd', 'UserPromptSubmit', 'Stop', 'Notification', 'PermissionRequest']
 
 for event in events:
     event_hooks = hooks.get(event, [])


### PR DESCRIPTION
## Summary

- Register `SessionEnd` hook event so `.state.json` gets cleaned up when sessions terminate
- Prune all 5 session-keyed dictionaries (`session_packs`, `prompt_timestamps`, `session_start_times`, `prompt_start_times`, `agent_sessions`) for the ending session
- Fix Cursor adapter bug: `sessionEnd` was incorrectly mapped to `SessionStart` instead of `SessionEnd`

Without this, every session adds entries to `.state.json` that persist forever — the file grows unbounded over days/weeks of use.