### PR TITLE
docs(webpage): style pack picker search input

### DIFF
--- a/docs/src/app/landing.css
+++ b/docs/src/app/landing.css
@@ -539,6 +539,26 @@ a:hover { text-decoration: underline; }
 }
 
 /* --- Pack picker --- */
+.picker-search {
+  width: 100%;
+  max-width: 360px;
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  padding: 10px 14px;
+  background: var(--wc3-card-bg);
+  border: 1px solid var(--wc3-card-border);
+  border-radius: 4px;
+  color: var(--wc3-text);
+  outline: none;
+  transition: border-color 0.2s;
+  margin-bottom: 16px;
+}
+.picker-search::placeholder {
+  color: var(--wc3-text-muted);
+}
+.picker-search:focus {
+  border-color: var(--wc3-gold);
+}
 .picker-filters {
   display: flex;
   gap: 8px;


### PR DESCRIPTION
## Summary
A minor polish, styled the search pack input field.

PS: Big thank this project is really awesome <3 Contributed a pack today.

## Preview
<img width="899" height="843" alt="peon-ping-search-after" src="https://github.com/user-attachments/assets/ccb4e778-8375-47f7-a909-5140189ce427" />

## Before 
<img width="863" height="801" alt="peon-ping-search-before" src="https://github.com/user-attachments/assets/6819d081-5e2b-4d94-a5ea-23d6d500a48b" />| 

## Test plan
- [X] Run `cd docs && npm run dev` and navigate to the pack picker section
- [X] Verify the search input is clearly visible with dark background styling
- [X] Matches in style with language filter buttons
- [X] Verify the input border turns gold on focus

🤖 Transparency: Generated with [Claude Code](https://claude.com/claude-code)