### PR TITLE
fix cross-platform support for Windows, add devcontainers

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,31 @@
+{
+  "name": "peon-ping Development",
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu-24.04",
+  
+  "features": {
+    "ghcr.io/devcontainers/features/common-utils:2": {
+      "installZsh": true,
+      "installOhMyZsh": true,
+      "upgradePackages": true
+    },
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "lts"
+    }
+  },
+
+  "postCreateCommand": "sudo apt-get update && sudo apt-get install -y bats ffmpeg pulseaudio-utils && bash install.sh --packs=peon && echo 'Dev container ready with peon-ping!'",
+
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "timonwong.shellcheck",
+        "foxundermoon.shell-format"
+      ],
+      "settings": {
+        "terminal.integrated.defaultProfile.linux": "bash"
+      }
+    }
+  },
+
+  "remoteUser": "vscode"
+}

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,23 @@
+# Normalize line endings for all text files
+* text=auto
+
+# Force LF for shell scripts (critical for Unix execution)
+*.sh text eol=lf
+*.bash text eol=lf
+*.fish text eol=lf
+*.bats text eol=lf
+
+# Force CRLF for Windows scripts
+*.ps1 text eol=crlf
+*.cmd text eol=crlf
+*.bat text eol=crlf
+
+# Binary files
+*.wav binary
+*.mp3 binary
+*.ogg binary
+*.png binary
+*.jpg binary
+*.gif binary
+*.ico binary
+*.svg text eol=lf

--- a/peon.sh
+++ b/peon.sh
@@ -13,10 +13,12 @@ detect_platform() {
         echo "mac"
       fi ;;
     Linux)
-      if grep -qi microsoft /proc/version 2>/dev/null; then
-        echo "wsl"
-      elif [ "${REMOTE_CONTAINERS:-}" = "true" ] || [ "${CODESPACES:-}" = "true" ]; then
+      # Check for devcontainer/Docker BEFORE checking for WSL
+      # (devcontainers on WSL2 have both indicators)
+      if [ "${REMOTE_CONTAINERS:-}" = "true" ] || [ "${CODESPACES:-}" = "true" ] || [ -f /.dockerenv ]; then
         echo "devcontainer"
+      elif grep -qi microsoft /proc/version 2>/dev/null; then
+        echo "wsl"
       elif [ -n "${SSH_CONNECTION:-}" ] || [ -n "${SSH_CLIENT:-}" ]; then
         echo "ssh"
       else

--- a/tests/peon.bats
+++ b/tests/peon.bats
@@ -1013,6 +1013,7 @@ JSON
 
 @test "devcontainer SessionStart shows relay guidance when relay unavailable" {
   export PLATFORM=devcontainer
+  rm -f "$TEST_DIR/.relay_available"  # Remove to simulate relay unavailable
   run_peon '{"hook_event_name":"SessionStart","cwd":"/tmp/myproject","session_id":"s1","permission_mode":"default"}'
   [ "$PEON_EXIT" -eq 0 ]
   [[ "$PEON_STDERR" == *"relay not reachable"* ]]
@@ -1113,6 +1114,7 @@ JSON
 
 @test "ssh SessionStart shows relay guidance when relay unavailable" {
   export PLATFORM=ssh
+  rm -f "$TEST_DIR/.relay_available"  # Remove to simulate relay unavailable
   run_peon '{"hook_event_name":"SessionStart","cwd":"/tmp/myproject","session_id":"s1","permission_mode":"default"}'
   [ "$PEON_EXIT" -eq 0 ]
   [[ "$PEON_STDERR" == *"SSH session detected"* ]]


### PR DESCRIPTION
Added devcontainer configuration:
- Ubuntu 24.04 base with auto-install of peon-ping, bats, and audio tools
- Isolated .claude directory (no mount conflicts with host)
- Enables testing and development in consistent Linux environment

Fixed platform detection in install.sh, peon.sh, and relay.sh:
- Check for Docker/devcontainer (/.dockerenv) BEFORE checking for WSL
- Devcontainers on WSL2 have both indicators, caused misdetection
- Create .claude directory automatically for devcontainer/SSH sessions
- Changes only affect platform routing for relay detection

Added Windows/WSL relay support in relay.sh:
- Detect WSL vs pure Linux vs Windows (Git Bash/MINGW)
- Play audio via PowerShell MediaPlayer on Windows hosts
- Convert WSL paths to Windows paths using wslpath when needed
- Enables devcontainer audio relay to Windows host machine

Fixed Windows installer (install.ps1):
- Write files without UTF-8 BOM for cross-platform compatibility (prevents JSON parse errors when files are read by Linux tools)
- Simplified peon.cmd CLI wrapper to use %* for cleaner argument passing
- Added bash-compatible wrapper script for Git Bash/WSL users

Added .gitattributes for line ending consistency:
- Force LF for shell scripts (critical for Unix execution)
- Force CRLF for Windows scripts (.ps1, .cmd, .bat)
- Prevents cross-platform line ending issues

Fixed test infrastructure for devcontainer compatibility:
- Mock relay as available by default in test setup
- Mock curl logs to afplay.log in afplay format for relay tests
- All peon.sh and relay.sh tests now pass in devcontainer (124/124, 20/20)

Partially fixed tests/install-windows.bats:
- Updated extraction pattern to handle CRLF from install.ps1
- PowerShell simulation tests still fail: Python mock outdated