### PR TITLE
feat: add category-based sound selection to relay

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,48 @@ Environment variables: `PEON_RELAY_PORT`, `PEON_RELAY_HOST`, `PEON_RELAY_BIND`.
 
 If peon-ping detects an SSH or container session but can't reach the relay, it prints setup instructions on `SessionStart`.
 
+### Category-based API (for lightweight remote hooks)
+
+The relay supports a category-based endpoint that handles sound selection server-side. This is useful for remote machines where peon-ping isn't installed — the remote hook only needs to send a category name, and the relay picks a random sound from the active pack.
+
+**Endpoints:**
+
+| Endpoint | Description |
+|---|---|
+| `GET /health` | Health check (returns "OK") |
+| `GET /play?file=<path>` | Play a specific sound file (legacy) |
+| `GET /play?category=<cat>` | Play random sound from category (recommended) |
+| `POST /notify` | Send desktop notification |
+
+**Example remote hook (`scripts/remote-hook.sh`):**
+
+```bash
+#!/bin/bash
+RELAY_URL="${PEON_RELAY_URL:-http://127.0.0.1:19998}"
+EVENT=$(cat | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('hook_event_name',''))" 2>/dev/null)
+case "$EVENT" in
+  SessionStart)      CATEGORY="session.start" ;;
+  Stop)              CATEGORY="task.complete" ;;
+  PermissionRequest) CATEGORY="input.required" ;;
+  *)                 exit 0 ;;
+esac
+curl -sf "${RELAY_URL}/play?category=${CATEGORY}" >/dev/null 2>&1 &
+```
+
+Copy this to your remote machine and register it in `~/.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "SessionStart": [{"command": "bash /path/to/remote-hook.sh"}],
+    "Stop": [{"command": "bash /path/to/remote-hook.sh"}],
+    "PermissionRequest": [{"command": "bash /path/to/remote-hook.sh"}]
+  }
+}
+```
+
+The relay reads `config.json` on your local machine to get the active pack and volume, loads the pack's manifest, and picks a random sound while avoiding repeats.
+
 ## Mobile notifications
 
 Get push notifications on your phone when tasks finish or need attention — useful when you're away from your desk.

--- a/scripts/remote-hook.sh
+++ b/scripts/remote-hook.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Minimal peon-ping relay hook for remote Claude Code sessions
+#
+# This hook is for machines where peon-ping isn't installed but a relay
+# is accessible (e.g., over SSH port forwarding). It sends category names
+# to the relay, which handles sound selection server-side.
+#
+# Setup:
+#   1. On your LOCAL machine: peon relay --daemon
+#   2. SSH with port forwarding: ssh -R 19998:localhost:19998 <host>
+#   3. Copy this script to the remote machine
+#   4. Register in ~/.claude/settings.json:
+#      {
+#        "hooks": {
+#          "SessionStart": [{"command": "bash /path/to/remote-hook.sh"}],
+#          "Stop": [{"command": "bash /path/to/remote-hook.sh"}],
+#          "PermissionRequest": [{"command": "bash /path/to/remote-hook.sh"}]
+#        }
+#      }
+#
+# The relay URL defaults to localhost:19998 (SSH tunnel). Override with:
+#   PEON_RELAY_URL=http://host.docker.internal:19998  (for devcontainers)
+#
+set -uo pipefail
+
+RELAY_URL="${PEON_RELAY_URL:-http://127.0.0.1:19998}"
+
+# Parse hook event from JSON stdin
+EVENT=$(cat | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('hook_event_name',''))" 2>/dev/null)
+
+# Map Claude Code events to CESP categories
+case "$EVENT" in
+  SessionStart)      CATEGORY="session.start" ;;
+  Stop)              CATEGORY="task.complete" ;;
+  PermissionRequest) CATEGORY="input.required" ;;
+  *)                 exit 0 ;;  # Ignore other events
+esac
+
+# Fire and forget - don't block Claude Code
+curl -sf "${RELAY_URL}/play?category=${CATEGORY}" >/dev/null 2>&1 &


### PR DESCRIPTION
Add /play?category=<cat> endpoint that handles sound selection server-side. This enables lightweight remote hooks that just send category names (e.g., session.start, task.complete) without needing peon-ping installed locally.

- Add load_config(), load_state(), save_state() Python functions
- Add pick_sound_for_category() for server-side sound selection with no-repeat logic
- Update relay version to v2.0 (category-aware)
- Add scripts/remote-hook.sh as an example minimal hook for SSH setups
- Document category-based API in README.md