### PR TITLE
feat: add Portuguese (BR) language filter to pack picker

### DIFF
--- a/docs/src/app/page.tsx
+++ b/docs/src/app/page.tsx
@@ -653,7 +653,7 @@ export default function LandingPage() {
   }, []);
 
   /* ---- Picker: filter and search ---- */
-  const knownLangs = ["en", "ru", "es", "fr", "cs"];
+  const knownLangs = ["en", "ru", "es", "fr", "cs", "pt-BR"];
   const filteredPacks = registryPacks
     .filter((p) => {
       if (activeFilter === "all") return true;
@@ -1012,6 +1012,7 @@ export default function LandingPage() {
               { lang: "es", label: "Spanish" },
               { lang: "fr", label: "French" },
               { lang: "cs", label: "Czech" },
+              { lang: "pt-BR", label: "Portuguese (BR)" },
               { lang: "other", label: "Other" },
               { lang: "all", label: "All" },
             ].map((f) => (


### PR DESCRIPTION
## Summary
- Adds a "Portuguese (BR)" language filter button to the pack picker section on peonping.com
- Adds `pt-BR` to the `knownLangs` array so Portuguese packs are not grouped under "Other"

## Test plan
- [x] Verified locally that the button appears between "Czech" and "Other"
- [x] Confirmed that clicking the filter correctly shows the 2 Portuguese (BR) packs

🤖 Generated with [Claude Code](https://claude.com/claude-code)