### PR TITLE
Fix WSL audio cutoff by using setsid for PowerShell playback

### DIFF
--- a/peon.sh
+++ b/peon.sh
@@ -191,7 +191,7 @@ play_sound() {
       else
         return 0
       fi
-      powershell.exe -NoProfile -NonInteractive -Command "
+      setsid powershell.exe -NoProfile -NonInteractive -Command "
         (New-Object Media.SoundPlayer '${tmpdir}peon-ping-sound.wav').PlaySync()
       " &>/dev/null &
       save_sound_pid $!


### PR DESCRIPTION
## Summary

- WSL audio (PowerShell `PlaySync()`) gets killed mid-playback when the hook process exits, because the IDE cleans up the entire process group
- All other backends (Linux/macOS) use `nohup` to detach, but that's not enough — `setsid` is needed to create a new session fully isolated from the hook's process tree
- One-line change: `powershell.exe` → `setsid powershell.exe`

## Root cause

When Claude Code (and likely other IDEs) run hooks, they kill child processes after the hook script exits. The PowerShell process playing audio via `PlaySync()` is still part of the hook's process group, so it gets terminated ~0.2s after launch while the audio is ~1s long.

`nohup` + `disown` was tested first but wasn't sufficient — the IDE sends SIGKILL to the process group. Only `setsid` (which creates an entirely new session) fully isolates the process.

## Test plan

- [x] Verified audio files are not truncated (`ffprobe` shows full duration)
- [x] Verified `PlaySync()` works when run directly (`time powershell.exe ... PlaySync()` = 1.5s)
- [x] Tested with `setsid` on WSL2 + Claude Code — all hook events (`UserPromptSubmit`, `Stop`, `PermissionRequest`) play audio to completion
- [x] Tested multiple sound files across categories (peasant pack: "Yes milord", "More work", "Right-o", "Alright" etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)