### PR TITLE
fix: add unpause hints to pause/toggle messages

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1002,4 +1002,4 @@ if [ "$LOCAL_MODE" = false ]; then
   echo "  peon status        — check if sounds are paused"
 fi
 echo ""
-echo "Ready to work!"
+echo "Ready to work! (run 'peon toggle' to mute)"

--- a/peon.sh
+++ b/peon.sh
@@ -597,11 +597,11 @@ sync_adapter_paused() {
 }
 
 case "${1:-}" in
-  pause)   touch "$PAUSED_FILE"; sync_adapter_paused; echo "peon-ping: sounds paused"; exit 0 ;;
+  pause)   touch "$PAUSED_FILE"; sync_adapter_paused; echo "peon-ping: sounds paused (run 'peon toggle' to unpause)"; exit 0 ;;
   resume)  rm -f "$PAUSED_FILE"; sync_adapter_paused; echo "peon-ping: sounds resumed"; exit 0 ;;
   toggle)
     if [ -f "$PAUSED_FILE" ]; then rm -f "$PAUSED_FILE"; echo "peon-ping: sounds resumed"
-    else touch "$PAUSED_FILE"; echo "peon-ping: sounds paused"; fi
+    else touch "$PAUSED_FILE"; echo "peon-ping: sounds paused (run 'peon toggle' to unpause)"; fi
     sync_adapter_paused; exit 0 ;;
   status)
     [ -f "$PAUSED_FILE" ] && echo "peon-ping: paused" || echo "peon-ping: active"


### PR DESCRIPTION
## Summary

- `peon pause` and `peon toggle` (when pausing) now print `(run 'peon toggle' to unpause)` so users know how to restore sounds
- Install script final message now says `(run 'peon toggle' to mute)` to clarify that sounds start active

Addresses confusion reported in #155 where users ran `peon toggle` expecting to enable sounds, not realizing they were already active.