### PR TITLE
feat: tab color profiles

### DIFF
--- a/peon.sh
+++ b/peon.sh
@@ -1974,6 +1974,9 @@ if tab_color_enabled:
         'needs_approval': [150, 70, 70],   # muted red
     }
     custom = tab_color_cfg.get('colors', {})
+    color_profiles = tab_color_cfg.get('color_profiles', {})
+    if project in color_profiles and isinstance(color_profiles[project], dict):
+        custom = dict(custom, **color_profiles[project])
     colors = dict((k, custom.get(k, v)) for k, v in default_colors.items())
     status_key = status.replace(' ', '_') if status else ''
     if status_key in colors:
@@ -2078,6 +2081,8 @@ fi
 
 # --- Set iTerm2 tab color (OSC 6) ---
 # Uses /dev/tty for the same reason as tab title above.
+# In test mode, write resolved color to file for BATS verification.
+[ "${PEON_TEST:-0}" = "1" ] && [ -n "$TAB_COLOR_RGB" ] && echo "$TAB_COLOR_RGB" > "$PEON_DIR/.tab_color_rgb"
 if [ -n "$TAB_COLOR_RGB" ] && [[ "${TERM_PROGRAM:-}" == "iTerm.app" ]]; then
   read -r _R _G _B <<< "$TAB_COLOR_RGB"
   printf "\033]6;1;bg;red;brightness;%d\a" "$_R" > /dev/tty 2>/dev/null || true


### PR DESCRIPTION
🤖 This PR was generated with [Claude Code](https://claude.ai/claude-code)

  ## What this does

  Tab colors are currently the same for every project. This adds **color profiles** — per-project overrides so each
   project gets its own colors across the 4 states. Projects without a profile fall back to defaults.

  Builds on #118.

  ## Configuration

  Keys match the directory name (last component of `cwd`). Partial overrides supported — unspecified states inherit
   from `tab_color.colors` or defaults.

      {
        "tab_color": {
          "color_profiles": {
            "my-api": {
              "ready":          [20, 70, 90],
              "working":        [65, 110, 140],
              "done":           [35, 110, 145],
              "needs_approval": [80, 130, 185]
            },
            "my-frontend": {
              "ready":          [100, 70, 30],
              "working":        [140, 100, 35],
              "done":           [165, 115, 45],
              "needs_approval": [200, 145, 45]
            }
          }
        }
      }


  ## Tests
  - [x] Profile match, fallback, partial override, invalid value handling
  - [x] Full suite passes (143/143)