### PR TITLE
fix: correct stale comments in peon.sh and install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -836,7 +836,7 @@ events = ['SessionStart', 'SessionEnd', 'UserPromptSubmit', 'Stop', 'Notificatio
 
 # PostToolUseFailure only triggers on Bash failures — use matcher to limit scope
 bash_only_events = ('PostToolUseFailure',)
-# PreCompact doesn't support matchers — empty matcher is fine
+# PreCompact supports manual|auto matchers — empty matcher fires for both
 
 for event in events:
     hook = peon_hook_sync if event in sync_events else peon_hook_async

--- a/peon.sh
+++ b/peon.sh
@@ -1873,7 +1873,7 @@ elif event == 'SessionEnd':
     print('PEON_EXIT=true')
     sys.exit(0)
 else:
-    # Unknown event (e.g. PostToolUseFailure) — exit cleanly
+    # Unknown event — exit cleanly
     print('PEON_EXIT=true')
     sys.exit(0)
 


### PR DESCRIPTION
## Summary
- Remove stale `PostToolUseFailure` example from unknown-event comment in `peon.sh` (it's now a handled event)
- Correct `PreCompact` matcher comment in `install.sh` — it does support `manual|auto` matchers; empty matcher fires for both