### PR TITLE
fix: skip greeting sound on context compaction

### DIFF
--- a/peon.sh
+++ b/peon.sh
@@ -1780,6 +1780,11 @@ notify_color = ''
 msg = ''
 
 if event == 'SessionStart':
+    source = event_data.get('source', '')
+    if source == 'compact':
+        # Compaction is mid-conversation — greeting makes no sense
+        print('PEON_EXIT=true')
+        sys.exit(0)
     category = 'session.start'
     status = 'ready'
 elif event == 'UserPromptSubmit':

--- a/tests/peon.bats
+++ b/tests/peon.bats
@@ -22,6 +22,12 @@ teardown() {
   [[ "$sound" == *"/packs/peon/sounds/Hello"* ]]
 }
 
+@test "SessionStart compact skips greeting" {
+  run_peon '{"hook_event_name":"SessionStart","source":"compact","cwd":"/tmp/myproject","session_id":"s1","permission_mode":"default"}'
+  [ "$PEON_EXIT" -eq 0 ]
+  ! afplay_was_called
+}
+
 @test "Notification permission_prompt sets tab title but no sound (PermissionRequest handles sound)" {
   run_peon '{"hook_event_name":"Notification","notification_type":"permission_prompt","cwd":"/tmp/myproject","session_id":"s1","permission_mode":"default"}'
   [ "$PEON_EXIT" -eq 0 ]


### PR DESCRIPTION
## Summary

- Skip the greeting sound when `SessionStart` fires due to context compaction (`source: "compact"`), since compaction happens mid-conversation and a greeting makes no sense there
- Checks the `source` field from the event data and exits early for compact
- Adds test coverage for the compact case