### PR TITLE
feat: add peon packs install and registry listing

### DIFF
--- a/completions.bash
+++ b/completions.bash
@@ -15,7 +15,11 @@ _peon_completions() {
     case "$subcmd" in
       packs)
         if [ "$cword" -eq 2 ]; then
-          COMPREPLY=( $(compgen -W "list use next remove" -- "$cur") )
+          COMPREPLY=( $(compgen -W "list use next install remove" -- "$cur") )
+        elif [ "$cword" -eq 3 ] && [ "$prev" = "install" ]; then
+          COMPREPLY=( $(compgen -W "--all" -- "$cur") )
+        elif [ "$cword" -eq 3 ] && [ "$prev" = "list" ]; then
+          COMPREPLY=( $(compgen -W "--registry" -- "$cur") )
         elif [ "$cword" -eq 3 ] && { [ "$prev" = "use" ] || [ "$prev" = "remove" ]; }; then
           packs_dir="${CLAUDE_PEON_DIR:-${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/peon-ping}/packs"
           [ ! -d "$packs_dir" ] && [ -d "$HOME/.openpeon/packs" ] && packs_dir="$HOME/.openpeon/packs"

--- a/completions.fish
+++ b/completions.fish
@@ -36,7 +36,14 @@ complete -c peon -n __peon_no_subcommand -a help -d "Show help message"
 complete -c peon -n "__peon_using_subcommand packs" -a list -d "List installed sound packs"
 complete -c peon -n "__peon_using_subcommand packs" -a use -d "Switch to a specific pack"
 complete -c peon -n "__peon_using_subcommand packs" -a next -d "Cycle to the next pack"
+complete -c peon -n "__peon_using_subcommand packs" -a install -d "Download and install new packs"
 complete -c peon -n "__peon_using_subcommand packs" -a remove -d "Remove specific packs"
+
+# packs install options
+complete -c peon -n "__peon_packs_subcommand install" -a "--all" -d "Install all packs from registry"
+
+# packs list options
+complete -c peon -n "__peon_packs_subcommand list" -a "--registry" -d "List all available packs from registry"
 
 # Pack name completions for 'packs use' and 'packs remove'
 complete -c peon -n "__peon_packs_subcommand use" -a "(

--- a/install.sh
+++ b/install.sh
@@ -70,10 +70,6 @@ fi
 # Default packs (curated English set installed by default)
 DEFAULT_PACKS="peon peasant glados sc_kerrigan sc_battlecruiser ra2_kirov dota2_axe duke_nukem tf2_engineer hd2_helldiver"
 
-# Fallback pack list (used if registry is unreachable)
-FALLBACK_PACKS="acolyte_de acolyte_ru aoe2 aom_greek brewmaster_ru dota2_axe duke_nukem glados hd2_helldiver molag_bal murloc ocarina_of_time peon peon_cz peon_de peon_es peon_fr peon_pl peon_ru peasant peasant_cz peasant_es peasant_fr peasant_ru ra2_kirov ra2_soviet_engineer ra_soviet rick sc_battlecruiser sc_firebat sc_kerrigan sc_medic sc_scv sc_tank sc_terran sc_vessel sheogorath sopranos tf2_engineer wc2_peasant"
-FALLBACK_REPO="PeonPing/og-packs"
-FALLBACK_REF="v1.1.0"
 
 # --- Platform detection ---
 detect_platform() {
@@ -326,6 +322,7 @@ else
   mkdir -p "$INSTALL_DIR/scripts"
   curl -fsSL "$REPO_BASE/scripts/hook-handle-use.sh" -o "$INSTALL_DIR/scripts/hook-handle-use.sh" 2>/dev/null || true
   curl -fsSL "$REPO_BASE/scripts/hook-handle-use.ps1" -o "$INSTALL_DIR/scripts/hook-handle-use.ps1" 2>/dev/null || true
+  curl -fsSL "$REPO_BASE/scripts/pack-download.sh" -o "$INSTALL_DIR/scripts/pack-download.sh" 2>/dev/null || true
   mkdir -p "$INSTALL_DIR/docs"
   curl -fsSL "$REPO_BASE/docs/peon-icon.png" -o "$INSTALL_DIR/docs/peon-icon.png" 2>/dev/null || true
   if [ "$UPDATING" = false ]; then
@@ -333,312 +330,22 @@ else
   fi
 fi
 
-# --- Fetch pack list from registry ---
-PACKS=""
-ALL_PACKS=""
-REGISTRY_JSON=""
+# --- Download sound packs via shared engine ---
+PACK_DL="$INSTALL_DIR/scripts/pack-download.sh"
+chmod +x "$PACK_DL" 2>/dev/null || true
 
-is_safe_pack_name() {
-  [[ "$1" =~ ^[A-Za-z0-9._-]+$ ]]
-}
-
-is_safe_source_repo() {
-  [[ "$1" =~ ^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$ ]]
-}
-
-is_safe_source_ref() {
-  [[ "$1" =~ ^[A-Za-z0-9._/-]+$ ]] && [[ "$1" != *".."* ]] && [[ "$1" != /* ]]
-}
-
-is_safe_source_path() {
-  [[ "$1" =~ ^[A-Za-z0-9._/-]+$ ]] && [[ "$1" != *".."* ]] && [[ "$1" != /* ]]
-}
-
-is_safe_filename() {
-  [[ "$1" =~ ^[A-Za-z0-9._?!-]+$ ]]
-}
-
-# URL-encode characters that break raw GitHub URLs (e.g. ? in filenames)
-urlencode_filename() {
-  local f="$1"
-  f="${f//\?/%3F}"
-  f="${f//\!/%21}"
-  f="${f//\#/%23}"
-  printf '%s' "$f"
-}
-
-# Compute sha256 of a file (portable across macOS and Linux)
-file_sha256() {
-  if command -v shasum &>/dev/null; then
-    shasum -a 256 "$1" 2>/dev/null | cut -d' ' -f1
-  elif command -v sha256sum &>/dev/null; then
-    sha256sum "$1" 2>/dev/null | cut -d' ' -f1
-  else
-    # fallback: use python
-    python3 -c "import hashlib; print(hashlib.sha256(open('$1','rb').read()).hexdigest())" 2>/dev/null
-  fi
-}
-
-# Check if a downloaded sound file matches its stored checksum
-is_cached_valid() {
-  local filepath="$1" checksums_file="$2" filename="$3"
-  [ -s "$filepath" ] || return 1
-  [ -f "$checksums_file" ] || return 1
-  local stored_hash current_hash
-  stored_hash=$(grep -F "$filename " "$checksums_file" 2>/dev/null | head -1 | cut -d' ' -f2)
-  [ -n "$stored_hash" ] || return 1
-  current_hash=$(file_sha256 "$filepath")
-  [ "$stored_hash" = "$current_hash" ]
-}
-
-# Store checksum for a downloaded file
-store_checksum() {
-  local checksums_file="$1" filename="$2" filepath="$3"
-  local hash
-  hash=$(file_sha256 "$filepath")
-  # Remove old entry if present, then append new one
-  grep -vF "$filename " "$checksums_file" > "$checksums_file.tmp" 2>/dev/null || true
-  echo "$filename $hash" >> "$checksums_file.tmp"
-  mv "$checksums_file.tmp" "$checksums_file"
-}
-
-echo "Fetching pack registry..."
-if REGISTRY_JSON=$(curl -fsSL "$REGISTRY_URL" 2>/dev/null); then
-  ALL_PACKS=$(python3 -c "
-import json, sys
-data = json.loads(sys.stdin.read())
-for p in data.get('packs', []):
-    print(p['name'])
-" <<< "$REGISTRY_JSON")
-  TOTAL_AVAILABLE=$(echo "$ALL_PACKS" | wc -l | tr -d ' ')
-  echo "Registry: $TOTAL_AVAILABLE packs available"
-else
-  echo "Warning: Could not fetch registry, using fallback pack list"
-  ALL_PACKS="$FALLBACK_PACKS"
-fi
-
-# Select packs to install
 if [ -n "$CUSTOM_PACKS" ]; then
-  PACKS=$(echo "$CUSTOM_PACKS" | tr ',' ' ')
-  echo "Installing custom packs: $PACKS"
+  bash "$PACK_DL" --dir="$INSTALL_DIR" --packs="$CUSTOM_PACKS"
 elif [ "$INSTALL_ALL" = true ]; then
-  PACKS="$ALL_PACKS"
-  echo "Installing all $(echo "$PACKS" | wc -l | tr -d ' ') packs..."
+  bash "$PACK_DL" --dir="$INSTALL_DIR" --all
 else
-  PACKS="$DEFAULT_PACKS"
-  echo "Installing $(echo "$PACKS" | wc -w | tr -d ' ') default packs (use --all for all $(echo "$ALL_PACKS" | wc -l | tr -d ' '))"
-fi
-
-# --- Download sound packs ---
-PACK_ARRAY=($PACKS)
-TOTAL_PACKS=${#PACK_ARRAY[@]}
-PACK_INDEX=0
-
-IS_TTY=false
-[ -t 1 ] && IS_TTY=true
-
-TOTAL_DOWNLOAD_FILES=0
-TOTAL_DOWNLOAD_BYTES=0
-TOTAL_DOWNLOAD_PACKS=0
-
-draw_progress() {
-  local pidx="$1" ptotal="$2" pname="$3"
-  local cur="$4" total="$5" bytes="$6"
-  local idx_width=${#ptotal}
-  local bar_width=20 filled=0 empty i bar=""
-
-  if [ "$total" -gt 0 ]; then
-    filled=$(( cur * bar_width / total ))
-  fi
-  empty=$(( bar_width - filled ))
-  for (( i=0; i<filled; i++ )); do bar+="#"; done
-  for (( i=0; i<empty; i++ )); do bar+="-"; done
-
-  local size_str
-  if [ "$bytes" -ge 1048576 ]; then
-    size_str="$(( bytes / 1048576 )).$(( (bytes % 1048576) * 10 / 1048576 )) MB"
-  elif [ "$bytes" -ge 1024 ]; then
-    size_str="$(( bytes / 1024 )) KB"
-  else
-    size_str="$bytes B"
-  fi
-
-  printf "\r  [%${idx_width}d/%d] %-20s [%s] %d/%d (%s)%-10s" \
-    "$pidx" "$ptotal" "$pname" "$bar" "$cur" "$total" "$size_str" ""
-}
-
-echo ""
-echo "Downloading packs..."
-for pack in $PACKS; do
-  if ! is_safe_pack_name "$pack"; then
-    echo "  Warning: skipping invalid pack name: $pack" >&2
-    continue
-  fi
-
-  PACK_INDEX=$((PACK_INDEX + 1))
-
-  mkdir -p "$INSTALL_DIR/packs/$pack/sounds"
-
-  # Get source info from registry (or use fallback)
-  SOURCE_REPO=""
-  SOURCE_REF=""
-  SOURCE_PATH=""
-  if [ -n "$REGISTRY_JSON" ]; then
-    PACK_META=$(PACK_NAME="$pack" python3 -c "
-import json, sys
-data = json.loads(sys.stdin.read())
-for p in data.get('packs', []):
-    if p.get('name') == __import__('os').environ.get('PACK_NAME'):
-        print(p.get('source_repo', ''))
-        print(p.get('source_ref', 'main'))
-        print(p.get('source_path', ''))
-        break
-" <<< "$REGISTRY_JSON" 2>/dev/null || true)
-    SOURCE_REPO=$(printf '%s\n' "$PACK_META" | sed -n '1p')
-    SOURCE_REF=$(printf '%s\n' "$PACK_META" | sed -n '2p')
-    SOURCE_PATH=$(printf '%s\n' "$PACK_META" | sed -n '3p')
-  fi
-
-  if [ -n "$SOURCE_REPO" ] && ! is_safe_source_repo "$SOURCE_REPO"; then
-    SOURCE_REPO=""
-  fi
-  if [ -n "$SOURCE_REF" ] && ! is_safe_source_ref "$SOURCE_REF"; then
-    SOURCE_REF=""
-  fi
-  if [ -n "$SOURCE_PATH" ] && ! is_safe_source_path "$SOURCE_PATH"; then
-    SOURCE_PATH=""
-  fi
-
-  if [ -z "$SOURCE_REPO" ] || [ -z "$SOURCE_REF" ] || [ -z "$SOURCE_PATH" ]; then
-    SOURCE_REPO="$FALLBACK_REPO"
-    SOURCE_REF="$FALLBACK_REF"
-    SOURCE_PATH="$pack"
-  fi
-
-  # Construct base URL for this pack's files
-  if [ -n "$SOURCE_PATH" ]; then
-    PACK_BASE="https://raw.githubusercontent.com/$SOURCE_REPO/$SOURCE_REF/$SOURCE_PATH"
-  else
-    PACK_BASE="https://raw.githubusercontent.com/$SOURCE_REPO/$SOURCE_REF"
-  fi
-
-  # Download manifest
-  if ! curl -fsSL "$PACK_BASE/openpeon.json" -o "$INSTALL_DIR/packs/$pack/openpeon.json" 2>/dev/null; then
-    echo "  Warning: failed to download manifest for $pack" >&2
-    continue
-  fi
-
-  # Download sound files
-  manifest="$INSTALL_DIR/packs/$pack/openpeon.json"
-  SOUND_COUNT=$(python3 -c "
-import json, os
-m = json.load(open('$manifest'))
-seen = set()
-for cat in m.get('categories', {}).values():
-    for s in cat.get('sounds', []):
-        seen.add(os.path.basename(s['file']))
-print(len(seen))
-" 2>/dev/null || echo "?")
-
-  CHECKSUMS_FILE="$INSTALL_DIR/packs/$pack/.checksums"
-  touch "$CHECKSUMS_FILE"
-
-  if [ "$IS_TTY" = true ] && [ "$SOUND_COUNT" != "?" ]; then
-    local_file_count=0
-    local_byte_count=0
-
-    draw_progress "$PACK_INDEX" "$TOTAL_PACKS" "$pack" 0 "$SOUND_COUNT" 0
-
-    while read -r sfile; do
-      if ! is_safe_filename "$sfile"; then
-        echo "  Warning: skipped unsafe filename in $pack: $sfile" >&2
-        continue
-      fi
-      if is_cached_valid "$INSTALL_DIR/packs/$pack/sounds/$sfile" "$CHECKSUMS_FILE" "$sfile"; then
-        local_file_count=$((local_file_count + 1))
-        fsize=$(wc -c < "$INSTALL_DIR/packs/$pack/sounds/$sfile" | tr -d ' ')
-        local_byte_count=$((local_byte_count + fsize))
-      elif curl -fsSL "$PACK_BASE/sounds/$(urlencode_filename "$sfile")" \
-           -o "$INSTALL_DIR/packs/$pack/sounds/$sfile" </dev/null 2>/dev/null; then
-        store_checksum "$CHECKSUMS_FILE" "$sfile" "$INSTALL_DIR/packs/$pack/sounds/$sfile"
-        local_file_count=$((local_file_count + 1))
-        fsize=$(wc -c < "$INSTALL_DIR/packs/$pack/sounds/$sfile" | tr -d ' ')
-        local_byte_count=$((local_byte_count + fsize))
-      else
-        echo "  Warning: failed to download $pack/sounds/$sfile" >&2
-      fi
-      draw_progress "$PACK_INDEX" "$TOTAL_PACKS" "$pack" \
-        "$local_file_count" "$SOUND_COUNT" "$local_byte_count"
-    done < <(python3 -c "
-import json, os
-m = json.load(open('$manifest'))
-seen = set()
-for cat in m.get('categories', {}).values():
-    for s in cat.get('sounds', []):
-        f = s['file']
-        basename = os.path.basename(f)
-        if basename not in seen:
-            seen.add(basename)
-            print(basename)
-")
-
-    draw_progress "$PACK_INDEX" "$TOTAL_PACKS" "$pack" \
-      "$local_file_count" "$SOUND_COUNT" "$local_byte_count"
-    printf "\n"
-
-    TOTAL_DOWNLOAD_FILES=$((TOTAL_DOWNLOAD_FILES + local_file_count))
-    TOTAL_DOWNLOAD_BYTES=$((TOTAL_DOWNLOAD_BYTES + local_byte_count))
-    TOTAL_DOWNLOAD_PACKS=$((TOTAL_DOWNLOAD_PACKS + 1))
-  else
-    printf "  [%d/%d] %s " "$PACK_INDEX" "$TOTAL_PACKS" "$pack"
-
-    python3 -c "
-import json, os
-m = json.load(open('$manifest'))
-seen = set()
-for cat in m.get('categories', {}).values():
-    for s in cat.get('sounds', []):
-        f = s['file']
-        basename = os.path.basename(f)
-        if basename not in seen:
-            seen.add(basename)
-            print(basename)
-" | while read -r sfile; do
-      if ! is_safe_filename "$sfile"; then
-        echo "  Warning: skipped unsafe filename in $pack: $sfile" >&2
-        continue
-      fi
-      if is_cached_valid "$INSTALL_DIR/packs/$pack/sounds/$sfile" "$CHECKSUMS_FILE" "$sfile"; then
-        printf "."
-      elif curl -fsSL "$PACK_BASE/sounds/$(urlencode_filename "$sfile")" -o "$INSTALL_DIR/packs/$pack/sounds/$sfile" </dev/null 2>/dev/null; then
-        store_checksum "$CHECKSUMS_FILE" "$sfile" "$INSTALL_DIR/packs/$pack/sounds/$sfile"
-        printf "."
-      else
-        printf "x"
-        echo "  Warning: failed to download $pack/sounds/$sfile" >&2
-      fi
-    done
-
-    printf " %s sounds\n" "$SOUND_COUNT"
-    TOTAL_DOWNLOAD_PACKS=$((TOTAL_DOWNLOAD_PACKS + 1))
-  fi
-done
-
-if [ "$IS_TTY" = true ] && [ "$TOTAL_DOWNLOAD_PACKS" -gt 0 ]; then
-  if [ "$TOTAL_DOWNLOAD_BYTES" -ge 1048576 ]; then
-    SUMMARY_SIZE="$(( TOTAL_DOWNLOAD_BYTES / 1048576 )).$(( (TOTAL_DOWNLOAD_BYTES % 1048576) * 10 / 1048576 )) MB"
-  elif [ "$TOTAL_DOWNLOAD_BYTES" -ge 1024 ]; then
-    SUMMARY_SIZE="$(( TOTAL_DOWNLOAD_BYTES / 1024 )) KB"
-  else
-    SUMMARY_SIZE="$TOTAL_DOWNLOAD_BYTES B"
-  fi
-  echo ""
-  echo "Downloaded $TOTAL_DOWNLOAD_PACKS packs ($TOTAL_DOWNLOAD_FILES files, $SUMMARY_SIZE)"
+  bash "$PACK_DL" --dir="$INSTALL_DIR" --packs="$(echo "$DEFAULT_PACKS" | tr ' ' ',')"
 fi
 
 chmod +x "$INSTALL_DIR/peon.sh"
 chmod +x "$INSTALL_DIR/relay.sh"
 chmod +x "$INSTALL_DIR/scripts/hook-handle-use.sh" 2>/dev/null || true
+chmod +x "$INSTALL_DIR/scripts/pack-download.sh" 2>/dev/null || true
 
 # --- Install skill (slash command) ---
 SKILL_DIR="$BASE_DIR/skills/peon-ping-toggle"
@@ -772,8 +479,18 @@ if [ -d "$HOME/.config/fish" ]; then
 fi
 
 # --- Verify sounds are installed ---
+if [ -n "$CUSTOM_PACKS" ]; then
+  VERIFY_PACKS=$(echo "$CUSTOM_PACKS" | tr ',' ' ')
+elif [ "$INSTALL_ALL" = true ]; then
+  VERIFY_PACKS=""
+  for _d in "$INSTALL_DIR/packs"/*/; do
+    [ -d "$_d" ] && VERIFY_PACKS="$VERIFY_PACKS $(basename "$_d")"
+  done
+else
+  VERIFY_PACKS="$DEFAULT_PACKS"
+fi
 echo ""
-for pack in $PACKS; do
+for pack in $VERIFY_PACKS; do
   sound_dir="$INSTALL_DIR/packs/$pack/sounds"
   sound_count=$({ ls "$sound_dir"/*.wav "$sound_dir"/*.mp3 "$sound_dir"/*.ogg 2>/dev/null || true; } | wc -l | tr -d ' ')
   if [ "$sound_count" -eq 0 ]; then

--- a/peon.sh
+++ b/peon.sh
@@ -762,6 +762,15 @@ print('peon-ping: desktop notifications off')
   packs)
     case "${2:-}" in
       list)
+        if [ "${3:-}" = "--registry" ]; then
+          PACK_DL="$PEON_DIR/scripts/pack-download.sh"
+          if [ ! -f "$PACK_DL" ]; then
+            echo "Error: pack-download.sh not found. Run 'peon update' to fix." >&2
+            exit 1
+          fi
+          bash "$PACK_DL" --list-registry --dir="$PEON_DIR"
+          exit 0
+        fi
         python3 -c "
 import json, os, glob
 config_path = '$CONFIG'
@@ -947,8 +956,27 @@ if rotation:
     json.dump(cfg, open(config_path, 'w'), indent=2)
 "
         sync_adapter_configs; exit 0 ;;
+      install)
+        INSTALL_ARG="${3:-}"
+        PACK_DL="$PEON_DIR/scripts/pack-download.sh"
+        if [ ! -f "$PACK_DL" ]; then
+          echo "Error: pack-download.sh not found. Run 'peon update' to fix." >&2
+          exit 1
+        fi
+        if [ "$INSTALL_ARG" = "--all" ]; then
+          bash "$PACK_DL" --dir="$PEON_DIR" --all
+        elif [ -n "$INSTALL_ARG" ]; then
+          bash "$PACK_DL" --dir="$PEON_DIR" --packs="$INSTALL_ARG"
+        else
+          echo "Usage: peon packs install <pack1,pack2,...>" >&2
+          echo "       peon packs install --all" >&2
+          echo "" >&2
+          echo "Run 'peon packs list --registry' to see available packs." >&2
+          exit 1
+        fi
+        exit 0 ;;
       *)
-        echo "Usage: peon packs <list|use|next|remove>" >&2; exit 1 ;;
+        echo "Usage: peon packs <list|use|next|install|remove>" >&2; exit 1 ;;
     esac ;;
   mobile)
     case "${2:-}" in
@@ -1300,10 +1328,13 @@ Commands:
   help                 Show this help
 
 Pack management:
-  packs list           List installed sound packs
-  packs use <name>     Switch to a specific pack
-  packs next           Cycle to the next pack
-  packs remove <p1,p2> Remove specific packs
+  packs list              List installed sound packs
+  packs list --registry   List all available packs from registry
+  packs install <p1,p2>   Download and install new packs
+  packs install --all     Download all packs from registry
+  packs use <name>        Switch to a specific pack
+  packs next              Cycle to the next pack
+  packs remove <p1,p2>    Remove specific packs
 
 Mobile notifications:
   mobile ntfy <topic>  Set up ntfy.sh push notifications

--- a/scripts/pack-download.sh
+++ b/scripts/pack-download.sh
@@ -1,0 +1,386 @@
+#!/bin/bash
+# peon-ping shared pack download engine
+# Used by install.sh and `peon packs install`
+set -euo pipefail
+
+REGISTRY_URL="https://peonping.github.io/registry/index.json"
+
+# Fallback pack list (used if registry is unreachable)
+FALLBACK_PACKS="acolyte_de acolyte_ru aoe2 aom_greek brewmaster_ru dota2_axe duke_nukem glados hd2_helldiver molag_bal murloc ocarina_of_time peon peon_cz peon_de peon_es peon_fr peon_pl peon_ru peasant peasant_cz peasant_es peasant_fr peasant_ru ra2_kirov ra2_soviet_engineer ra_soviet rick sc_battlecruiser sc_firebat sc_kerrigan sc_medic sc_scv sc_tank sc_terran sc_vessel sheogorath sopranos tf2_engineer wc2_peasant"
+FALLBACK_REPO="PeonPing/og-packs"
+FALLBACK_REF="v1.1.0"
+
+# Parse arguments
+PEON_DIR=""
+PACKS_CSV=""
+INSTALL_ALL=false
+LIST_REGISTRY=false
+
+for arg in "$@"; do
+  case "$arg" in
+    --dir=*) PEON_DIR="${arg#--dir=}" ;;
+    --packs=*) PACKS_CSV="${arg#--packs=}" ;;
+    --all) INSTALL_ALL=true ;;
+    --list-registry) LIST_REGISTRY=true ;;
+  esac
+done
+
+# --- Safety validators ---
+
+is_safe_pack_name() {
+  [[ "$1" =~ ^[A-Za-z0-9._-]+$ ]]
+}
+
+is_safe_source_repo() {
+  [[ "$1" =~ ^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$ ]]
+}
+
+is_safe_source_ref() {
+  [[ "$1" =~ ^[A-Za-z0-9._/-]+$ ]] && [[ "$1" != *".."* ]] && [[ "$1" != /* ]]
+}
+
+is_safe_source_path() {
+  [[ "$1" =~ ^[A-Za-z0-9._/-]+$ ]] && [[ "$1" != *".."* ]] && [[ "$1" != /* ]]
+}
+
+is_safe_filename() {
+  [[ "$1" =~ ^[A-Za-z0-9._?!-]+$ ]]
+}
+
+# URL-encode characters that break raw GitHub URLs (e.g. ? in filenames)
+urlencode_filename() {
+  local f="$1"
+  f="${f//\?/%3F}"
+  f="${f//\!/%21}"
+  f="${f//\#/%23}"
+  printf '%s' "$f"
+}
+
+# --- Checksum functions ---
+
+# Compute sha256 of a file (portable across macOS and Linux)
+file_sha256() {
+  if command -v shasum &>/dev/null; then
+    shasum -a 256 "$1" 2>/dev/null | cut -d' ' -f1
+  elif command -v sha256sum &>/dev/null; then
+    sha256sum "$1" 2>/dev/null | cut -d' ' -f1
+  else
+    # fallback: use python
+    python3 -c "import hashlib; print(hashlib.sha256(open('$1','rb').read()).hexdigest())" 2>/dev/null
+  fi
+}
+
+# Check if a downloaded sound file matches its stored checksum
+is_cached_valid() {
+  local filepath="$1" checksums_file="$2" filename="$3"
+  [ -s "$filepath" ] || return 1
+  [ -f "$checksums_file" ] || return 1
+  local stored_hash current_hash
+  stored_hash=$(grep -F "$filename " "$checksums_file" 2>/dev/null | head -1 | cut -d' ' -f2)
+  [ -n "$stored_hash" ] || return 1
+  current_hash=$(file_sha256 "$filepath")
+  [ "$stored_hash" = "$current_hash" ]
+}
+
+# Store checksum for a downloaded file
+store_checksum() {
+  local checksums_file="$1" filename="$2" filepath="$3"
+  local hash
+  hash=$(file_sha256 "$filepath")
+  # Remove old entry if present, then append new one
+  grep -vF "$filename " "$checksums_file" > "$checksums_file.tmp" 2>/dev/null || true
+  echo "$filename $hash" >> "$checksums_file.tmp"
+  mv "$checksums_file.tmp" "$checksums_file"
+}
+
+# --- Progress bar ---
+
+draw_progress() {
+  local pidx="$1" ptotal="$2" pname="$3"
+  local cur="$4" total="$5" bytes="$6"
+  local idx_width=${#ptotal}
+  local bar_width=20 filled=0 empty i bar=""
+
+  if [ "$total" -gt 0 ]; then
+    filled=$(( cur * bar_width / total ))
+  fi
+  empty=$(( bar_width - filled ))
+  for (( i=0; i<filled; i++ )); do bar+="#"; done
+  for (( i=0; i<empty; i++ )); do bar+="-"; done
+
+  local size_str
+  if [ "$bytes" -ge 1048576 ]; then
+    size_str="$(( bytes / 1048576 )).$(( (bytes % 1048576) * 10 / 1048576 )) MB"
+  elif [ "$bytes" -ge 1024 ]; then
+    size_str="$(( bytes / 1024 )) KB"
+  else
+    size_str="$bytes B"
+  fi
+
+  printf "\r  [%${idx_width}d/%d] %-20s [%s] %d/%d (%s)%-10s" \
+    "$pidx" "$ptotal" "$pname" "$bar" "$cur" "$total" "$size_str" ""
+}
+
+# --- Registry fetch ---
+
+REGISTRY_JSON=""
+ALL_PACKS=""
+
+fetch_registry() {
+  echo "Fetching pack registry..."
+  if REGISTRY_JSON=$(curl -fsSL "$REGISTRY_URL" 2>/dev/null); then
+    ALL_PACKS=$(python3 -c "
+import json, sys
+data = json.loads(sys.stdin.read())
+for p in data.get('packs', []):
+    print(p['name'])
+" <<< "$REGISTRY_JSON")
+    TOTAL_AVAILABLE=$(echo "$ALL_PACKS" | wc -l | tr -d ' ')
+    echo "Registry: $TOTAL_AVAILABLE packs available"
+  else
+    echo "Warning: Could not fetch registry, using fallback pack list" >&2
+    ALL_PACKS="$FALLBACK_PACKS"
+    REGISTRY_JSON=""
+  fi
+}
+
+# --- List registry mode ---
+
+if [ "$LIST_REGISTRY" = true ]; then
+  fetch_registry
+  if [ -n "$REGISTRY_JSON" ]; then
+    PEON_DIR="$PEON_DIR" python3 -c "
+import json, sys, os
+
+registry = json.loads(sys.stdin.read())
+peon_dir = os.environ.get('PEON_DIR', '')
+installed = set()
+if peon_dir:
+    packs_dir = os.path.join(peon_dir, 'packs')
+    if os.path.isdir(packs_dir):
+        installed = set(os.listdir(packs_dir))
+
+for p in registry.get('packs', []):
+    name = p['name']
+    display = p.get('display_name', name)
+    marker = ' ✓' if name in installed else ''
+    print(f'  {name:24s} {display}{marker}')
+" <<< "$REGISTRY_JSON"
+  else
+    for pack in $ALL_PACKS; do
+      if [ -n "$PEON_DIR" ] && [ -d "$PEON_DIR/packs/$pack" ]; then
+        echo "  $pack ✓"
+      else
+        echo "  $pack"
+      fi
+    done
+  fi
+  exit 0
+fi
+
+# --- Validate arguments ---
+
+if [ -z "$PEON_DIR" ]; then
+  echo "Error: --dir is required" >&2
+  exit 1
+fi
+
+if [ -z "$PACKS_CSV" ] && [ "$INSTALL_ALL" = false ]; then
+  echo "Error: --packs=<names> or --all is required" >&2
+  exit 1
+fi
+
+# --- Fetch registry and select packs ---
+
+fetch_registry
+
+if [ "$INSTALL_ALL" = true ]; then
+  PACKS="$ALL_PACKS"
+  echo "Installing all $(echo "$PACKS" | wc -l | tr -d ' ') packs..."
+else
+  PACKS=$(echo "$PACKS_CSV" | tr ',' ' ')
+  PACK_COUNT=$(echo "$PACKS" | wc -w | tr -d ' ')
+  echo "Installing $PACK_COUNT pack(s)..."
+fi
+
+# --- Download packs ---
+
+PACK_ARRAY=($PACKS)
+TOTAL_PACKS=${#PACK_ARRAY[@]}
+PACK_INDEX=0
+
+IS_TTY=false
+[ -t 1 ] && IS_TTY=true
+
+TOTAL_DOWNLOAD_FILES=0
+TOTAL_DOWNLOAD_BYTES=0
+TOTAL_DOWNLOAD_PACKS=0
+
+echo ""
+echo "Downloading packs..."
+for pack in $PACKS; do
+  if ! is_safe_pack_name "$pack"; then
+    echo "  Warning: skipping invalid pack name: $pack" >&2
+    continue
+  fi
+
+  PACK_INDEX=$((PACK_INDEX + 1))
+
+  mkdir -p "$PEON_DIR/packs/$pack/sounds"
+
+  # Get source info from registry (or use fallback)
+  SOURCE_REPO=""
+  SOURCE_REF=""
+  SOURCE_PATH=""
+  if [ -n "$REGISTRY_JSON" ]; then
+    PACK_META=$(PACK_NAME="$pack" python3 -c "
+import json, sys
+data = json.loads(sys.stdin.read())
+for p in data.get('packs', []):
+    if p.get('name') == __import__('os').environ.get('PACK_NAME'):
+        print(p.get('source_repo', ''))
+        print(p.get('source_ref', 'main'))
+        print(p.get('source_path', ''))
+        break
+" <<< "$REGISTRY_JSON" 2>/dev/null || true)
+    SOURCE_REPO=$(printf '%s\n' "$PACK_META" | sed -n '1p')
+    SOURCE_REF=$(printf '%s\n' "$PACK_META" | sed -n '2p')
+    SOURCE_PATH=$(printf '%s\n' "$PACK_META" | sed -n '3p')
+  fi
+
+  if [ -n "$SOURCE_REPO" ] && ! is_safe_source_repo "$SOURCE_REPO"; then
+    SOURCE_REPO=""
+  fi
+  if [ -n "$SOURCE_REF" ] && ! is_safe_source_ref "$SOURCE_REF"; then
+    SOURCE_REF=""
+  fi
+  if [ -n "$SOURCE_PATH" ] && ! is_safe_source_path "$SOURCE_PATH"; then
+    SOURCE_PATH=""
+  fi
+
+  if [ -z "$SOURCE_REPO" ] || [ -z "$SOURCE_REF" ] || [ -z "$SOURCE_PATH" ]; then
+    SOURCE_REPO="$FALLBACK_REPO"
+    SOURCE_REF="$FALLBACK_REF"
+    SOURCE_PATH="$pack"
+  fi
+
+  # Construct base URL for this pack's files
+  if [ -n "$SOURCE_PATH" ]; then
+    PACK_BASE="https://raw.githubusercontent.com/$SOURCE_REPO/$SOURCE_REF/$SOURCE_PATH"
+  else
+    PACK_BASE="https://raw.githubusercontent.com/$SOURCE_REPO/$SOURCE_REF"
+  fi
+
+  # Download manifest
+  if ! curl -fsSL "$PACK_BASE/openpeon.json" -o "$PEON_DIR/packs/$pack/openpeon.json" 2>/dev/null; then
+    echo "  Warning: failed to download manifest for $pack" >&2
+    continue
+  fi
+
+  # Download sound files
+  manifest="$PEON_DIR/packs/$pack/openpeon.json"
+  SOUND_COUNT=$(python3 -c "
+import json, os
+m = json.load(open('$manifest'))
+seen = set()
+for cat in m.get('categories', {}).values():
+    for s in cat.get('sounds', []):
+        seen.add(os.path.basename(s['file']))
+print(len(seen))
+" 2>/dev/null || echo "?")
+
+  CHECKSUMS_FILE="$PEON_DIR/packs/$pack/.checksums"
+  touch "$CHECKSUMS_FILE"
+
+  if [ "$IS_TTY" = true ] && [ "$SOUND_COUNT" != "?" ]; then
+    local_file_count=0
+    local_byte_count=0
+
+    draw_progress "$PACK_INDEX" "$TOTAL_PACKS" "$pack" 0 "$SOUND_COUNT" 0
+
+    while read -r sfile; do
+      if ! is_safe_filename "$sfile"; then
+        echo "  Warning: skipped unsafe filename in $pack: $sfile" >&2
+        continue
+      fi
+      if is_cached_valid "$PEON_DIR/packs/$pack/sounds/$sfile" "$CHECKSUMS_FILE" "$sfile"; then
+        local_file_count=$((local_file_count + 1))
+        fsize=$(wc -c < "$PEON_DIR/packs/$pack/sounds/$sfile" | tr -d ' ')
+        local_byte_count=$((local_byte_count + fsize))
+      elif curl -fsSL "$PACK_BASE/sounds/$(urlencode_filename "$sfile")" \
+           -o "$PEON_DIR/packs/$pack/sounds/$sfile" </dev/null 2>/dev/null; then
+        store_checksum "$CHECKSUMS_FILE" "$sfile" "$PEON_DIR/packs/$pack/sounds/$sfile"
+        local_file_count=$((local_file_count + 1))
+        fsize=$(wc -c < "$PEON_DIR/packs/$pack/sounds/$sfile" | tr -d ' ')
+        local_byte_count=$((local_byte_count + fsize))
+      else
+        echo "  Warning: failed to download $pack/sounds/$sfile" >&2
+      fi
+      draw_progress "$PACK_INDEX" "$TOTAL_PACKS" "$pack" \
+        "$local_file_count" "$SOUND_COUNT" "$local_byte_count"
+    done < <(python3 -c "
+import json, os
+m = json.load(open('$manifest'))
+seen = set()
+for cat in m.get('categories', {}).values():
+    for s in cat.get('sounds', []):
+        f = s['file']
+        basename = os.path.basename(f)
+        if basename not in seen:
+            seen.add(basename)
+            print(basename)
+")
+
+    draw_progress "$PACK_INDEX" "$TOTAL_PACKS" "$pack" \
+      "$local_file_count" "$SOUND_COUNT" "$local_byte_count"
+    printf "\n"
+
+    TOTAL_DOWNLOAD_FILES=$((TOTAL_DOWNLOAD_FILES + local_file_count))
+    TOTAL_DOWNLOAD_BYTES=$((TOTAL_DOWNLOAD_BYTES + local_byte_count))
+    TOTAL_DOWNLOAD_PACKS=$((TOTAL_DOWNLOAD_PACKS + 1))
+  else
+    printf "  [%d/%d] %s " "$PACK_INDEX" "$TOTAL_PACKS" "$pack"
+
+    python3 -c "
+import json, os
+m = json.load(open('$manifest'))
+seen = set()
+for cat in m.get('categories', {}).values():
+    for s in cat.get('sounds', []):
+        f = s['file']
+        basename = os.path.basename(f)
+        if basename not in seen:
+            seen.add(basename)
+            print(basename)
+" | while read -r sfile; do
+      if ! is_safe_filename "$sfile"; then
+        echo "  Warning: skipped unsafe filename in $pack: $sfile" >&2
+        continue
+      fi
+      if is_cached_valid "$PEON_DIR/packs/$pack/sounds/$sfile" "$CHECKSUMS_FILE" "$sfile"; then
+        printf "."
+      elif curl -fsSL "$PACK_BASE/sounds/$(urlencode_filename "$sfile")" -o "$PEON_DIR/packs/$pack/sounds/$sfile" </dev/null 2>/dev/null; then
+        store_checksum "$CHECKSUMS_FILE" "$sfile" "$PEON_DIR/packs/$pack/sounds/$sfile"
+        printf "."
+      else
+        printf "x"
+        echo "  Warning: failed to download $pack/sounds/$sfile" >&2
+      fi
+    done
+
+    printf " %s sounds\n" "$SOUND_COUNT"
+    TOTAL_DOWNLOAD_PACKS=$((TOTAL_DOWNLOAD_PACKS + 1))
+  fi
+done
+
+if [ "$IS_TTY" = true ] && [ "$TOTAL_DOWNLOAD_PACKS" -gt 0 ]; then
+  if [ "$TOTAL_DOWNLOAD_BYTES" -ge 1048576 ]; then
+    SUMMARY_SIZE="$(( TOTAL_DOWNLOAD_BYTES / 1048576 )).$(( (TOTAL_DOWNLOAD_BYTES % 1048576) * 10 / 1048576 )) MB"
+  elif [ "$TOTAL_DOWNLOAD_BYTES" -ge 1024 ]; then
+    SUMMARY_SIZE="$(( TOTAL_DOWNLOAD_BYTES / 1024 )) KB"
+  else
+    SUMMARY_SIZE="$TOTAL_DOWNLOAD_BYTES B"
+  fi
+  echo ""
+  echo "Downloaded $TOTAL_DOWNLOAD_PACKS packs ($TOTAL_DOWNLOAD_FILES files, $SUMMARY_SIZE)"
+fi

--- a/tests/install.bats
+++ b/tests/install.bats
@@ -22,6 +22,8 @@ setup() {
   cp "$(dirname "$BATS_TEST_FILENAME")/../relay.sh" "$CLONE_DIR/"
   cp "$(dirname "$BATS_TEST_FILENAME")/../uninstall.sh" "$CLONE_DIR/" 2>/dev/null || touch "$CLONE_DIR/uninstall.sh"
   cp -r "$(dirname "$BATS_TEST_FILENAME")/../skills" "$CLONE_DIR/" 2>/dev/null || true
+  mkdir -p "$CLONE_DIR/scripts"
+  cp "$(dirname "$BATS_TEST_FILENAME")/../scripts/"*.sh "$CLONE_DIR/scripts/" 2>/dev/null || true
 
   INSTALL_DIR="$TEST_HOME/.claude/hooks/peon-ping"
 
@@ -290,8 +292,8 @@ print('OK')
 # --- is_safe_filename tests ---
 
 @test "is_safe_filename allows question marks and exclamation marks" {
-  # Source just the function from install.sh
-  eval "$(sed -n '/^is_safe_filename()/,/^}/p' "$CLONE_DIR/install.sh")"
+  # Source just the function from pack-download.sh
+  eval "$(sed -n '/^is_safe_filename()/,/^}/p' "$CLONE_DIR/scripts/pack-download.sh")"
   is_safe_filename "New_construction?.mp3"
   is_safe_filename "Yeah?.mp3"
   is_safe_filename "What!.wav"
@@ -299,7 +301,7 @@ print('OK')
 }
 
 @test "is_safe_filename rejects unsafe characters" {
-  eval "$(sed -n '/^is_safe_filename()/,/^}/p' "$CLONE_DIR/install.sh")"
+  eval "$(sed -n '/^is_safe_filename()/,/^}/p' "$CLONE_DIR/scripts/pack-download.sh")"
   ! is_safe_filename "../etc/passwd"
   ! is_safe_filename "file;rm -rf /"
   ! is_safe_filename 'file$(cmd)'
@@ -308,25 +310,25 @@ print('OK')
 # --- urlencode_filename tests ---
 
 @test "urlencode_filename encodes question marks" {
-  eval "$(sed -n '/^urlencode_filename()/,/^}/p' "$CLONE_DIR/install.sh")"
+  eval "$(sed -n '/^urlencode_filename()/,/^}/p' "$CLONE_DIR/scripts/pack-download.sh")"
   result=$(urlencode_filename "New_construction?.mp3")
   [ "$result" = "New_construction%3F.mp3" ]
 }
 
 @test "urlencode_filename encodes exclamation marks" {
-  eval "$(sed -n '/^urlencode_filename()/,/^}/p' "$CLONE_DIR/install.sh")"
+  eval "$(sed -n '/^urlencode_filename()/,/^}/p' "$CLONE_DIR/scripts/pack-download.sh")"
   result=$(urlencode_filename "Wow!.mp3")
   [ "$result" = "Wow%21.mp3" ]
 }
 
 @test "urlencode_filename encodes hash symbols" {
-  eval "$(sed -n '/^urlencode_filename()/,/^}/p' "$CLONE_DIR/install.sh")"
+  eval "$(sed -n '/^urlencode_filename()/,/^}/p' "$CLONE_DIR/scripts/pack-download.sh")"
   result=$(urlencode_filename "Track#1.mp3")
   [ "$result" = "Track%231.mp3" ]
 }
 
 @test "urlencode_filename leaves normal filenames unchanged" {
-  eval "$(sed -n '/^urlencode_filename()/,/^}/p' "$CLONE_DIR/install.sh")"
+  eval "$(sed -n '/^urlencode_filename()/,/^}/p' "$CLONE_DIR/scripts/pack-download.sh")"
   result=$(urlencode_filename "Hello.wav")
   [ "$result" = "Hello.wav" ]
 }

--- a/tests/pack-download.bats
+++ b/tests/pack-download.bats
@@ -1,0 +1,151 @@
+#!/usr/bin/env bats
+
+load setup.bash
+
+setup() {
+  setup_test_env
+  setup_pack_download_env
+}
+
+teardown() {
+  teardown_test_env
+}
+
+# ============================================================
+# --list-registry
+# ============================================================
+
+@test "--list-registry prints pack names from registry" {
+  run bash "$PACK_DL_SH" --list-registry --dir="$TEST_DIR"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"test_pack_a"* ]]
+  [[ "$output" == *"test_pack_b"* ]]
+  [[ "$output" == *"Test Pack A"* ]]
+}
+
+@test "--list-registry shows checkmark for installed packs" {
+  # Pre-install test_pack_a
+  mkdir -p "$TEST_DIR/packs/test_pack_a"
+  run bash "$PACK_DL_SH" --list-registry --dir="$TEST_DIR"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"test_pack_a"*"✓"* ]]
+  # test_pack_b is not installed — no checkmark
+  line_b=$(echo "$output" | grep "test_pack_b")
+  [[ "$line_b" != *"✓"* ]]
+}
+
+@test "--list-registry works without --dir" {
+  run bash "$PACK_DL_SH" --list-registry
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"test_pack_a"* ]]
+}
+
+@test "--list-registry falls back when registry unreachable" {
+  touch "$TEST_DIR/.mock_registry_fail"
+  run bash "$PACK_DL_SH" --list-registry --dir="$TEST_DIR"
+  [ "$status" -eq 0 ]
+  # Should use fallback pack list (contains "peon")
+  [[ "$output" == *"peon"* ]]
+}
+
+# ============================================================
+# --packs (download specific packs)
+# ============================================================
+
+@test "--packs downloads specified packs" {
+  run bash "$PACK_DL_SH" --dir="$TEST_DIR" --packs=test_pack_a,test_pack_b
+  [ "$status" -eq 0 ]
+  [ -d "$TEST_DIR/packs/test_pack_a/sounds" ]
+  [ -d "$TEST_DIR/packs/test_pack_b/sounds" ]
+  [ -f "$TEST_DIR/packs/test_pack_a/openpeon.json" ]
+  [ -f "$TEST_DIR/packs/test_pack_b/openpeon.json" ]
+}
+
+@test "--packs downloads sound files" {
+  run bash "$PACK_DL_SH" --dir="$TEST_DIR" --packs=test_pack_a
+  [ "$status" -eq 0 ]
+  [ -f "$TEST_DIR/packs/test_pack_a/sounds/Hello1.wav" ]
+}
+
+@test "--packs creates checksums file" {
+  run bash "$PACK_DL_SH" --dir="$TEST_DIR" --packs=test_pack_a
+  [ "$status" -eq 0 ]
+  [ -f "$TEST_DIR/packs/test_pack_a/.checksums" ]
+}
+
+@test "--packs with single pack works" {
+  run bash "$PACK_DL_SH" --dir="$TEST_DIR" --packs=test_pack_a
+  [ "$status" -eq 0 ]
+  [ -d "$TEST_DIR/packs/test_pack_a" ]
+  [ ! -d "$TEST_DIR/packs/test_pack_b" ]
+}
+
+# ============================================================
+# --all (download all from registry)
+# ============================================================
+
+@test "--all downloads all packs from registry" {
+  run bash "$PACK_DL_SH" --dir="$TEST_DIR" --all
+  [ "$status" -eq 0 ]
+  [ -d "$TEST_DIR/packs/test_pack_a" ]
+  [ -d "$TEST_DIR/packs/test_pack_b" ]
+}
+
+# ============================================================
+# Validation
+# ============================================================
+
+@test "invalid pack name is skipped" {
+  run bash "$PACK_DL_SH" --dir="$TEST_DIR" --packs="../etc/passwd"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"skipping invalid"* ]] || [[ "$(cat "$TEST_DIR/stderr.log" 2>/dev/null)" == *"skipping invalid"* ]]
+}
+
+@test "missing --dir shows error" {
+  run bash "$PACK_DL_SH" --packs=test_pack_a
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"--dir is required"* ]]
+}
+
+@test "missing --packs and --all shows error" {
+  run bash "$PACK_DL_SH" --dir="$TEST_DIR"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"--packs"* ]]
+}
+
+# ============================================================
+# Safety functions
+# ============================================================
+
+@test "is_safe_filename allows question marks and exclamation marks" {
+  eval "$(sed -n '/^is_safe_filename()/,/^}/p' "$PACK_DL_SH")"
+  is_safe_filename "New_construction?.mp3"
+  is_safe_filename "Yeah?.mp3"
+  is_safe_filename "What!.wav"
+  is_safe_filename "Hello.wav"
+}
+
+@test "is_safe_filename rejects unsafe characters" {
+  eval "$(sed -n '/^is_safe_filename()/,/^}/p' "$PACK_DL_SH")"
+  ! is_safe_filename "../etc/passwd"
+  ! is_safe_filename "file;rm -rf /"
+  ! is_safe_filename 'file$(cmd)'
+}
+
+@test "urlencode_filename encodes question marks" {
+  eval "$(sed -n '/^urlencode_filename()/,/^}/p' "$PACK_DL_SH")"
+  result=$(urlencode_filename "New_construction?.mp3")
+  [ "$result" = "New_construction%3F.mp3" ]
+}
+
+@test "urlencode_filename encodes exclamation marks" {
+  eval "$(sed -n '/^urlencode_filename()/,/^}/p' "$PACK_DL_SH")"
+  result=$(urlencode_filename "Wow!.mp3")
+  [ "$result" = "Wow%21.mp3" ]
+}
+
+@test "urlencode_filename leaves normal filenames unchanged" {
+  eval "$(sed -n '/^urlencode_filename()/,/^}/p' "$PACK_DL_SH")"
+  result=$(urlencode_filename "Hello.wav")
+  [ "$result" = "Hello.wav" ]
+}

--- a/tests/peon.bats
+++ b/tests/peon.bats
@@ -775,6 +775,68 @@ JSON
 }
 
 # ============================================================
+# packs install
+# ============================================================
+
+@test "packs install with no args shows usage" {
+  setup_pack_download_env
+  run bash "$PEON_SH" packs install
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Usage"* ]]
+  [[ "$output" == *"packs install"* ]]
+}
+
+@test "packs install downloads pack via pack-download.sh" {
+  setup_pack_download_env
+  run bash "$PEON_SH" packs install test_pack_a
+  [ "$status" -eq 0 ]
+  [ -d "$TEST_DIR/packs/test_pack_a" ]
+  [ -f "$TEST_DIR/packs/test_pack_a/openpeon.json" ]
+}
+
+@test "packs install --all downloads all packs" {
+  setup_pack_download_env
+  run bash "$PEON_SH" packs install --all
+  [ "$status" -eq 0 ]
+  [ -d "$TEST_DIR/packs/test_pack_a" ]
+  [ -d "$TEST_DIR/packs/test_pack_b" ]
+}
+
+@test "packs install errors when pack-download.sh missing" {
+  # Don't call setup_pack_download_env — no scripts/ dir
+  run bash "$PEON_SH" packs install test_pack_a
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"pack-download.sh not found"* ]]
+}
+
+@test "packs list --registry shows registry packs" {
+  setup_pack_download_env
+  run bash "$PEON_SH" packs list --registry
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"test_pack_a"* ]]
+  [[ "$output" == *"Test Pack A"* ]]
+}
+
+@test "packs list --registry errors when pack-download.sh missing" {
+  # Don't call setup_pack_download_env — no scripts/ dir
+  run bash "$PEON_SH" packs list --registry
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"pack-download.sh not found"* ]]
+}
+
+@test "help shows packs install command" {
+  run bash "$PEON_SH" help
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"packs install"* ]]
+}
+
+@test "help shows packs list --registry" {
+  run bash "$PEON_SH" help
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"--registry"* ]]
+}
+
+# ============================================================
 # Pack rotation
 # ============================================================
 


### PR DESCRIPTION
## Summary
- Extract pack download logic from `install.sh` into a shared `scripts/pack-download.sh` engine
- Add `peon packs install <pack1,pack2>` and `peon packs install --all` for post-install pack management
- Add `peon packs list --registry` to browse all available packs from the registry
- Add bash and fish shell completions for new commands
- Add tests for pack-download.sh and peon.sh integration

## Test plan
- [ ] `bats tests/pack-download.bats` — new standalone tests for the download engine
- [ ] `bats tests/peon.bats` — integration tests for `packs install` and `packs list --registry`
- [ ] `bats tests/install.bats` — verify installer still works with extracted logic
- [ ] Manual: `peon packs list --registry` shows available packs with checkmarks for installed
- [ ] Manual: `peon packs install <name>` downloads and installs a new pack

🤖 Generated with [Claude Code](https://claude.com/claude-code)