### PR TITLE
Fix: use INSTALL_DIR for skill path in local installs

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -643,11 +643,7 @@ chmod +x "$INSTALL_DIR/scripts/hook-handle-use.sh" 2>/dev/null || true
 # --- Install skill (slash command) ---
 SKILL_DIR="$BASE_DIR/skills/peon-ping-toggle"
 mkdir -p "$SKILL_DIR"
-if [ "$LOCAL_MODE" = true ]; then
-  SKILL_HOOK_CMD="bash $HOME/.claude/hooks/peon-ping/peon.sh"
-else
-  SKILL_HOOK_CMD="bash $INSTALL_DIR/peon.sh"
-fi
+SKILL_HOOK_CMD="bash $INSTALL_DIR/peon.sh"
 if [ -n "$SCRIPT_DIR" ] && [ -d "$SCRIPT_DIR/skills/peon-ping-toggle" ]; then
   cp "$SCRIPT_DIR/skills/peon-ping-toggle/SKILL.md" "$SKILL_DIR/"
   if [ "$LOCAL_MODE" = true ]; then


### PR DESCRIPTION
## Summary of PR

The local mode branch hardcoded $HOME/.claude/ for SKILL_HOOK_CMD, which is the global path. When peon-ping is only installed locally (--local), this path doesn't exist and the skill fails with "No such file or directory".

INSTALL_DIR already resolves to the correct absolute path for both local ($PWD/.claude/hooks/peon-ping) and global modes, so the if/else was unnecessary.

## Steps to reproduce

1. `mkdir -p ~/test-project/.claude && cd ~/test-project`
2. `curl -fsSL https://raw.githubusercontent.com/PeonPing/peon-ping/main/install.sh | bash -s -- --local --packs=peon`
3. `grep "bash.*peon.sh" .claude/skills/peon-ping-toggle/SKILL.md`
   - Shows: `bash /Users/<you>/.claude/hooks/peon-ping/peon.sh` (global path, doesn't exist)
4. Invoking `/peon-ping-toggle` in Claude Code fails with exit code 127

## Fix

Remove the special-case `if LOCAL_MODE` branch for `SKILL_HOOK_CMD` — `$INSTALL_DIR` is already correct for both modes.