### PR TITLE
docs: add peon packs install and list --registry commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,8 +54,9 @@ peon-ping is part of the [PeonPing](https://github.com/PeonPing) org:
 - **`peon.sh`** — Main hook script (Unix/WSL2). Receives JSON event data on stdin, routes events via an embedded Python block that handles config loading, event parsing, sound selection, and state management in a single invocation. Shell code then handles async audio playback (`nohup` + background processes), desktop notifications, and mobile push notifications.
 - **`peon.ps1`** — Main hook script (native Windows). Pure PowerShell implementation with same event flow as `peon.sh` but without Python dependency. Handles JSON parsing, config/state management, CESP category mapping, sound selection (no-repeat logic), and async audio playback via `win-play.ps1`.
 - **`relay.sh`** — HTTP relay server for SSH/devcontainer/Codespaces. Runs on the local machine, receives audio and notification requests from remote sessions.
-- **`install.sh`** — Installer (Unix/WSL2). Fetches pack registry from GitHub Pages, downloads selected packs, registers hooks in `~/.claude/settings.json`. Falls back to a hardcoded pack list if registry is unreachable.
+- **`install.sh`** — Installer (Unix/WSL2). Fetches pack registry from GitHub Pages, registers hooks in `~/.claude/settings.json`, and delegates pack downloads to `pack-download.sh`. Falls back to a hardcoded pack list if registry is unreachable.
 - **`install.ps1`** — Installer (native Windows). PowerShell version with registry fetching, pack downloads, hook registration, CLI shortcut creation (`peon.cmd` in `~/.local/bin`), and skills installation. Supports `-Packs` param for selective installs and `-All` for full registry.
+- **`scripts/pack-download.sh`** — Shared pack download engine used by both `install.sh` and `peon packs install`. Handles registry fetching, pack validation, tarball downloads, and extraction.
 - **`scripts/win-play.ps1`** — Windows audio playback backend. Async MP3/WAV player using `MediaPlayer` class with volume control.
 - **`config.json`** — Default configuration template.
 

--- a/README.md
+++ b/README.md
@@ -115,6 +115,9 @@ peon pause                # Mute sounds
 peon resume               # Unmute sounds
 peon status               # Check if paused or active
 peon packs list           # List installed sound packs
+peon packs list --registry # Browse all available packs in the registry
+peon packs install <p1,p2> # Install packs from the registry
+peon packs install --all  # Install all packs from the registry
 peon packs use <name>     # Switch to a specific pack
 peon packs next           # Cycle to the next pack
 peon packs remove <p1,p2> # Remove specific packs
@@ -492,6 +495,9 @@ Install all with `--all`, or switch packs anytime:
 peon packs use glados             # switch to a specific pack
 peon packs next                   # cycle to the next pack
 peon packs list                   # list all installed packs
+peon packs list --registry        # browse all available packs
+peon packs install glados,murloc  # install specific packs
+peon packs install --all          # install every pack in the registry
 ```
 
 Want to add your own pack? See the [full guide at openpeon.com/create](https://openpeon.com/create) or [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/README_zh.md
+++ b/README_zh.md
@@ -115,6 +115,9 @@ peon pause                # 静音
 peon resume               # 取消静音
 peon status               # 查看暂停或活动状态
 peon packs list           # 列出已安装的语音包
+peon packs list --registry # 浏览注册表中所有可用语音包
+peon packs install <p1,p2> # 从注册表安装语音包
+peon packs install --all  # 从注册表安装所有语音包
 peon packs use <name>     # 切换到指定语音包
 peon packs next           # 切换到下一个语音包
 peon packs remove <p1,p2> # 移除指定语音包
@@ -492,6 +495,9 @@ peon mobile test          # 发送测试通知
 peon packs use glados             # 切换到指定语音包
 peon packs next                   # 切换到下一个语音包
 peon packs list                   # 列出所有已安装语音包
+peon packs list --registry        # 浏览所有可用语音包
+peon packs install glados,murloc  # 安装指定语音包
+peon packs install --all          # 安装注册表中所有语音包
 ```
 
 想添加自己的语音包？参见 [openpeon.com/create 完整指南](https://openpeon.com/create) 或 [CONTRIBUTING.md](CONTRIBUTING.md)。

--- a/docs/src/app/page.tsx
+++ b/docs/src/app/page.tsx
@@ -979,7 +979,7 @@ export default function LandingPage() {
               <strong><span className="pack-count">{packCount}</span> packs and counting!</strong> You&apos;re only seeing a few above &mdash; there are many more including GLaDOS, StarCraft Terran units, Czech, Spanish &amp; Russian &amp; Polish Warcraft packs, and others.
             </p>
             <p>
-              Run <code>peon packs list</code> to see them all, or <a href="https://openpeon.com/packs">browse the full catalog at openpeon.com</a>.
+              Run <code>peon packs list --registry</code> to see what&apos;s available, <code>peon packs install</code> to add more, or <a href="https://openpeon.com/packs">browse the full catalog at openpeon.com</a>.
             </p>
             <p className="contribute-ideas">
               <strong>Want to add your own?</strong> Any game, any character &mdash; create a GitHub repo with your sounds, register it, and it&apos;s available to everyone. <a href="https://openpeon.com/create">Create a pack &rarr;</a>


### PR DESCRIPTION
## Summary
- Add `peon packs install <p1,p2>`, `peon packs install --all`, and `peon packs list --registry` to the CLI reference in README.md and README_zh.md
- Add usage examples to the Sound Packs section in both READMEs
- Add `scripts/pack-download.sh` to CLAUDE.md core files, update `install.sh` description
- Update landing page CTA to reference the new commands

## Test plan
- [x] `bats tests/` — 323/324 pass (1 pre-existing WSL toast failure)
- [ ] Visual review of rendered markdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)