### PR TITLE
feat: add --install flag to packs use command

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ peon packs list --registry # Browse all available packs in the registry
 peon packs install <p1,p2> # Install packs from the registry
 peon packs install --all  # Install all packs from the registry
 peon packs use <name>     # Switch to a specific pack
+peon packs use --install <name>  # Switch to pack, installing from registry if needed
 peon packs next           # Cycle to the next pack
 peon packs remove <p1,p2> # Remove specific packs
 peon notifications on     # Enable desktop notifications
@@ -493,6 +494,7 @@ Install all with `--all`, or switch packs anytime:
 
 ```bash
 peon packs use glados             # switch to a specific pack
+peon packs use --install glados   # install (or update) and switch in one step
 peon packs next                   # cycle to the next pack
 peon packs list                   # list all installed packs
 peon packs list --registry        # browse all available packs

--- a/tests/peon.bats
+++ b/tests/peon.bats
@@ -633,6 +633,45 @@ json.dump(c, open('$TEST_DIR/config.json', 'w'), indent=2)
 }
 
 # ============================================================
+# packs use --install
+# ============================================================
+
+@test "packs use --install downloads and switches to absent pack" {
+  setup_pack_download_env
+  run bash "$PEON_SH" packs use --install test_pack_a
+  [ "$status" -eq 0 ]
+  [ -d "$TEST_DIR/packs/test_pack_a" ]
+  [ -f "$TEST_DIR/packs/test_pack_a/openpeon.json" ]
+  [[ "$output" == *"switched to test_pack_a"* ]]
+  active=$(/usr/bin/python3 -c "import json; print(json.load(open('$TEST_DIR/config.json'))['active_pack'])")
+  [ "$active" = "test_pack_a" ]
+}
+
+@test "packs use --install re-downloads already-installed pack" {
+  setup_pack_download_env
+  run bash "$PEON_SH" packs use --install sc_kerrigan
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"switched to sc_kerrigan"* ]]
+  active=$(/usr/bin/python3 -c "import json; print(json.load(open('$TEST_DIR/config.json'))['active_pack'])")
+  [ "$active" = "sc_kerrigan" ]
+}
+
+@test "packs use <name> --install works (flag after name)" {
+  setup_pack_download_env
+  run bash "$PEON_SH" packs use test_pack_a --install
+  [ "$status" -eq 0 ]
+  [ -d "$TEST_DIR/packs/test_pack_a" ]
+  [[ "$output" == *"switched to test_pack_a"* ]]
+}
+
+@test "packs use --install errors when pack-download.sh missing" {
+  # Don't call setup_pack_download_env — no scripts/ dir
+  run bash "$PEON_SH" packs use --install test_pack_a
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"pack-download.sh not found"* ]]
+}
+
+# ============================================================
 # packs next (cycle, no argument)
 # ============================================================
 


### PR DESCRIPTION
## Summary

- Adds `--install` flag to `peon packs use` so users can download and switch to a pack in one step (`peon packs use --install glados`)
- Also acts as a force-update mechanism for already-installed packs (re-downloads via `pack-download.sh` which has checksum caching)
- Supports both orderings: `peon packs use --install <name>` and `peon packs use <name> --install`

## Test plan

- [x] `packs use --install` downloads and switches to absent pack
- [x] `packs use --install` re-downloads already-installed pack
- [x] `packs use <name> --install` works (flag after name)
- [x] `packs use --install` errors when `pack-download.sh` missing
- [x] All existing `packs use` tests still pass
- [x] Full test suite passes (264 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)