### PR TITLE
fix(opencode): respect desktop_notifications config setting

### DIFF
--- a/adapters/opencode/peon-ping-internals.ts
+++ b/adapters/opencode/peon-ping-internals.ts
@@ -74,6 +74,7 @@ export interface PeonConfig {
   active_pack: string
   volume: number
   enabled: boolean
+  desktop_notifications: boolean
   use_sound_effects_device: boolean
   categories: Partial<Record<CESPCategory, boolean>>
   spam_threshold: number
@@ -142,6 +143,7 @@ export const DEFAULT_CONFIG: PeonConfig = {
   active_pack: "peon",
   volume: 0.5,
   enabled: true,
+  desktop_notifications: true,
   use_sound_effects_device: true,
   categories: {
     "session.start": true,

--- a/adapters/opencode/peon-ping.ts
+++ b/adapters/opencode/peon-ping.ts
@@ -91,6 +91,7 @@ interface PeonConfig {
   active_pack: string
   volume: number
   enabled: boolean
+  desktop_notifications: boolean
   use_sound_effects_device: boolean
   categories: Partial<Record<CESPCategory, boolean>>
   spam_threshold: number
@@ -156,6 +157,7 @@ const DEFAULT_CONFIG: PeonConfig = {
   active_pack: "peon",
   volume: 0.5,
   enabled: true,
+  desktop_notifications: true,
   use_sound_effects_device: true,
   categories: {
     "session.start": true,
@@ -765,8 +767,8 @@ export const PeonPingPlugin: Plugin = async ({ directory }) => {
       }
     }
 
-    // Desktop notification (only when terminal is NOT focused)
-    if (notify && !paused) {
+    // Desktop notification (only when enabled and terminal is NOT focused)
+    if (notify && !paused && config.desktop_notifications !== false) {
       const focused = await isTerminalFocused()
       if (!focused) {
         const title = notifyTitle || `${marker}${projectName}: ${status}`


### PR DESCRIPTION
Fixes #207.

The OpenCode plugin was always sending desktop notifications regardless of the `desktop_notifications` setting in `~/.config/opencode/peon-ping/config.json`. The `PeonConfig` type and `DEFAULT_CONFIG` were also missing the field entirely, so there was no way to load or apply it.

## Changes

- Add `desktop_notifications: boolean` to `PeonConfig` interface in both `peon-ping.ts` and `peon-ping-internals.ts`
- Add `desktop_notifications: true` to `DEFAULT_CONFIG` in both files (preserves existing behaviour for users who haven't set the field)
- Gate the `emitCESP` notification block on `config.desktop_notifications !== false`

The relay notification path (SSH/devcontainer) is also correctly suppressed since it lives inside the same gated block.