### PR TITLE
Add GitHub Copilot adapter with tests and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@
 ![macOS](https://img.shields.io/badge/macOS-blue) ![WSL2](https://img.shields.io/badge/WSL2-blue) ![Linux](https://img.shields.io/badge/Linux-blue) ![Windows](https://img.shields.io/badge/Windows-blue) ![SSH](https://img.shields.io/badge/SSH-blue)
 ![License](https://img.shields.io/badge/license-MIT-green)
 
-![Claude Code](https://img.shields.io/badge/Claude_Code-hook-ffab01) ![Codex](https://img.shields.io/badge/Codex-adapter-ffab01) ![Cursor](https://img.shields.io/badge/Cursor-adapter-ffab01) ![OpenCode](https://img.shields.io/badge/OpenCode-adapter-ffab01) ![Kilo CLI](https://img.shields.io/badge/Kilo_CLI-adapter-ffab01) ![Kiro](https://img.shields.io/badge/Kiro-adapter-ffab01) ![Windsurf](https://img.shields.io/badge/Windsurf-adapter-ffab01) ![Antigravity](https://img.shields.io/badge/Antigravity-adapter-ffab01) ![OpenClaw](https://img.shields.io/badge/OpenClaw-adapter-ffab01)
+![Claude Code](https://img.shields.io/badge/Claude_Code-hook-ffab01) ![GitHub Copilot](https://img.shields.io/badge/GitHub_Copilot-adapter-ffab01) ![Codex](https://img.shields.io/badge/Codex-adapter-ffab01) ![Cursor](https://img.shields.io/badge/Cursor-adapter-ffab01) ![OpenCode](https://img.shields.io/badge/OpenCode-adapter-ffab01) ![Kilo CLI](https://img.shields.io/badge/Kilo_CLI-adapter-ffab01) ![Kiro](https://img.shields.io/badge/Kiro-adapter-ffab01) ![Windsurf](https://img.shields.io/badge/Windsurf-adapter-ffab01) ![Antigravity](https://img.shields.io/badge/Antigravity-adapter-ffab01) ![OpenClaw](https://img.shields.io/badge/OpenClaw-adapter-ffab01)
 
 **Game character voice lines + visual overlay notifications when your AI coding agent needs attention — or let the agent pick its own sound via MCP.**
 
-AI coding agents don't notify you when they finish or need permission. You tab away, lose focus, and waste 15 minutes getting back into flow. peon-ping fixes this with voice lines and bold on-screen banners from Warcraft, StarCraft, Portal, Zelda, and more — works with **Claude Code**, **Codex**, **Cursor**, **OpenCode**, **Kilo CLI**, **Kiro**, **Windsurf**, **Google Antigravity**, and any MCP client.
+AI coding agents don't notify you when they finish or need permission. You tab away, lose focus, and waste 15 minutes getting back into flow. peon-ping fixes this with voice lines and bold on-screen banners from Warcraft, StarCraft, Portal, Zelda, and more — works with **Claude Code**, **GitHub Copilot**, **Codex**, **Cursor**, **OpenCode**, **Kilo CLI**, **Kiro**, **Windsurf**, **Google Antigravity**, and any MCP client.
 
 **See it in action** &rarr; [peonping.com](https://peonping.com/)
 
@@ -285,6 +285,7 @@ peon-ping works with any agentic IDE that supports hooks. Adapters translate IDE
 | IDE | Status | Setup |
 |---|---|---|
 | **Claude Code** | Built-in | `curl \| bash` install handles everything |
+| **GitHub Copilot** | Adapter | Add hooks to `.github/hooks/hooks.json` pointing to `adapters/copilot.sh` ([setup](#github-copilot-setup)) |
 | **OpenAI Codex** | Adapter | Add `notify = ["bash", "/absolute/path/to/.claude/hooks/peon-ping/adapters/codex.sh"]` to `~/.codex/config.toml` |
 | **Cursor** | Built-in | `curl \| bash` or `peon-ping-setup` auto-detects and registers Cursor hooks |
 | **OpenCode** | Adapter | `curl -fsSL https://raw.githubusercontent.com/PeonPing/peon-ping/main/adapters/opencode.sh \| bash` ([setup](#opencode-setup)) |
@@ -293,6 +294,67 @@ peon-ping works with any agentic IDE that supports hooks. Adapters translate IDE
 | **Windsurf** | Adapter | Add hook entries to `~/.codeium/windsurf/hooks.json` pointing to `adapters/windsurf.sh` ([setup](#windsurf-setup)) |
 | **Google Antigravity** | Adapter | `bash ~/.claude/hooks/peon-ping/adapters/antigravity.sh` (requires `fswatch`: `brew install fswatch`) |
 | **OpenClaw** | Adapter | Call `adapters/openclaw.sh <event>` from your OpenClaw skill. Supports all CESP categories and raw Claude Code event names. |
+
+### GitHub Copilot setup
+
+A shell adapter for [GitHub Copilot](https://github.com/features/copilot) with full [CESP v1.0](https://github.com/PeonPing/openpeon) conformance.
+
+**Setup:**
+
+1. Ensure peon-ping is installed (`curl -fsSL https://peonping.com/install | bash`)
+
+2. Create `.github/hooks/hooks.json` in your repository (on the default branch):
+
+   ```json
+   {
+     "version": 1,
+     "hooks": {
+       "sessionStart": [
+         {
+           "type": "command",
+           "bash": "bash ~/.claude/hooks/peon-ping/adapters/copilot.sh sessionStart"
+         }
+       ],
+       "userPromptSubmitted": [
+         {
+           "type": "command",
+           "bash": "bash ~/.claude/hooks/peon-ping/adapters/copilot.sh userPromptSubmitted"
+         }
+       ],
+       "postToolUse": [
+         {
+           "type": "command",
+           "bash": "bash ~/.claude/hooks/peon-ping/adapters/copilot.sh postToolUse"
+         }
+       ],
+       "errorOccurred": [
+         {
+           "type": "command",
+           "bash": "bash ~/.claude/hooks/peon-ping/adapters/copilot.sh errorOccurred"
+         }
+       ]
+     }
+   }
+   ```
+
+3. Commit and merge to your default branch. Hooks will activate on your next Copilot agent session.
+
+**Event mapping:**
+
+- `sessionStart` → Greeting sound (*"Ready to work?"*, *"Yes?"*)
+- `userPromptSubmitted` → First prompt = greeting, subsequent = spam detection
+- `postToolUse` → Completion sound (*"Work, work."*, *"Job's done!"*)
+- `errorOccurred` → Error sound (*"I can't do that."*)
+- `preToolUse` → Skipped (too noisy)
+- `sessionEnd` → No sound (session.end not yet implemented)
+
+**Features:**
+
+- **Sound playback** via `afplay` (macOS), `pw-play`/`paplay`/`ffplay` (Linux) — same priority chain as the shell hook
+- **CESP event mapping** — GitHub Copilot hooks map to standard CESP categories (`session.start`, `task.complete`, `task.error`, `user.spam`)
+- **Desktop notifications** — large overlay banners by default, or standard notifications
+- **Spam detection** — detects 3+ rapid prompts within 10 seconds, triggers `user.spam` voice lines
+- **Session tracking** — separate session markers per Copilot sessionId
 
 ### OpenCode setup
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -6,11 +6,11 @@
 ![macOS](https://img.shields.io/badge/macOS-blue) ![WSL2](https://img.shields.io/badge/WSL2-blue) ![Linux](https://img.shields.io/badge/Linux-blue) ![Windows](https://img.shields.io/badge/Windows-blue) ![SSH](https://img.shields.io/badge/SSH-blue)
 ![License](https://img.shields.io/badge/license-MIT-green)
 
-![Claude Code](https://img.shields.io/badge/Claude_Code-hook-ffab01) ![Codex](https://img.shields.io/badge/Codex-adapter-ffab01) ![Cursor](https://img.shields.io/badge/Cursor-adapter-ffab01) ![OpenCode](https://img.shields.io/badge/OpenCode-adapter-ffab01) ![Kilo CLI](https://img.shields.io/badge/Kilo_CLI-adapter-ffab01) ![Kiro](https://img.shields.io/badge/Kiro-adapter-ffab01) ![Windsurf](https://img.shields.io/badge/Windsurf-adapter-ffab01) ![Antigravity](https://img.shields.io/badge/Antigravity-adapter-ffab01) ![OpenClaw](https://img.shields.io/badge/OpenClaw-adapter-ffab01)
+![Claude Code](https://img.shields.io/badge/Claude_Code-hook-ffab01) ![GitHub Copilot](https://img.shields.io/badge/GitHub_Copilot-adapter-ffab01) ![Codex](https://img.shields.io/badge/Codex-adapter-ffab01) ![Cursor](https://img.shields.io/badge/Cursor-adapter-ffab01) ![OpenCode](https://img.shields.io/badge/OpenCode-adapter-ffab01) ![Kilo CLI](https://img.shields.io/badge/Kilo_CLI-adapter-ffab01) ![Kiro](https://img.shields.io/badge/Kiro-adapter-ffab01) ![Windsurf](https://img.shields.io/badge/Windsurf-adapter-ffab01) ![Antigravity](https://img.shields.io/badge/Antigravity-adapter-ffab01) ![OpenClaw](https://img.shields.io/badge/OpenClaw-adapter-ffab01)
 
 **当你的 AI 编程助手需要关注时，播放游戏角色语音 + 显示视觉覆盖通知 — 或通过 MCP 让 AI 自行选择音效。**
 
-AI 编程助手完成任务或需要权限时不会通知你。你切换标签页、失去焦点，然后浪费 15 分钟重新进入状态。peon-ping 通过魔兽争霸、星际争霸、传送门、塞尔达等游戏的角色语音和醒目的屏幕横幅来解决这个问题 — 支持 **Claude Code**、**Codex**、**Cursor**、**OpenCode**、**Kilo CLI**、**Kiro**、**Windsurf**、**Google Antigravity**、**OpenClaw** 及任何 MCP 客户端。
+AI 编程助手完成任务或需要权限时不会通知你。你切换标签页、失去焦点，然后浪费 15 分钟重新进入状态。peon-ping 通过魔兽争霸、星际争霸、传送门、塞尔达等游戏的角色语音和醒目的屏幕横幅来解决这个问题 — 支持 **Claude Code**、**GitHub Copilot**、**Codex**、**Cursor**、**OpenCode**、**Kilo CLI**、**Kiro**、**Windsurf**、**Google Antigravity**、**OpenClaw** 及任何 MCP 客户端.
 
 **查看演示** &rarr; [peonping.com](https://peonping.com/)
 
@@ -277,6 +277,7 @@ peon-ping 适用于任何支持钩子的代理式 IDE。适配器将 IDE 特定�
 | IDE | 状态 | 设置 |
 |---|---|---|
 | **Claude Code** | 内置 | `curl \| bash` 安装会自动处理 |
+| **GitHub Copilot** | 适配器 | 在 `.github/hooks/hooks.json` 中添加指向 `adapters/copilot.sh` 的钩子（[设置](#github-copilot-设置)） |
 | **OpenAI Codex** | 适配器 | 在 `~/.codex/config.toml` 中添加 `notify = ["bash", "/absolute/path/to/.claude/hooks/peon-ping/adapters/codex.sh"]` |
 | **Cursor** | 内置 | `curl \| bash` 或 `peon-ping-setup` 自动检测并注册 Cursor 钩子 |
 | **OpenCode** | 适配器 | `curl -fsSL https://raw.githubusercontent.com/PeonPing/peon-ping/main/adapters/opencode.sh \| bash`（[设置](#opencode-设置)） |
@@ -285,6 +286,67 @@ peon-ping 适用于任何支持钩子的代理式 IDE。适配器将 IDE 特定�
 | **Windsurf** | 适配器 | 在 `~/.codeium/windsurf/hooks.json` 中添加指向 `adapters/windsurf.sh` 的钩子条目（[设置](#windsurf-设置)） |
 | **Google Antigravity** | 适配器 | `bash ~/.claude/hooks/peon-ping/adapters/antigravity.sh`（需要 `fswatch`：`brew install fswatch`） |
 | **OpenClaw** | 适配器 | 在 OpenClaw 技能中调用 `adapters/openclaw.sh <event>`，支持所有 CESP 分类和原生 Claude Code 事件名 |
+
+### GitHub Copilot 设置
+
+[GitHub Copilot](https://github.com/features/copilot) 的 shell 适配器，完全符合 [CESP v1.0](https://github.com/PeonPing/openpeon) 规范。
+
+**设置步骤：**
+
+1. 确保已安装 peon-ping（`curl -fsSL https://peonping.com/install | bash`）
+
+2. 在仓库的默认分支中创建 `.github/hooks/hooks.json`：
+
+   ```json
+   {
+     "version": 1,
+     "hooks": {
+       "sessionStart": [
+         {
+           "type": "command",
+           "bash": "bash ~/.claude/hooks/peon-ping/adapters/copilot.sh sessionStart"
+         }
+       ],
+       "userPromptSubmitted": [
+         {
+           "type": "command",
+           "bash": "bash ~/.claude/hooks/peon-ping/adapters/copilot.sh userPromptSubmitted"
+         }
+       ],
+       "postToolUse": [
+         {
+           "type": "command",
+           "bash": "bash ~/.claude/hooks/peon-ping/adapters/copilot.sh postToolUse"
+         }
+       ],
+       "errorOccurred": [
+         {
+           "type": "command",
+           "bash": "bash ~/.claude/hooks/peon-ping/adapters/copilot.sh errorOccurred"
+         }
+       ]
+     }
+   }
+   ```
+
+3. 提交并合并到默认分支。下次 Copilot agent 会话时钩子将激活。
+
+**事件映射：**
+
+- `sessionStart` → 问候音效（*"Ready to work?"*、*"Yes?"*）
+- `userPromptSubmitted` → 首次提示 = 问候，后续 = 垃圾信息检测
+- `postToolUse` → 完成音效（*"Work, work."*、*"Job's done!"*）
+- `errorOccurred` → 错误音效（*"I can't do that."*）
+- `preToolUse` → 跳过（过于嘈杂）
+- `sessionEnd` → 无音效（session.end 尚未实现）
+
+**功能：**
+
+- **音频播放** 通过 `afplay`（macOS）、`pw-play`/`paplay`/`ffplay`（Linux）—— 与 shell 钩子相同的优先级链
+- **CESP 事件映射** —— GitHub Copilot 钩子映射到标准 CESP 分类（`session.start`、`task.complete`、`task.error`、`user.spam`）
+- **桌面通知** —— 默认使用大型覆盖横幅，或标准通知
+- **垃圾信息检测** —— 检测 10 秒内 3 次以上快速提示，触发 `user.spam` 语音
+- **会话跟踪** —— 每个 Copilot sessionId 独立的会话标记
 
 ### OpenCode 设置
 

--- a/adapters/copilot.sh
+++ b/adapters/copilot.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# peon-ping adapter for GitHub Copilot
+# Translates GitHub Copilot hook events into peon.sh stdin JSON
+#
+# Setup: Add to .github/hooks/hooks.json in your repository:
+#   {
+#     "version": 1,
+#     "hooks": {
+#       "sessionStart": [
+#         { "type": "command", "bash": "bash ~/.claude/hooks/peon-ping/adapters/copilot.sh sessionStart" }
+#       ],
+#       "sessionEnd": [
+#         { "type": "command", "bash": "bash ~/.claude/hooks/peon-ping/adapters/copilot.sh sessionEnd" }
+#       ],
+#       "userPromptSubmitted": [
+#         { "type": "command", "bash": "bash ~/.claude/hooks/peon-ping/adapters/copilot.sh userPromptSubmitted" }
+#       ],
+#       "postToolUse": [
+#         { "type": "command", "bash": "bash ~/.claude/hooks/peon-ping/adapters/copilot.sh postToolUse" }
+#       ],
+#       "errorOccurred": [
+#         { "type": "command", "bash": "bash ~/.claude/hooks/peon-ping/adapters/copilot.sh errorOccurred" }
+#       ]
+#     }
+#   }
+
+set -euo pipefail
+
+PEON_DIR="${CLAUDE_PEON_DIR:-${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/peon-ping}"
+
+COPILOT_EVENT="${1:-sessionStart}"
+
+# Copilot sends JSON with session data on stdin (timestamp, cwd, sessionId, etc.)
+INPUT=$(cat)
+SESSION_ID=$(echo "$INPUT" | jq -r '.sessionId // empty' 2>/dev/null)
+[ -z "$SESSION_ID" ] && SESSION_ID="copilot-$$"
+CWD=$(echo "$INPUT" | jq -r '.cwd // ""' 2>/dev/null)
+[ -z "$CWD" ] && CWD="${PWD}"
+
+# Map Copilot hook events to peon.sh PascalCase events
+case "$COPILOT_EVENT" in
+  sessionStart)
+    EVENT="SessionStart"
+    ;;
+  sessionEnd)
+    # Session end — no sound (not yet mapped in peon.sh)
+    exit 0
+    ;;
+  userPromptSubmitted)
+    # Prompt submitted — SessionStart handles greeting, this handles spam detection
+    SESSION_MARKER="$PEON_DIR/.copilot-session-${SESSION_ID}"
+    find "$PEON_DIR" -name ".copilot-session-*" -mtime +0 -delete 2>/dev/null
+    if [ ! -f "$SESSION_MARKER" ]; then
+      touch "$SESSION_MARKER"
+      EVENT="SessionStart"
+    else
+      EVENT="UserPromptSubmit"
+    fi
+    ;;
+  preToolUse)
+    # Before tool execution — skip (too noisy)
+    exit 0
+    ;;
+  postToolUse)
+    # After tool execution — treat as task completion
+    EVENT="Stop"
+    ;;
+  errorOccurred)
+    # Error occurred during session
+    EVENT="TaskError"
+    ;;
+  *)
+    # Unknown event — skip
+    exit 0
+    ;;
+esac
+
+echo "$INPUT" | jq --arg event "$EVENT" --arg sid "$SESSION_ID" --arg cwd "$CWD" \
+  '{hook_event_name: $event, notification_type: "", cwd: $cwd, session_id: $sid, permission_mode: ""}' \
+  | bash "$PEON_DIR/peon.sh"

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -2,7 +2,7 @@
 
 > Game character voice lines + visual overlay notifications when your AI coding agent needs attention.
 
-peon-ping plays voice lines and shows bold on-screen overlay banners from Warcraft, StarCraft, Portal, Zelda, and 75+ other games when your AI coding agent finishes a task, needs permission, or hits an error. Works with Claude Code, Cursor, OpenCode, Codex, Kiro, Windsurf, and any MCP-compatible AI agent.
+peon-ping plays voice lines and shows bold on-screen overlay banners from Warcraft, StarCraft, Portal, Zelda, and 75+ other games when your AI coding agent finishes a task, needs permission, or hits an error. Works with Claude Code, GitHub Copilot, Cursor, OpenCode, Codex, Kiro, Windsurf, and any MCP-compatible AI agent.
 
 ## Links
 
@@ -62,6 +62,7 @@ MCP resources: `peon-ping://catalog`, `peon-ping://pack/{name}`
 ## IDEs Supported (hook-based)
 
 - Claude Code (built-in)
+- GitHub Copilot (adapter)
 - OpenAI Codex
 - Cursor
 - OpenCode

--- a/tests/copilot.bats
+++ b/tests/copilot.bats
@@ -1,0 +1,217 @@
+#!/usr/bin/env bats
+
+load setup.bash
+
+setup() {
+  setup_test_env
+
+  # Derive repo root from PEON_SH (set by setup.bash using its own BASH_SOURCE)
+  COPILOT_SH="${PEON_SH%/peon.sh}/adapters/copilot.sh"
+
+  # Adapter resolves peon.sh via CLAUDE_PEON_DIR — symlink it into the test dir
+  ln -sf "$PEON_SH" "$TEST_DIR/peon.sh"
+}
+
+teardown() {
+  teardown_test_env
+}
+
+# Helper: run copilot adapter with an event name argument
+# Copilot passes event name as $1 and JSON on stdin
+run_copilot() {
+  local event="$1"
+  local json="${2:-{}}"
+  export PEON_TEST=1
+  echo "$json" | bash "$COPILOT_SH" "$event" 2>"$TEST_DIR/stderr.log"
+  COPILOT_EXIT=$?
+  COPILOT_STDERR=$(cat "$TEST_DIR/stderr.log" 2>/dev/null)
+  # On macOS peon.sh runs afplay via nohup & (background); wait for mock to finish
+  sleep 0.3
+}
+
+# ============================================================
+# Syntax validation
+# ============================================================
+
+@test "adapter script has valid bash syntax" {
+  run bash -n "$COPILOT_SH"
+  [ "$status" -eq 0 ]
+}
+
+# ============================================================
+# Event mapping
+# ============================================================
+
+@test "sessionStart maps to SessionStart and plays greeting" {
+  run_copilot sessionStart '{"sessionId":"test-123","cwd":"/tmp"}'
+  [ "$COPILOT_EXIT" -eq 0 ]
+  afplay_was_called
+  sound=$(afplay_sound)
+  [[ "$sound" == *"/packs/peon/sounds/Hello"* ]]
+}
+
+@test "postToolUse maps to Stop and plays completion sound" {
+  run_copilot postToolUse '{"sessionId":"test-123","cwd":"/tmp"}'
+  [ "$COPILOT_EXIT" -eq 0 ]
+  afplay_was_called
+  sound=$(afplay_sound)
+  [[ "$sound" == *"/packs/peon/sounds/Done"* ]]
+}
+
+@test "errorOccurred maps to TaskError and plays error sound" {
+  run_copilot errorOccurred '{"sessionId":"test-123","cwd":"/tmp"}'
+  [ "$COPILOT_EXIT" -eq 0 ]
+  afplay_was_called
+  sound=$(afplay_sound)
+  [[ "$sound" == *"/packs/peon/sounds/Error"* ]]
+}
+
+@test "first userPromptSubmitted maps to SessionStart and plays greeting" {
+  run_copilot userPromptSubmitted '{"sessionId":"test-456","cwd":"/tmp"}'
+  [ "$COPILOT_EXIT" -eq 0 ]
+  afplay_was_called
+  sound=$(afplay_sound)
+  [[ "$sound" == *"/packs/peon/sounds/Hello"* ]]
+}
+
+@test "subsequent userPromptSubmitted maps to UserPromptSubmit" {
+  # First call creates session marker (SessionStart)
+  run_copilot userPromptSubmitted '{"sessionId":"test-789","cwd":"/tmp"}'
+  # Second call is UserPromptSubmit — no sound normally
+  rm -f "$TEST_DIR/afplay.log"
+  run_copilot userPromptSubmitted '{"sessionId":"test-789","cwd":"/tmp"}'
+  [ "$COPILOT_EXIT" -eq 0 ]
+  ! afplay_was_called
+}
+
+# ============================================================
+# Skipped events
+# ============================================================
+
+@test "sessionEnd exits gracefully without sound" {
+  run_copilot sessionEnd '{"sessionId":"test-123","cwd":"/tmp"}'
+  [ "$COPILOT_EXIT" -eq 0 ]
+  ! afplay_was_called
+}
+
+@test "preToolUse exits gracefully without sound (too noisy)" {
+  run_copilot preToolUse '{"sessionId":"test-123","cwd":"/tmp","toolName":"bash"}'
+  [ "$COPILOT_EXIT" -eq 0 ]
+  ! afplay_was_called
+}
+
+@test "unknown event exits gracefully without sound" {
+  run_copilot some_future_event '{"sessionId":"test-123","cwd":"/tmp"}'
+  [ "$COPILOT_EXIT" -eq 0 ]
+  ! afplay_was_called
+}
+
+# ============================================================
+# JSON parsing
+# ============================================================
+
+@test "extracts sessionId from JSON input" {
+  run_copilot sessionStart '{"sessionId":"custom-session-id","cwd":"/tmp"}'
+  [ "$COPILOT_EXIT" -eq 0 ]
+  # Session marker file should use the custom session ID
+  [ -f "$TEST_DIR/.copilot-session-custom-session-id" ]
+}
+
+@test "extracts cwd from JSON input" {
+  run_copilot sessionStart '{"sessionId":"test-123","cwd":"/custom/path"}'
+  [ "$COPILOT_EXIT" -eq 0 ]
+  afplay_was_called
+}
+
+@test "falls back to default sessionId when JSON is empty" {
+  run_copilot sessionStart '{}'
+  [ "$COPILOT_EXIT" -eq 0 ]
+  afplay_was_called
+}
+
+@test "falls back to PWD when cwd is missing from JSON" {
+  run_copilot sessionStart '{"sessionId":"test-123"}'
+  [ "$COPILOT_EXIT" -eq 0 ]
+  afplay_was_called
+}
+
+# ============================================================
+# Config passthrough
+# ============================================================
+
+@test "paused state suppresses Copilot sounds" {
+  touch "$TEST_DIR/.paused"
+  run_copilot sessionStart '{"sessionId":"test-123","cwd":"/tmp"}'
+  [ "$COPILOT_EXIT" -eq 0 ]
+  ! afplay_was_called
+}
+
+@test "enabled=false suppresses Copilot sounds" {
+  cat > "$TEST_DIR/config.json" <<'JSON'
+{ "enabled": false, "active_pack": "peon", "volume": 0.5, "categories": {} }
+JSON
+  run_copilot sessionStart '{"sessionId":"test-123","cwd":"/tmp"}'
+  [ "$COPILOT_EXIT" -eq 0 ]
+  ! afplay_was_called
+}
+
+@test "volume from config is passed through" {
+  cat > "$TEST_DIR/config.json" <<'JSON'
+{ "active_pack": "peon", "volume": 0.3, "enabled": true, "categories": {} }
+JSON
+  run_copilot postToolUse '{"sessionId":"test-123","cwd":"/tmp"}'
+  afplay_was_called
+  log_line=$(tail -1 "$TEST_DIR/afplay.log")
+  [[ "$log_line" == *"-v 0.3"* ]]
+}
+
+# ============================================================
+# Spam detection
+# ============================================================
+
+@test "rapid Copilot prompts trigger annoyed sound" {
+  # First userPromptSubmitted is SessionStart (creates marker).
+  run_copilot userPromptSubmitted '{"sessionId":"spam-test","cwd":"/tmp"}'
+  # peon.sh suppresses sounds within 3s of SessionStart (session replay protection).
+  # Wait past the suppression window before sending rapid prompts.
+  sleep 3
+  rm -f "$TEST_DIR/afplay.log"
+  for i in $(seq 1 3); do
+    run_copilot userPromptSubmitted '{"sessionId":"spam-test","cwd":"/tmp"}'
+  done
+  afplay_was_called
+  sound=$(afplay_sound)
+  [[ "$sound" == *"Angry1.wav" ]]
+}
+
+# ============================================================
+# Debounce
+# ============================================================
+
+@test "second Stop within debounce window is suppressed" {
+  run_copilot postToolUse '{"sessionId":"test-123","cwd":"/tmp"}'
+  [ "$COPILOT_EXIT" -eq 0 ]
+  count1=$(afplay_call_count)
+  [ "$count1" = "1" ]
+
+  # Second stop within debounce window should be suppressed
+  run_copilot postToolUse '{"sessionId":"test-123","cwd":"/tmp"}'
+  [ "$COPILOT_EXIT" -eq 0 ]
+  count2=$(afplay_call_count)
+  [ "$count2" = "1" ]
+}
+
+# ============================================================
+# Default argument
+# ============================================================
+
+@test "no argument defaults to sessionStart" {
+  export PEON_TEST=1
+  echo '{"sessionId":"test-123","cwd":"/tmp"}' | bash "$COPILOT_SH" 2>"$TEST_DIR/stderr.log"
+  COPILOT_EXIT=$?
+  sleep 0.3
+  [ "$COPILOT_EXIT" -eq 0 ]
+  afplay_was_called
+  sound=$(afplay_sound)
+  [[ "$sound" == *"/packs/peon/sounds/Hello"* ]]
+}


### PR DESCRIPTION
**GitHub Copilot Integration:**

* Added a new shell adapter at `adapters/copilot.sh` that translates GitHub Copilot hook events into peon-ping notifications, mapping Copilot events to CESP categories and supporting session tracking, spam detection, and desktop notifications.

**Documentation Updates:**

* Updated `README.md` and `README_zh.md` to include GitHub Copilot as a supported agent, with detailed setup instructions and event mapping for both English and Chinese readers. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L9-R13) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R288) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R298-R358) [[4]](diffhunk://#diff-bc53aca037f8d406f619f15cf2c5c905a7a61f81f89cab98dd52f7ff65725f6eL9-R13) [[5]](diffhunk://#diff-bc53aca037f8d406f619f15cf2c5c905a7a61f81f89cab98dd52f7ff65725f6eR280) [[6]](diffhunk://#diff-bc53aca037f8d406f619f15cf2c5c905a7a61f81f89cab98dd52f7ff65725f6eR290-R350)
* Updated `docs/public/llms.txt` to list GitHub Copilot as a supported IDE/agent. [[1]](diffhunk://#diff-a0ab5071b8ab0c712eb764890bdc5535d30373299b81ea32b813a0e738882531L5-R5) [[2]](diffhunk://#diff-a0ab5071b8ab0c712eb764890bdc5535d30373299b81ea32b813a0e738882531R65)

**Testing:**

* Introduced a new Bats test suite in `tests/copilot.bats` to ensure the Copilot adapter correctly maps events, parses input, handles configuration, and triggers notifications and sounds as expected.