### PR TITLE
feat: add suppress_subagent_complete to silence sub-agent completion sounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ Config location depends on install mode:
 - **categories**: Toggle individual CESP sound categories on/off (e.g. `"session.start": false` to disable greeting sounds)
 - **annoyed_threshold / annoyed_window_seconds**: How many prompts in N seconds triggers the `user.spam` easter egg
 - **silent_window_seconds**: Suppress `task.complete` sounds and notifications for tasks shorter than N seconds. (e.g. `10` to only hear sounds for tasks that take longer than 10 seconds)
+- **suppress_subagent_complete** (boolean, default: `false`): Suppress `task.complete` sounds and notifications when a sub-agent session finishes. When Claude Code's Task tool dispatches parallel sub-agents, each one fires a completion sound — set this to `true` to hear only the parent session's completion sound.
 - **pack_rotation**: Array of pack names (e.g. `["peon", "sc_kerrigan", "peasant"]`). Used when `pack_rotation_mode` is `random` or `round-robin`; also lists valid packs for `agentskill` mode. Leave empty `[]` to use `active_pack` only.
 - **pack_rotation_mode**: `"random"` (default), `"round-robin"`, or `"agentskill"`. With `random`/`round-robin`, each session picks one pack from `pack_rotation`. With `agentskill`, the `/peon-ping-use <pack>` command assigns a pack per session. Invalid or missing packs fall back to `active_pack` and the stale assignment is removed.
 - **session_ttl_days** (number, default: 7): Expire stale per-session pack assignments older than N days. Keeps `.state.json` from growing unbounded when using `agentskill` mode.

--- a/README_zh.md
+++ b/README_zh.md
@@ -180,6 +180,7 @@ peon-ping 在 Claude Code 中安装两个斜杠命令：
 - **categories**：单独开关 CESP 声音分类（例如 `"session.start": false` 禁用问候声音）
 - **annoyed_threshold / annoyed_window_seconds**：在 N 秒内多少次提示触发 `user.spam` 彩蛋
 - **silent_window_seconds**：对于短于 N 秒的任务，抑制 `task.complete` 声音和通知。（例如 `10` 表示只播放超过 10 秒的任务声音）
+- **suppress_subagent_complete**（布尔值，默认：`false`）：当子 Agent 会话结束时，抑制 `task.complete` 声音和通知。当 Claude Code 的 Task 工具并行派发多个子 Agent 时，每个子 Agent 完成都会触发一次提示音——将此选项设为 `true`，则只播放父会话的完成提示音。
 - **pack_rotation**：语音包名称数组（例如 `["peon", "sc_kerrigan", "peasant"]`）。用于 `pack_rotation_mode` 为 `random` 或 `round-robin` 时；也列出 `agentskill` 模式的有效语音包。留空 `[]` 则仅使用 `active_pack`。
 - **pack_rotation_mode**：`"random"`（默认）、`"round-robin"` 或 `"agentskill"`。使用 `random`/`round-robin` 时，每个会话从 `pack_rotation` 中选择一个语音包。使用 `agentskill` 时，`/peon-ping-use <pack>` 命令为每个会话分配语音包。无效或缺失的语音包会回退到 `active_pack`，过期的分配会被移除。
 - **session_ttl_days**（数字，默认：7）：使超过 N 天的陈旧每会话语音包分配过期。防止使用 `agentskill` 模式时 `.state.json` 无限增长。

--- a/config.json
+++ b/config.json
@@ -15,6 +15,7 @@
   "annoyed_threshold": 3,
   "annoyed_window_seconds": 10,
   "silent_window_seconds": 0,
+  "suppress_subagent_complete": false,
   "pack_rotation": [],
   "pack_rotation_mode": "random",
   "session_ttl_days": 7,


### PR DESCRIPTION
## Summary

Closes #220

- Adds `suppress_subagent_complete` config option (default: `false`)
- When enabled, sessions detected as sub-agents via the `SubagentStart` → `SessionStart` inheritance path are tracked in `state['subagent_sessions']`
- Their `Stop` events exit early — no sound, no notification
- The parent session's `Stop` still fires normally
- Stale entries pruned after 5 minutes; `SessionEnd` cleans up immediately

## Implementation

- `config.json`: new key `"suppress_subagent_complete": false`
- `peon.sh`: read config key; mark session in `subagent_sessions` dict during subagent inheritance `SessionStart`; suppress in `Stop`; clean up in `SessionEnd`
- 4 new BATS tests: suppression fires, parent plays, default off, `SessionEnd` cleanup
- `README.md` + `README_zh.md` docs

## Test plan

- [x] `bats tests/` — 420/420 pass
- [x] `suppress_subagent_complete: subagent Stop is suppressed`
- [x] `suppress_subagent_complete: parent Stop still plays sound`
- [x] `suppress_subagent_complete: disabled by default does not suppress`
- [x] `suppress_subagent_complete: subagent_sessions cleaned up on SessionEnd`

🤖 Generated with [Claude Code](https://claude.com/claude-code)