### PR TITLE
fix: add Zed terminal to click-to-focus bundle ID map

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,8 +185,8 @@ Config location depends on install mode:
 - **volume**: 0.0–1.0 (quiet enough for the office)
 - **desktop_notifications**: `true`/`false` — toggle desktop notification popups independently from sounds (default: `true`)
 - **notification_style**: `"overlay"` or `"standard"` — controls how desktop notifications appear (default: `"overlay"`)
-  - **overlay**: large, visible banners — JXA Cocoa overlay on macOS, Windows Forms popup on WSL. Clicking the overlay focuses your terminal (supports Ghostty, Warp, iTerm2, Terminal.app)
-  - **standard**: system notifications — [`terminal-notifier`](https://github.com/julienXX/terminal-notifier) / `osascript` on macOS, Windows toast on WSL. When `terminal-notifier` is installed (`brew install terminal-notifier`), clicking a standard notification focuses your terminal automatically (supports Ghostty, Warp, iTerm2, Terminal.app)
+  - **overlay**: large, visible banners — JXA Cocoa overlay on macOS, Windows Forms popup on WSL. Clicking the overlay focuses your terminal (supports Ghostty, Warp, iTerm2, Zed, Terminal.app)
+  - **standard**: system notifications — [`terminal-notifier`](https://github.com/julienXX/terminal-notifier) / `osascript` on macOS, Windows toast on WSL. When `terminal-notifier` is installed (`brew install terminal-notifier`), clicking a standard notification focuses your terminal automatically (supports Ghostty, Warp, iTerm2, Zed, Terminal.app)
 - **categories**: Toggle individual CESP sound categories on/off (e.g. `"session.start": false` to disable greeting sounds)
 - **annoyed_threshold / annoyed_window_seconds**: How many prompts in N seconds triggers the `user.spam` easter egg
 - **silent_window_seconds**: Suppress `task.complete` sounds and notifications for tasks shorter than N seconds. (e.g. `10` to only hear sounds for tasks that take longer than 10 seconds)

--- a/README_zh.md
+++ b/README_zh.md
@@ -177,7 +177,7 @@ peon-ping 在 Claude Code 中安装两个斜杠命令：
 - **volume**：0.0–1.0（适合办公室使用的音量）
 - **desktop_notifications**：`true`/`false` — 独立于声音控制桌面通知弹窗（默认：`true`）
 - **notification_style**：`"overlay"` 或 `"standard"` — 控制桌面通知显示方式（默认：`"overlay"`）
-  - **overlay**：大型醒目横幅 — macOS 上使用 JXA Cocoa 覆盖，WSL 上使用 Windows Forms 弹窗。点击覆盖层可聚焦终端（支持 Ghostty、Warp、iTerm2、Terminal.app）
+  - **overlay**：大型醒目横幅 — macOS 上使用 JXA Cocoa 覆盖，WSL 上使用 Windows Forms 弹窗。点击覆盖层可聚焦终端（支持 Ghostty、Warp、iTerm2、Zed、Terminal.app）
   - **standard**：系统通知 — macOS 上使用 [`terminal-notifier`](https://github.com/julienXX/terminal-notifier) / `osascript`，WSL 上使用 Windows toast。安装 `terminal-notifier`（`brew install terminal-notifier`）后，点击通知可自动聚焦终端
   - **wsl_toast**：`true`/`false` — 在 WSL 上使用原生 Windows toast 通知代替 Windows Forms 弹窗。Toast 不会抢占焦点并出现在操作中心。（默认：`true`）
 - **categories**：单独开关 CESP 声音分类（例如 `"session.start": false` 禁用问候声音）

--- a/peon.sh
+++ b/peon.sh
@@ -273,6 +273,7 @@ _mac_terminal_bundle_id() {
     iTerm.app)      echo "com.googlecode.iterm2" ;;
     WarpTerminal)   echo "dev.warp.Warp-Stable" ;;
     Apple_Terminal) echo "com.apple.Terminal" ;;
+    zed)            echo "dev.zed.Zed" ;;
     *)              echo "" ;;
   esac
 }

--- a/tests/mac-overlay.bats
+++ b/tests/mac-overlay.bats
@@ -118,6 +118,13 @@ json.dump(m, open('$TEST_DIR/packs/peon/manifest.json', 'w'))
   [[ "$(overlay_log)" == *"dev.warp.Warp-Stable"* ]]
 }
 
+@test "macOS overlay passes bundle ID for Zed click-to-focus" {
+  TERM_PROGRAM=zed run_peon '{"hook_event_name":"Stop","cwd":"/tmp/myproject","session_id":"s1","permission_mode":"default"}'
+  [ "$PEON_EXIT" -eq 0 ]
+  overlay_was_called
+  [[ "$(overlay_log)" == *"dev.zed.Zed"* ]]
+}
+
 @test "macOS overlay passes empty bundle ID for unknown terminal" {
   # Unknown terminal — bundle ID should be empty (no -activate)
   TERM_PROGRAM=unknown_terminal run_peon '{"hook_event_name":"Stop","cwd":"/tmp/myproject","session_id":"s1","permission_mode":"default"}'
@@ -320,6 +327,17 @@ JSON
   [ -f "$TEST_DIR/terminal_notifier.log" ]
   [[ "$(terminal_notifier_log)" == *"-activate"* ]]
   [[ "$(terminal_notifier_log)" == *"dev.warp.Warp-Stable"* ]]
+}
+
+@test "standard: terminal-notifier includes -activate for Zed" {
+  cat > "$TEST_DIR/config.json" <<'JSON'
+{ "active_pack": "peon", "volume": 0.5, "enabled": true, "desktop_notifications": true, "notification_style": "standard", "categories": { "task.complete": true } }
+JSON
+  TERM_PROGRAM=zed run_peon '{"hook_event_name":"Stop","cwd":"/tmp/myproject","session_id":"s1","permission_mode":"default"}'
+  [ "$PEON_EXIT" -eq 0 ]
+  [ -f "$TEST_DIR/terminal_notifier.log" ]
+  [[ "$(terminal_notifier_log)" == *"-activate"* ]]
+  [[ "$(terminal_notifier_log)" == *"dev.zed.Zed"* ]]
 }
 
 @test "standard: terminal-notifier no -activate for unknown terminal" {


### PR DESCRIPTION
## Summary

- `TERM_PROGRAM=zed` was missing from `_mac_terminal_bundle_id()`, so clicking overlay or standard notifications had no effect for Zed users
- Maps `zed` → `dev.zed.Zed` (bundle ID verified against `/Applications/Zed.app`)
- Updates supported terminal list in README and README_zh
- Adds two tests: overlay and standard style

| `TERM_PROGRAM` | Bundle ID |
|---|---|
| `ghostty` | `com.mitchellh.ghostty` |
| `iTerm.app` | `com.googlecode.iterm2` |
| `WarpTerminal` | `dev.warp.Warp-Stable` |
| `zed` | `dev.zed.Zed` ✨ |
| `Apple_Terminal` | `com.apple.Terminal` |