### PR TITLE
feat(config): flag to skip shell config

### DIFF
--- a/config.json
+++ b/config.json
@@ -16,6 +16,7 @@
   "annoyed_window_seconds": 10,
   "silent_window_seconds": 0,
   "suppress_subagent_complete": false,
+  "no_rc": false,
   "pack_rotation": [],
   "pack_rotation_mode": "random",
   "session_ttl_days": 7,


### PR DESCRIPTION
when --no-rc is passed to the install script, skip modifying .bashrc, config.fish.

Also adds "no_rc" (boolean) to config.json.