### PR TITLE
fix(win): Cursor on Windows — BOM handling, camelCase events, flat-array hooks.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## v2.8.0 (2026-02-20)
 
+### Fixed
+- **Cursor on Windows**: peon.ps1 now maps Cursor's camelCase event names (`sessionStart`, `stop`, etc.) to PascalCase, fixing no-sounds-on-new-chat when using Third-party skills
+- **Cursor on Windows**: `install.ps1` and `uninstall.ps1` now handle Cursor's flat-array `hooks.json` format (matching `install.sh` fix from v2.7.x)
+- peon.ps1 pack rotation: accept `session_override` alias in addition to `agentskill`
+
 ### Added
 - Click-to-focus for IDE embedded terminals (Cursor, VS Code, Windsurf, Zed) — when `TERM_PROGRAM` doesn't map to a standalone terminal, falls back to deriving the IDE's bundle ID from its PID via `lsappinfo` (macOS built-in)
 - PID-based `NSRunningApplication` activation in `mac-overlay.js` as belt-and-suspenders fallback when bundle ID lookup fails

--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ peon-ping works with any agentic IDE that supports hooks. Adapters translate IDE
 | **Gemini CLI** | Adapter | Add hooks to `~/.gemini/settings.json` pointing to `adapters/gemini.sh` ([setup](#gemini-cli-setup)) |
 | **GitHub Copilot** | Adapter | Add hooks to `.github/hooks/hooks.json` pointing to `adapters/copilot.sh` ([setup](#github-copilot-setup)) |
 | **OpenAI Codex** | Adapter | Add `notify = ["bash", "/absolute/path/to/.claude/hooks/peon-ping/adapters/codex.sh"]` to `~/.codex/config.toml` |
-| **Cursor** | Built-in | `curl \| bash` or `peon-ping-setup` auto-detects and registers Cursor hooks |
+| **Cursor** | Built-in | `curl \| bash`, `peon-ping-setup`, or Windows `install.ps1` auto-detect and register hooks. On Windows, enable **Settings → Features → Third-party skills** so Cursor loads `~/.claude/settings.json` for SessionStart/Stop sounds. |
 | **OpenCode** | Adapter | `curl -fsSL https://raw.githubusercontent.com/PeonPing/peon-ping/main/adapters/opencode.sh \| bash` ([setup](#opencode-setup)) |
 | **Kilo CLI** | Adapter | `curl -fsSL https://raw.githubusercontent.com/PeonPing/peon-ping/main/adapters/kilo.sh \| bash` ([setup](#kilo-cli-setup)) |
 | **Kiro** | Adapter | Add hook entries to `~/.kiro/agents/peon-ping.json` pointing to `adapters/kiro.sh` ([setup](#kiro-setup)) |

--- a/README_zh.md
+++ b/README_zh.md
@@ -286,7 +286,7 @@ peon-ping 适用于任何支持钩子的代理式 IDE。适配器将 IDE 特定�
 | **Gemini CLI** | 适配器 | 在 `~/.gemini/settings.json` 中添加指向 `adapters/gemini.sh` 的钩子（[设置](#gemini-cli-设置)） |
 | **GitHub Copilot** | 适配器 | 在 `.github/hooks/hooks.json` 中添加指向 `adapters/copilot.sh` 的钩子（[设置](#github-copilot-设置)） |
 | **OpenAI Codex** | 适配器 | 在 `~/.codex/config.toml` 中添加 `notify = ["bash", "/absolute/path/to/.claude/hooks/peon-ping/adapters/codex.sh"]` |
-| **Cursor** | 内置 | `curl \| bash` 或 `peon-ping-setup` 自动检测并注册 Cursor 钩子 |
+| **Cursor** | 内置 | `curl \| bash`、`peon-ping-setup` 或 Windows `install.ps1` 自动检测并注册钩子。在 Windows 上，请在 **设置 → 功能 → 第三方技能** 中启用，以便 Cursor 加载 `~/.claude/settings.json` 以播放 SessionStart/Stop 音效。 |
 | **OpenCode** | 适配器 | `curl -fsSL https://raw.githubusercontent.com/PeonPing/peon-ping/main/adapters/opencode.sh \| bash`（[设置](#opencode-设置)） |
 | **Kilo CLI** | 适配器 | `curl -fsSL https://raw.githubusercontent.com/PeonPing/peon-ping/main/adapters/kilo.sh \| bash`（[设置](#kilo-cli-设置)） |
 | **Kiro** | 适配器 | 在 `~/.kiro/agents/peon-ping.json` 中添加指向 `adapters/kiro.sh` 的钩子条目（[设置](#kiro-设置)） |

--- a/scripts/hook-handle-use.ps1
+++ b/scripts/hook-handle-use.ps1
@@ -34,8 +34,11 @@ if ($args.Count -ge 1 -and $args[0]) {
 }
 
 if (-not $cliMode) {
-    # Hook mode: read JSON from stdin ($Input is reserved, use $stdinJson)
-    $stdinJson = [Console]::In.ReadToEnd()
+    # Hook mode: read JSON from stdin (StreamReader with UTF-8 auto-strips BOM on Windows)
+    $stream = [Console]::OpenStandardInput()
+    $reader = New-Object System.IO.StreamReader($stream, [System.Text.Encoding]::UTF8)
+    $stdinJson = $reader.ReadToEnd()
+    $reader.Close()
     Write-Log "invoked stdin_len=$($stdinJson.Length)"
 
     try {


### PR DESCRIPTION
- Use StreamReader+UTF8 for stdin (auto BOM strip) in peon.ps1 and hook-handle-use.ps1
- Map Cursor camelCase events (sessionStart, stop) to PascalCase in peon.ps1
- Handle Cursor flat-array hooks.json format in install.ps1 and uninstall.ps1
- Add session_override alias for pack rotation in peon.ps1
- Document Third-party skills requirement for Cursor on Windows in README