### PR TITLE
feat(cli): add peon packs install-local command

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ peon packs list           # List installed sound packs
 peon packs list --registry # Browse all available packs in the registry
 peon packs install <p1,p2> # Install packs from the registry
 peon packs install --all  # Install all packs from the registry
+peon packs install-local <path> # Install a pack from a local directory
 peon packs use <name>     # Switch to a specific pack
 peon packs use --install <name>  # Switch to pack, installing from registry if needed
 peon packs next           # Cycle to the next pack

--- a/README_zh.md
+++ b/README_zh.md
@@ -124,6 +124,7 @@ peon packs list           # 列出已安装的语音包
 peon packs list --registry # 浏览注册表中所有可用语音包
 peon packs install <p1,p2> # 从注册表安装语音包
 peon packs install --all  # 从注册表安装所有语音包
+peon packs install-local <path> # 从本地目录安装语音包
 peon packs use <name>     # 切换到指定语音包
 peon packs next           # 切换到下一个语音包
 peon packs remove <p1,p2> # 移除指定语音包

--- a/completions.bash
+++ b/completions.bash
@@ -15,7 +15,7 @@ _peon_completions() {
     case "$subcmd" in
       packs)
         if [ "$cword" -eq 2 ]; then
-          COMPREPLY=( $(compgen -W "list use next install remove rotation" -- "$cur") )
+          COMPREPLY=( $(compgen -W "list use next install install-local remove rotation" -- "$cur") )
         elif [ "$cword" -eq 3 ] && [ "$prev" = "rotation" ]; then
           COMPREPLY=( $(compgen -W "list add remove" -- "$cur") )
         elif [ "$cword" -eq 4 ] && [ "${words[2]}" = "rotation" ] && { [ "$prev" = "add" ] || [ "$prev" = "remove" ]; }; then
@@ -28,6 +28,8 @@ _peon_completions() {
           fi
         elif [ "$cword" -eq 3 ] && [ "$prev" = "install" ]; then
           COMPREPLY=( $(compgen -W "--all" -- "$cur") )
+        elif [ "$cword" -eq 3 ] && [ "$prev" = "install-local" ]; then
+          COMPREPLY=( $(compgen -d -- "$cur") )
         elif [ "$cword" -eq 3 ] && [ "$prev" = "list" ]; then
           COMPREPLY=( $(compgen -W "--registry" -- "$cur") )
         elif [ "$cword" -eq 3 ] && { [ "$prev" = "use" ] || [ "$prev" = "remove" ]; }; then

--- a/completions.fish
+++ b/completions.fish
@@ -39,6 +39,7 @@ complete -c peon -n "__peon_using_subcommand packs" -a list -d "List installed s
 complete -c peon -n "__peon_using_subcommand packs" -a use -d "Switch to a specific pack"
 complete -c peon -n "__peon_using_subcommand packs" -a next -d "Cycle to the next pack"
 complete -c peon -n "__peon_using_subcommand packs" -a install -d "Download and install new packs"
+complete -c peon -n "__peon_using_subcommand packs" -a install-local -d "Install a pack from a local directory" -F
 complete -c peon -n "__peon_using_subcommand packs" -a remove -d "Remove specific packs"
 complete -c peon -n "__peon_using_subcommand packs" -a rotation -d "Manage pack rotation list"
 


### PR DESCRIPTION
## Summary
- Adds `peon packs install-local <path> [--force]` CLI command to install sound packs from a local directory
- Validates manifest presence (`openpeon.json`, falls back to `manifest.json`), extracts pack name, warns on missing sound files, and supports `--force` to overwrite existing packs
- Adds tab completions for bash (directory completion) and fish

## Test plan
- [x] 10 new BATS tests covering: successful install, no-args error, nonexistent path, missing manifest, overwrite protection, `--force` overwrite, `packs list` integration, missing sound file warnings, `manifest.json` fallback, dirname fallback when `name` field is absent
- [x] Full test suite passes (229/230 — 1 pre-existing flaky test unrelated to this change)

## Why
I'd like to compose some personal sound packs that I don't necessarily want to publish to the registry, e.g. sounds from multiple unrelated sources that are fun to me but not others.
Currently I could achieve this by manually adding the sound pack folders to `~/.claude/hooks/peon-ping/packs`. But this `install-local` feature can be beneficial in making this process easier and ensure the installed custom packs are validated just as those from the registry.