### PR TITLE
fix: guard completions.bash for non-interactive shells

### DIFF
--- a/completions.bash
+++ b/completions.bash
@@ -66,9 +66,14 @@ _peon_completions() {
   return 0
 }
 
-# zsh compatibility: enable bashcompinit first
-if [ -n "$ZSH_VERSION" ]; then
-  autoload -Uz bashcompinit 2>/dev/null && bashcompinit
-fi
-
-complete -F _peon_completions peon
+# Only register completions in interactive shells (complete is unavailable in
+# non-interactive contexts like Nix hook environments, CI runners, etc.)
+case "$-" in
+  *i*)
+    # zsh compatibility: enable bashcompinit first
+    if [ -n "$ZSH_VERSION" ]; then
+      autoload -Uz bashcompinit 2>/dev/null && bashcompinit
+    fi
+    complete -F _peon_completions peon
+    ;;
+esac


### PR DESCRIPTION
Wraps the `complete` registration in a `case "$-" in *i*)` check so `completions.bash` can be safely sourced in non-interactive contexts (Nix hook environments, CI runners, scripts) without producing `complete: command not found` errors.

**Changes:** `completions.bash` — moved the `complete` call and zsh `bashcompinit` inside an interactivity guard.

**Tests:** Full suite passes (477/478 — 1 pre-existing TTY flake unrelated).

Fixes #240