### PR TITLE
fix(preview): respect use_sound_effects_device from config

### DIFF
--- a/peon.sh
+++ b/peon.sh
@@ -1558,6 +1558,7 @@ try:
 except Exception:
     cfg = {}
 volume = cfg.get('volume', 0.5)
+use_sound_effects_device = cfg.get('use_sound_effects_device', True)
 active_pack = cfg.get('default_pack', cfg.get('active_pack', 'peon'))
 
 # Load manifest
@@ -1587,6 +1588,7 @@ if not cat_data or not cat_data.get('sounds'):
 display_name = manifest.get('display_name', active_pack)
 print('PACK_DISPLAY=' + repr(display_name))
 print('VOLUME=' + str(volume))
+print('USE_SOUND_EFFECTS_DEVICE=' + str(use_sound_effects_device).lower())
 
 sounds = cat_data['sounds']
 for i, s in enumerate(sounds):
@@ -1612,6 +1614,8 @@ for i, s in enumerate(sounds):
     # Parse output
     PREVIEW_VOL=$(echo "$PREVIEW_OUTPUT" | grep '^VOLUME=' | head -1 | cut -d= -f2)
     PREVIEW_VOL="${PREVIEW_VOL:-0.5}"
+    USE_SOUND_EFFECTS_DEVICE=$(echo "$PREVIEW_OUTPUT" | grep '^USE_SOUND_EFFECTS_DEVICE=' | head -1 | cut -d= -f2)
+    USE_SOUND_EFFECTS_DEVICE="${USE_SOUND_EFFECTS_DEVICE:-true}"
     PACK_DISPLAY=$(echo "$PREVIEW_OUTPUT" | grep '^PACK_DISPLAY=' | head -1 | sed "s/^PACK_DISPLAY=//;s/^'//;s/'$//")
 
     echo "peon-ping: previewing [$PREVIEW_CAT] from $PACK_DISPLAY"


### PR DESCRIPTION
## Summary
- read use_sound_effects_device from preview config payload
- export it to shell env before calling play_sound
- keep existing behavior when the key is absent (default true)

## Bug
peon preview ignores use_sound_effects_device=false and still attempts peon-play.
On some macOS setups where peon-play fails, preview becomes silent even though afplay works.

## Repro
1. Set use_sound_effects_device to false in config
2. Run peon preview session.start
3. Before this fix: silent preview (still tries peon-play)
4. After this fix: preview uses afplay path and audio plays

## Scope
- only the preview command path
- no change to regular hook event handling