### PR TITLE
feat: add declarative relay service for NixOS and nix-darwin

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ For reproducible setups, use the Home Manager module:
 
 ```nix
 # In your home.nix or flake.nix
-{ inputs, ... }: {
+{ inputs, pkgs, ... }: {
   imports = [ inputs.peon-ping.homeManagerModules.default ];
 
   programs.peon-ping = {
@@ -724,7 +724,7 @@ Mobile notifications fire on every event regardless of window focus — they're 
 
 ## Sound packs
 
-75+ packs across Warcraft, StarCraft, Red Alert, Portal, Zelda, Dota 2, Helldivers 2, Elder Scrolls, and more. The default install includes 5 curated packs:
+99 packs across Warcraft, StarCraft, Red Alert, Portal, Zelda, Dota 2, Helldivers 2, Elder Scrolls, and more. The default install includes 5 curated packs:
 
 | Pack | Character | Sounds |
 |---|---|---|

--- a/flake.nix
+++ b/flake.nix
@@ -10,6 +10,12 @@
     let
       # Home Manager module (system-agnostic)
       homeManagerModules.default = import ./nix/hm-module.nix;
+      
+      # NixOS module
+      nixosModules.default = import ./nix/nixos-module.nix;
+      
+      # nix-darwin module
+      darwinModules.default = import ./nix/darwin-module.nix;
     in
     flake-utils.lib.eachDefaultSystem (system:
       let
@@ -122,5 +128,7 @@
           '';
         };
       }
-    ) // { inherit homeManagerModules; };
+    ) // { 
+      inherit homeManagerModules nixosModules darwinModules;
+    };
 }

--- a/nix/darwin-module.nix
+++ b/nix/darwin-module.nix
@@ -1,0 +1,59 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.peon-ping-relay;
+in
+{
+  options.services.peon-ping-relay = {
+    enable = mkEnableOption "peon-ping audio relay server for SSH/devcontainer support";
+    
+    package = mkOption {
+      type = types.package;
+      default = pkgs.peon-ping or (throw "peon-ping not available. Import the flake package.");
+      defaultText = literalExpression "pkgs.peon-ping";
+      description = "The peon-ping package to use";
+    };
+    
+    port = mkOption {
+      type = types.port;
+      default = 19998;
+      description = "Port for the relay server to listen on";
+    };
+    
+    bindAddress = mkOption {
+      type = types.str;
+      default = "127.0.0.1";
+      description = "Address to bind to";
+    };
+    
+    logDir = mkOption {
+      type = types.str;
+      default = "/tmp/peon-ping";
+      description = "Directory for relay log files. Must be writable by the service user.";
+    };
+  };
+  
+  config = mkIf cfg.enable {
+    system.activationScripts.peon-ping-relay-logs.text = ''
+      mkdir -p ${cfg.logDir}
+    '';
+    
+    launchd.user.agents.peon-ping-relay = {
+      serviceConfig = {
+        ProgramArguments = [ 
+          "${cfg.package}/bin/peon" 
+          "relay" 
+          "--port=${toString cfg.port}"
+          "--bind=${cfg.bindAddress}"
+        ];
+        KeepAlive = true;
+        ThrottleInterval = 30;
+        RunAtLoad = true;
+        StandardOutPath = "${cfg.logDir}/peon-relay.log";
+        StandardErrorPath = "${cfg.logDir}/peon-relay.error.log";
+      };
+    };
+  };
+}

--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -84,10 +84,12 @@ in
     # Create the config file at the legacy location peon-ping expects
     home.file.".openpeon/config.json".source = jsonFormat.generate "peon-ping-config" cfg.settings;
 
-    # Install sound packs via activation script
-    home.activation.peonPacksInstall = lib.hm.dag.entryAfter [ "writeBoundary" ] (mkIf (cfg.installPacks != [ ]) ''
-      $DRY_RUN_CMD ${cfg.package}/bin/peon packs install ${lib.concatStringsSep "," cfg.installPacks}
-    '');
+    # Install sound packs via activation script (only if packs specified)
+    home.activation.peonPacksInstall = lib.mkIf (cfg.installPacks != [ ]) (
+      lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+        $DRY_RUN_CMD ${cfg.package}/bin/peon packs install ${lib.concatStringsSep "," cfg.installPacks}
+      ''
+    );
 
     # Shell completions
     programs.zsh.initExtra = mkIf cfg.enableZshIntegration ''

--- a/nix/nixos-module.nix
+++ b/nix/nixos-module.nix
@@ -1,0 +1,64 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.peon-ping-relay;
+in
+{
+  options.services.peon-ping-relay = {
+    enable = mkEnableOption "peon-ping audio relay server for SSH/devcontainer support";
+    
+    package = mkOption {
+      type = types.package;
+      default = pkgs.peon-ping or (throw "peon-ping not available. Import the flake package.");
+      description = "The peon-ping package to use";
+    };
+    
+    port = mkOption {
+      type = types.port;
+      default = 19998;
+      description = "Port for the relay server to listen on";
+    };
+    
+    bindAddress = mkOption {
+      type = types.str;
+      default = "127.0.0.1";
+      description = "Address to bind to. Use 0.0.0.0 to allow remote SSH connections";
+    };
+    
+    openFirewall = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Open the relay port in the firewall";
+    };
+  };
+  
+  config = mkIf cfg.enable {
+    systemd.services.peon-ping-relay = {
+      description = "peon-ping audio relay server";
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+      
+      serviceConfig = {
+        Type = "simple";
+        ExecStart = "${cfg.package}/bin/peon relay --port=${toString cfg.port} --bind=${cfg.bindAddress}";
+        Restart = "always";
+        RestartSec = 5;
+        
+        # Security hardening
+        DynamicUser = true;
+        RuntimeDirectory = "peon-ping";
+        NoNewPrivileges = true;
+        PrivateTmp = true;
+        ProtectSystem = "strict";
+        ProtectHome = "read-only";
+        ReadWritePaths = [ "/tmp" ];
+        RestrictAddressFamilies = [ "AF_INET" "AF_INET6" ];
+        CapabilityBoundingSet = "";
+      };
+    };
+    
+    networking.firewall.allowedTCPPorts = mkIf cfg.openFirewall [ cfg.port ];
+  };
+}


### PR DESCRIPTION
This PR adds system service modules for running the peon-ping relay server declaratively on NixOS and nix-darwin.

## Background

The peon-ping relay enables audio playback from remote SSH sessions and devcontainers. Previously, users had to manually run `peon relay --daemon`. This PR adds proper service management.

## Changes

**New modules:**
- `nix/nixos-module.nix` - systemd service for NixOS
- `nix/darwin-module.nix` - launchd service for macOS

**Updated:**
- `flake.nix` - exposes `nixosModules` and `darwinModules` outputs
- `peon.sh` - fixes relay.sh discovery when PEON_DIR points to user config (not install dir)

## Usage

**NixOS:**
```nix
services.peon-ping-relay = {
  enable = true;
  port = 19998;
  bindAddress = "127.0.0.1";
  openFirewall = false;
};
```

**nix-darwin:**
```nix
services.peon-ping-relay = {
  enable = true;
  port = 19998;
  bindAddress = "127.0.0.1";
};
```

## Technical Details

The relay.sh lookup now uses \_INSTALL_DIR (saved at startup before PEON_DIR gets redirected to ~/.openpeon) to find the bundled script in Nix/Homebrew installs.

## Testing

- [x] Module evaluates correctly
- [x] Package includes relay.sh
- [x] Service configuration generated properly

After merge, users can SSH into remote machines with port forwarding and peon-ping will automatically route audio through the relay.