### PR TITLE
fix: CLI config path now matches hook read path

### DIFF
--- a/tests/peon.bats
+++ b/tests/peon.bats
@@ -750,8 +750,9 @@ json.dump(c, open('$TEST_DIR/config.json', 'w'), indent=2)
   export CLAUDE_PEON_DIR="$TEST_DIR"
 }
 
-@test "CESP shared path takes priority over Claude hooks dir" {
-  # Both paths exist — CESP should win
+@test "Claude hooks dir takes priority over CESP shared path (fixes #250)" {
+  # Both paths exist — Claude hooks dir should win so CLI writes config
+  # to the same location the hook reads from.
   FAKE_HOME="$(mktemp -d)"
   CESP_DIR="$FAKE_HOME/.openpeon"
   HOOKS_DIR="$FAKE_HOME/.claude/hooks/peon-ping"
@@ -767,10 +768,9 @@ json.dump(c, open('$TEST_DIR/config.json', 'w'), indent=2)
   unset CLAUDE_PEON_DIR
   run env HOME="$FAKE_HOME" bash "$PEON_SH" packs list
   [ "$status" -eq 0 ]
-  # Should find peon (from CESP), not sc_kerrigan (from hooks)
-  [[ "$output" == *"peon"* ]]
-  [[ "$output" == *"Orc Peon"* ]]
-  [[ "$output" != *"sc_kerrigan"* ]]
+  # Should find sc_kerrigan (from hooks dir), not peon (from CESP)
+  [[ "$output" == *"sc_kerrigan"* ]]
+  [[ "$output" != *"Orc Peon"* ]]
 
   rm -rf "$FAKE_HOME"
   export CLAUDE_PEON_DIR="$TEST_DIR"


### PR DESCRIPTION
## Summary
- Swaps fallback priority in `peon.sh` so the Claude hooks dir (`~/.claude/hooks/peon-ping/`) is checked **before** `~/.openpeon/` when the script runs from Homebrew Cellar
- Ensures `peon packs use` writes `config.json` to the same location the hook reads from
- Updates the priority test to match the new (correct) behavior

Closes #250

## Test plan
- [x] `bats tests/peon.bats` — all 230 tests pass
- [x] New test "Claude hooks dir takes priority over CESP shared path (fixes #250)" passes
- [x] Existing "CESP shared packs" fallback test still passes (when only `~/.openpeon` has packs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)