### PR TITLE
Add suppress_sound_when_tab_focused config option

### DIFF
--- a/config.json
+++ b/config.json
@@ -24,6 +24,7 @@
   "use_sound_effects_device": true,
   "linux_audio_player": "",
   "headphones_only": false,
+  "suppress_sound_when_tab_focused": false,
   "trainer": {
     "enabled": false,
     "exercises": {

--- a/tests/peon.bats
+++ b/tests/peon.bats
@@ -3166,3 +3166,47 @@ json.dump(c, open('$TEST_DIR/config.json', 'w'))
   afplay_was_called
 }
 
+# ============================================================
+# Suppress sound when tab focused
+# ============================================================
+
+@test "suppress_sound_when_tab_focused: skips sound when terminal is focused" {
+  # Enable the feature
+  /usr/bin/python3 -c "
+import json
+c = json.load(open('$TEST_DIR/config.json'))
+c['suppress_sound_when_tab_focused'] = True
+json.dump(c, open('$TEST_DIR/config.json', 'w'))
+"
+  # Mock terminal as focused (Terminal.app — a recognized terminal)
+  echo "Terminal" > "$TEST_DIR/.mock_terminal_focused"
+
+  run_peon '{"hook_event_name":"Stop","cwd":"/tmp/myproject","session_id":"s1","permission_mode":"default"}'
+  [ "$PEON_EXIT" -eq 0 ]
+  ! afplay_was_called
+}
+
+@test "suppress_sound_when_tab_focused: plays sound when terminal is not focused" {
+  # Enable the feature
+  /usr/bin/python3 -c "
+import json
+c = json.load(open('$TEST_DIR/config.json'))
+c['suppress_sound_when_tab_focused'] = True
+json.dump(c, open('$TEST_DIR/config.json', 'w'))
+"
+  # Default mock: osascript returns "Safari" (not a terminal) — not focused
+
+  run_peon '{"hook_event_name":"Stop","cwd":"/tmp/myproject","session_id":"s1","permission_mode":"default"}'
+  [ "$PEON_EXIT" -eq 0 ]
+  afplay_was_called
+}
+
+@test "suppress_sound_when_tab_focused disabled: plays sound even when terminal is focused" {
+  # Feature defaults to false — mock terminal as focused
+  echo "Terminal" > "$TEST_DIR/.mock_terminal_focused"
+
+  run_peon '{"hook_event_name":"Stop","cwd":"/tmp/myproject","session_id":"s1","permission_mode":"default"}'
+  [ "$PEON_EXIT" -eq 0 ]
+  afplay_was_called
+}
+

--- a/tests/setup.bash
+++ b/tests/setup.bash
@@ -232,9 +232,18 @@ SCRIPT
   # Mock osascript — log calls instead of running AppleScript/JXA
   cat > "$MOCK_BIN/osascript" <<'SCRIPT'
 #!/bin/bash
-# For the frontmost app check, return "Safari" (not a terminal) so notifications fire
+# For the frontmost app check, return terminal name or "Safari" based on fixture
 if [[ "$*" == *"frontmost"* ]]; then
-  echo "Safari"
+  if [ -f "${CLAUDE_PEON_DIR}/.mock_terminal_focused" ]; then
+    cat "${CLAUDE_PEON_DIR}/.mock_terminal_focused"
+  else
+    echo "Safari"
+  fi
+elif [[ "$*" == *"iTerm2"* ]] && [[ "$*" == *"tty"* ]]; then
+  # iTerm2 tty query — return mock tty if fixture exists
+  if [ -f "${CLAUDE_PEON_DIR}/.mock_iterm_active_ttys" ]; then
+    cat "${CLAUDE_PEON_DIR}/.mock_iterm_active_ttys"
+  fi
 elif [[ "$1" == "-l" ]] && [[ "$2" == "JavaScript" ]]; then
   # JXA overlay call — log to overlay.log with full arguments
   echo "$@" >> "${CLAUDE_PEON_DIR}/overlay.log"


### PR DESCRIPTION
Adds an opt-in config option to suppress sound playback when the terminal tab generating the event is the currently focused tab. Useful for users who only want audio cues when working in a different tab or application.

## Changes

- Adds `suppress_sound_when_tab_focused` config option (default: `false`) that skips sound playback when the terminal tab is the active/focused tab
- Uses lazy evaluation to avoid calling `osascript` when the feature is disabled — zero performance cost for users who don't opt in
- Composes with `headphones_only` via a `_skip_sound` flag instead of nested no-op branches
- Covers trainer sound suppression as well
- Includes 3 BATS tests and updated osascript mock fixtures

Depends on #256 for multi-window iTerm2 tty detection accuracy.

Closes #255