### PR TITLE
fix(security): harden shell-to-Python handoffs, adapter JSON, atomic writes, audio allowlist

### DIFF
--- a/adapters/antigravity.sh
+++ b/adapters/antigravity.sh
@@ -108,8 +108,16 @@ emit_event() {
   local guid="$2"
   local session_id="antigravity-${guid:0:8}"
 
-  echo "{\"hook_event_name\":\"$event\",\"notification_type\":\"\",\"cwd\":\"$PWD\",\"session_id\":\"$session_id\",\"permission_mode\":\"\"}" \
-    | bash "$PEON_DIR/peon.sh" 2>/dev/null || true
+  _PE="$event" _PC="$PWD" _PS="$session_id" python3 -c "
+import json, os
+print(json.dumps({
+    'hook_event_name': os.environ['_PE'],
+    'notification_type': '',
+    'cwd': os.environ['_PC'],
+    'session_id': os.environ['_PS'],
+    'permission_mode': '',
+}))
+" | bash "$PEON_DIR/peon.sh" 2>/dev/null || true
 }
 
 # --- Handle a conversation file change ---

--- a/adapters/codex.sh
+++ b/adapters/codex.sh
@@ -39,5 +39,13 @@ NTYPE="${NTYPE:-}"
 SESSION_ID="codex-${CODEX_SESSION_ID:-$$}"
 CWD="${PWD}"
 
-echo "{\"hook_event_name\":\"$EVENT\",\"notification_type\":\"$NTYPE\",\"cwd\":\"$CWD\",\"session_id\":\"$SESSION_ID\",\"permission_mode\":\"\"}" \
-  | bash "$PEON_DIR/peon.sh"
+_PE="$EVENT" _PN="$NTYPE" _PC="$CWD" _PS="$SESSION_ID" python3 -c "
+import json, os
+print(json.dumps({
+    'hook_event_name': os.environ['_PE'],
+    'notification_type': os.environ['_PN'],
+    'cwd': os.environ['_PC'],
+    'session_id': os.environ['_PS'],
+    'permission_mode': '',
+}))
+" | bash "$PEON_DIR/peon.sh"

--- a/adapters/windsurf.sh
+++ b/adapters/windsurf.sh
@@ -54,5 +54,13 @@ esac
 SESSION_ID="windsurf-${PPID:-$$}"
 CWD="${PWD}"
 
-echo "{\"hook_event_name\":\"$EVENT\",\"notification_type\":\"\",\"cwd\":\"$CWD\",\"session_id\":\"$SESSION_ID\",\"permission_mode\":\"\"}" \
-  | bash "$PEON_DIR/peon.sh"
+_PE="$EVENT" _PC="$CWD" _PS="$SESSION_ID" python3 -c "
+import json, os
+print(json.dumps({
+    'hook_event_name': os.environ['_PE'],
+    'notification_type': '',
+    'cwd': os.environ['_PC'],
+    'session_id': os.environ['_PS'],
+    'permission_mode': '',
+}))
+" | bash "$PEON_DIR/peon.sh"

--- a/scripts/hook-handle-use.sh
+++ b/scripts/hook-handle-use.sh
@@ -91,11 +91,12 @@ fi
 # so peon.sh will apply this pack for sessions without explicit assignment
 
 # Update config.json to enable agentskill mode and ensure pack is in rotation
+export PEON_ENV_CONFIG="$CONFIG" PEON_ENV_PACK_NAME="$PACK_NAME"
 python3 -c "
-import json, sys
+import json, sys, os
 
-config_path = '$CONFIG'
-pack_name = '$PACK_NAME'
+config_path = os.environ.get('PEON_ENV_CONFIG', '')
+pack_name = os.environ.get('PEON_ENV_PACK_NAME', '')
 
 # Load config
 try:
@@ -120,12 +121,13 @@ with open(config_path, 'w') as f:
 "
 
 # Update .state.json to map session to pack
+export PEON_ENV_STATE="$STATE" PEON_ENV_SESSION_ID="$SESSION_ID" PEON_ENV_PACK_NAME="$PACK_NAME"
 python3 -c "
-import json, sys, time
+import json, sys, time, os
 
-state_path = '$STATE'
-session_id = '$SESSION_ID'
-pack_name = '$PACK_NAME'
+state_path = os.environ.get('PEON_ENV_STATE', '')
+session_id = os.environ.get('PEON_ENV_SESSION_ID', '')
+pack_name = os.environ.get('PEON_ENV_PACK_NAME', '')
 
 # Load or create state
 try:


### PR DESCRIPTION
Applies security hardening from #248 rebased onto current main. Closes #248.

- Replace shell variable interpolation into Python code strings with os.environ lookups (RCE prevention)
- Escape PowerShell single quotes in WSL/Windows audio paths
- Add safe_eval_python() guard to validate Python output before eval
- Use python3 json.dumps() in codex, windsurf, antigravity adapters (JSON injection prevention)
- Atomic state file writes via tempfile + os.replace (concurrent hook protection)
- Audio file extension allowlist (.wav/.mp3/.ogg/.flac/.aac/.m4a/.opus)