### PR TITLE
feat: auto-suppress sounds when microphone is active

### DIFF
--- a/config.json
+++ b/config.json
@@ -24,6 +24,7 @@
   "use_sound_effects_device": true,
   "linux_audio_player": "",
   "headphones_only": false,
+  "meeting_detect": false,
   "suppress_sound_when_tab_focused": false,
   "trainer": {
     "enabled": false,

--- a/install.sh
+++ b/install.sh
@@ -496,6 +496,22 @@ if [ "$PLATFORM" = "mac" ] && command -v swiftc &>/dev/null; then
   fi
 fi
 
+# --- Build meeting-detect (macOS mic-in-use detection) ---
+if [ "$PLATFORM" = "mac" ] && command -v swiftc &>/dev/null; then
+  MEETING_DETECT_SRC="$INSTALL_DIR/scripts/meeting-detect.swift"
+  if [ ! -f "$MEETING_DETECT_SRC" ] && [ -z "$SCRIPT_DIR" ]; then
+    curl -fsSL "$REPO_BASE/scripts/meeting-detect.swift" -o "$MEETING_DETECT_SRC" 2>/dev/null || true
+  fi
+  if [ -f "$MEETING_DETECT_SRC" ]; then
+    echo "Building meeting-detect (mic-in-use detection)..."
+    swiftc -O -o "$INSTALL_DIR/scripts/meeting-detect" \
+      "$MEETING_DETECT_SRC" \
+      -framework CoreAudio 2>/dev/null \
+      && echo "  meeting-detect built successfully" \
+      || echo "  Warning: could not build meeting-detect, using process-based fallback"
+  fi
+fi
+
 # --- Install skill (slash command) ---
 SKILL_DIR="$BASE_DIR/skills/peon-ping-toggle"
 mkdir -p "$SKILL_DIR"

--- a/scripts/meeting-detect.swift
+++ b/scripts/meeting-detect.swift
@@ -1,0 +1,91 @@
+// meeting-detect.swift — Check if any microphone is currently in use
+// Queries CoreAudio kAudioDevicePropertyDeviceIsRunningSomewhere on input devices.
+// Outputs "MIC_IN_USE" or "MIC_NOT_IN_USE" to stdout.
+// Build: swiftc -O -o meeting-detect meeting-detect.swift -framework CoreAudio
+
+import CoreAudio
+import Foundation
+
+func isMicInUse() -> Bool {
+    var propertySize: UInt32 = 0
+    var propertyAddress = AudioObjectPropertyAddress(
+        mSelector: kAudioHardwarePropertyDevices,
+        mScope: kAudioObjectPropertyScopeGlobal,
+        mElement: kAudioObjectPropertyElementMain
+    )
+
+    // Get the size of the device list
+    var status = AudioObjectGetPropertyDataSize(
+        AudioObjectID(kAudioObjectSystemObject),
+        &propertyAddress,
+        0, nil,
+        &propertySize
+    )
+    guard status == noErr else { return false }
+
+    let deviceCount = Int(propertySize) / MemoryLayout<AudioDeviceID>.size
+    guard deviceCount > 0 else { return false }
+
+    var deviceIDs = [AudioDeviceID](repeating: 0, count: deviceCount)
+    status = AudioObjectGetPropertyData(
+        AudioObjectID(kAudioObjectSystemObject),
+        &propertyAddress,
+        0, nil,
+        &propertySize,
+        &deviceIDs
+    )
+    guard status == noErr else { return false }
+
+    for deviceID in deviceIDs {
+        // Check if this device has input channels
+        var inputAddress = AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyStreamConfiguration,
+            mScope: kAudioDevicePropertyScopeInput,
+            mElement: kAudioObjectPropertyElementMain
+        )
+
+        var bufferListSize: UInt32 = 0
+        status = AudioObjectGetPropertyDataSize(deviceID, &inputAddress, 0, nil, &bufferListSize)
+        guard status == noErr, bufferListSize > 0 else { continue }
+
+        let bufferListPtr = UnsafeMutablePointer<AudioBufferList>.allocate(capacity: 1)
+        defer { bufferListPtr.deallocate() }
+
+        status = AudioObjectGetPropertyData(deviceID, &inputAddress, 0, nil, &bufferListSize, bufferListPtr)
+        guard status == noErr else { continue }
+
+        let bufferList = bufferListPtr.pointee
+        var hasInputChannels = false
+        let bufferCount = Int(bufferList.mNumberBuffers)
+        if bufferCount > 0 {
+            // Check first buffer for channels
+            if bufferList.mBuffers.mNumberChannels > 0 {
+                hasInputChannels = true
+            }
+        }
+
+        guard hasInputChannels else { continue }
+
+        // Check if this input device is running (mic in use)
+        var isRunning: UInt32 = 0
+        var runningSize = UInt32(MemoryLayout<UInt32>.size)
+        var runningAddress = AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyDeviceIsRunningSomewhere,
+            mScope: kAudioDevicePropertyScopeInput,
+            mElement: kAudioObjectPropertyElementMain
+        )
+
+        status = AudioObjectGetPropertyData(deviceID, &runningAddress, 0, nil, &runningSize, &isRunning)
+        if status == noErr && isRunning != 0 {
+            return true
+        }
+    }
+
+    return false
+}
+
+if isMicInUse() {
+    print("MIC_IN_USE")
+} else {
+    print("MIC_NOT_IN_USE")
+}

--- a/tests/setup.bash
+++ b/tests/setup.bash
@@ -348,6 +348,18 @@ SCRIPT
 
   export PATH="$MOCK_BIN:$PATH"
 
+  # Mock meeting-detect binary — returns MIC_IN_USE or MIC_NOT_IN_USE based on fixture
+  mkdir -p "$TEST_DIR/scripts"
+  cat > "$TEST_DIR/scripts/meeting-detect" <<'SCRIPT'
+#!/bin/bash
+if [ -f "${CLAUDE_PEON_DIR}/.mock_mic_in_use" ]; then
+  echo "MIC_IN_USE"
+else
+  echo "MIC_NOT_IN_USE"
+fi
+SCRIPT
+  chmod +x "$TEST_DIR/scripts/meeting-detect"
+
   # Copy notify.sh into test dir so send_notification() can find it
   _src_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
   mkdir -p "$TEST_DIR/scripts"


### PR DESCRIPTION
## Summary

- Adds `meeting_detect` config option (default: `false`) that detects active microphone use and suppresses sound playback during calls
- Uses CoreAudio on macOS (compiled Swift binary) and PipeWire/PulseAudio on Linux
- Works with any app using the mic — Zoom, Teams, Meet, FaceTime, Discord, etc.
- Follows the same pattern as `headphones_only` (config key, detection function, `_skip_sound` check)

## Files changed

| File | Change |
|------|--------|
| `scripts/meeting-detect.swift` | New — CoreAudio mic-in-use detection source |
| `peon.sh` | `detect_meeting()` function, config parsing, sound suppression |
| `config.json` | Added `"meeting_detect": false` |
| `install.sh` | `swiftc` compile step for meeting-detect binary |
| `tests/peon.bats` | 3 new tests |
| `tests/setup.bash` | Mock for meeting-detect binary |

## Test plan

- [x] `bats tests/peon.bats --filter meeting_detect` — all 3 new tests pass
- [x] `bats tests/peon.bats --filter headphones_only` — existing tests unaffected
- [ ] Manual: enable `meeting_detect: true`, start a call, verify sound suppressed
- [ ] Manual: end call, verify sound plays again