### PR TITLE
fix(windows): normalize PSCustomObject for session_packs in hook-handle-use.ps1

### DIFF
--- a/scripts/hook-handle-use.ps1
+++ b/scripts/hook-handle-use.ps1
@@ -163,12 +163,15 @@ try {
     if (Test-Path $statePath) {
         $state = Get-Content $statePath -Raw | ConvertFrom-Json
     } else {
-        $state = @{}
+        # Use PSCustomObject (not hashtable) so Add-Member works correctly on it
+        $state = [PSCustomObject]@{}
     }
     
     # Ensure session_packs exists
     if (-not $state.session_packs) {
-        $state | Add-Member -NotePropertyName "session_packs" -NotePropertyValue @{} -Force
+        # Use PSCustomObject (not hashtable @{}) so subsequent Add-Member calls correctly
+        # insert key-value entries rather than adding NoteProperties to the hashtable object
+        $state | Add-Member -NotePropertyName "session_packs" -NotePropertyValue ([PSCustomObject]@{}) -Force
     }
     
     # Map this session to the requested pack (new dict format with timestamp)


### PR DESCRIPTION
## Problem

Fixes #264

In `scripts/hook-handle-use.ps1`, when `.state.json` doesn't exist:

1. `$state = @{}` creates a PowerShell **hashtable**
2. `Add-Member -NotePropertyValue @{}` adds a nested hashtable for `session_packs`
3. `$state.session_packs | Add-Member -NotePropertyName $sessionId ...` calls `Add-Member` on the hashtable — which adds a NoteProperty to the hashtable *object* (not a key-value entry), so the session mapping silently drops

When `.state.json` exists, `ConvertFrom-Json` returns a `PSCustomObject` where `Add-Member` works correctly. The bug only manifests on first use or after `.state.json` is emptied.

## Fix

Use `[PSCustomObject]@{}` instead of `@{}` for both the fresh `$state` and the initial `session_packs` value. Minimal change — same `Add-Member` pattern everywhere, but the objects are now consistently `PSCustomObject`.

## Tests

238/239 pass. The one failure (`no arguments on a TTY shows usage hint and exits`) is pre-existing on `main` and unrelated to this change.