### PR TITLE
feat: add bind/unbind/bindings CLI commands for per-directory pack rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,10 @@ peon packs use <name>     # Switch to a specific pack
 peon packs use --install <name>  # Switch to pack, installing from registry if needed
 peon packs next           # Cycle to the next pack
 peon packs remove <p1,p2> # Remove specific packs
+peon packs bind <name>    # Bind a pack to the current directory
+peon packs bind --pattern <path> # Bind a pack to a directory pattern, e.g. "*/services"
+peon packs unbind         # Remove the current directory
+peon packs bindings       # List all assigned bindings
 peon notifications on     # Enable desktop notifications
 peon notifications off    # Disable desktop notifications
 peon notifications overlay   # Use large overlay banners (default)

--- a/completions.bash
+++ b/completions.bash
@@ -15,7 +15,7 @@ _peon_completions() {
     case "$subcmd" in
       packs)
         if [ "$cword" -eq 2 ]; then
-          COMPREPLY=( $(compgen -W "list use next install install-local remove rotation" -- "$cur") )
+          COMPREPLY=( $(compgen -W "list use next install install-local remove rotation bind unbind bindings" -- "$cur") )
         elif [ "$cword" -eq 3 ] && [ "$prev" = "rotation" ]; then
           COMPREPLY=( $(compgen -W "list add remove" -- "$cur") )
         elif [ "$cword" -eq 4 ] && [ "${words[2]}" = "rotation" ] && { [ "$prev" = "add" ] || [ "$prev" = "remove" ]; }; then
@@ -32,7 +32,7 @@ _peon_completions() {
           COMPREPLY=( $(compgen -d -- "$cur") )
         elif [ "$cword" -eq 3 ] && [ "$prev" = "list" ]; then
           COMPREPLY=( $(compgen -W "--registry" -- "$cur") )
-        elif [ "$cword" -eq 3 ] && { [ "$prev" = "use" ] || [ "$prev" = "remove" ]; }; then
+        elif [ "$cword" -eq 3 ] && { [ "$prev" = "use" ] || [ "$prev" = "remove" ] || [ "$prev" = "bind" ]; }; then
           packs_dir="${CLAUDE_PEON_DIR:-${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/peon-ping}/packs"
           [ ! -d "$packs_dir" ] && [ -d "$HOME/.openpeon/packs" ] && packs_dir="$HOME/.openpeon/packs"
           if [ -d "$packs_dir" ]; then

--- a/completions.fish
+++ b/completions.fish
@@ -42,6 +42,9 @@ complete -c peon -n "__peon_using_subcommand packs" -a install -d "Download and 
 complete -c peon -n "__peon_using_subcommand packs" -a install-local -d "Install a pack from a local directory" -F
 complete -c peon -n "__peon_using_subcommand packs" -a remove -d "Remove specific packs"
 complete -c peon -n "__peon_using_subcommand packs" -a rotation -d "Manage pack rotation list"
+complete -c peon -n "__peon_using_subcommand packs" -a bind -d "Bind a pack to the current directory"
+complete -c peon -n "__peon_using_subcommand packs" -a unbind -d "Remove pack binding for current directory"
+complete -c peon -n "__peon_using_subcommand packs" -a bindings -d "List all directory-to-pack bindings"
 
 # packs rotation subcommands
 complete -c peon -n "__peon_packs_subcommand rotation" -a list -d "Show current rotation list and mode"
@@ -56,6 +59,17 @@ complete -c peon -n "__peon_packs_subcommand list" -a "--registry" -d "List all 
 
 # Pack name completions for 'packs use' and 'packs remove'
 complete -c peon -n "__peon_packs_subcommand use" -a "(
+  set -l packs_dir (set -q CLAUDE_PEON_DIR; and echo \$CLAUDE_PEON_DIR; or echo \$HOME/.claude/hooks/peon-ping)/packs
+  if not test -d \$packs_dir; and test -d \$HOME/.openpeon/packs
+    set packs_dir \$HOME/.openpeon/packs
+  end
+  if test -d \$packs_dir
+    for manifest in \$packs_dir/*/manifest.json \$packs_dir/*/openpeon.json
+      basename (dirname \$manifest)
+    end
+  end
+)"
+complete -c peon -n "__peon_packs_subcommand bind" -a "(
   set -l packs_dir (set -q CLAUDE_PEON_DIR; and echo \$CLAUDE_PEON_DIR; or echo \$HOME/.claude/hooks/peon-ping)/packs
   if not test -d \$packs_dir; and test -d \$HOME/.openpeon/packs
     set packs_dir \$HOME/.openpeon/packs

--- a/skills/peon-ping-config/SKILL.md
+++ b/skills/peon-ping-config/SKILL.md
@@ -75,6 +75,49 @@ Set:
 }
 ```
 
+## Directory pack bindings
+
+Permanently associate a sound pack with a working directory so every session in that directory uses the right pack automatically. Uses the `path_rules` config key (array of `{ "pattern": "<glob>", "pack": "<name>" }` objects).
+
+### CLI commands
+
+```bash
+# Bind a pack to the current directory
+peon packs bind <pack>
+# e.g. peon packs bind glados
+# → bound glados to /Users/dan/Frontend
+
+# Bind with a custom glob pattern (matches any dir with that name)
+peon packs bind <pack> --pattern "*/Frontend/*"
+
+# Auto-download a missing pack and bind it
+peon packs bind <pack> --install
+
+# Remove binding for the current directory
+peon packs unbind
+
+# Remove a specific pattern binding
+peon packs unbind --pattern "*/Frontend/*"
+
+# List all bindings (* marks rules matching current directory)
+peon packs bindings
+```
+
+### Manual config
+
+The `path_rules` array in `config.json` can also be edited directly:
+
+```json
+{
+  "path_rules": [
+    { "pattern": "/Users/dan/Frontend/*", "pack": "glados" },
+    { "pattern": "*/backend/*", "pack": "sc_kerrigan" }
+  ]
+}
+```
+
+Patterns use Python `fnmatch` glob syntax. First matching rule wins. Path rules override `default_pack` and `pack_rotation` but are overridden by `session_override` (agentskill) assignments.
+
 ## List available packs
 
 To show available packs, run:


### PR DESCRIPTION
Summary:

  The path_rules config key and fnmatch matching already existed in the event handler. This adds the CLI convenience layer so users don't have  to hand-edit JSON.

  - Add `peon packs bind <pack>` to permanently associate a sound pack with the current working directory via path_rules in config
  - Add `peon packs unbind` to remove bindings, with `--pattern` option for targeting  specific rules
  - Add peon packs bindings to list all directory-to-pack bindings (marks active matches with *)
  - Support --pattern flag for custom globs and --install to auto-download missing packs
  - Fix default pattern to use exact cwd match (not $PWD/*) so Claude's cwd field matches correctly

Files changed:
  - peon.sh: bind), unbind), bindings) cases in packs dispatch
  - completions.bash / completions.fish: tab completion for new subcommands
  - skills/peon-ping-config/SKILL.md: documents path_rules and new CLI
  - tests/peon.bats — 12 new tests (bind, unbind, bindings, edge cases, end-to-end)

Test Plan:
  - All 12 new bind/unbind/bindings BATS tests pass
  - No regressions in existing 240+ tests
  - Manual QA: peon packs bind <pack> in a directory, start Claude session, verify correct pack plays
  - Tab completion: peon packs bind <TAB> lists installed packs (bash and fish)
  
  references issue [275](https://github.com/PeonPing/peon-ping/issues/275)
