### PR TITLE
fix: relay does not apply local notification position/dismiss settings

### DIFF
--- a/relay.sh
+++ b/relay.sh
@@ -394,11 +394,12 @@ def send_notification_on_host(title, message, color="red"):
     notify_script = os.path.join(PEON_DIR, "scripts", "notify.sh")
     if os.path.isfile(notify_script):
         config = load_config()
-        notif_style = config.get("notification_style", "overlay")
         icon_path = os.path.join(PEON_DIR, "docs", "peon-icon.png")
         env = os.environ.copy()
         env["PEON_PLATFORM"] = HOST_PLATFORM
-        env["PEON_NOTIF_STYLE"] = notif_style
+        env["PEON_NOTIF_STYLE"] = config.get("notification_style", "overlay")
+        env["PEON_NOTIF_POSITION"] = config.get("notification_position", "top-center")
+        env["PEON_NOTIF_DISMISS"] = str(config.get("notification_dismiss_seconds", 4))
         env["PEON_DIR"] = PEON_DIR
         env["PEON_SYNC"] = os.environ.get("PEON_TEST", "0")
         subprocess.Popen(


### PR DESCRIPTION
relay.sh's send_notification_on_host() only set PEON_NOTIF_STYLE when calling notify.sh, omitting PEON_NOTIF_POSITION and PEON_NOTIF_DISMISS. This meant the host's config.json settings for notification_position and notification_dismiss_seconds were never applied to relay-triggered notifications.

Read notification_position and notification_dismiss_seconds from local config.json and pass them as env vars to notify.sh. Also accept optional overrides from the POST /notify JSON payload.