### PR TITLE
fix: resolve Windows install failures (#292)

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -838,14 +838,23 @@ $adapterFiles = @(
     "kimi.ps1", "opencode.ps1", "kilo.ps1"
 )
 
-$sourceAdaptersDir = Join-Path $PSScriptRoot "adapters"
+$sourceAdaptersDir = Join-Path $ScriptDir "adapters"
 foreach ($adapterFile in $adapterFiles) {
+    $destPath = Join-Path $adaptersDir $adapterFile
     $sourcePath = Join-Path $sourceAdaptersDir $adapterFile
     if (Test-Path $sourcePath) {
-        $destPath = Join-Path $adaptersDir $adapterFile
+        # Local install: copy from repo
         Copy-Item $sourcePath $destPath -Force
-        Unblock-File -Path $destPath -ErrorAction SilentlyContinue
+    } else {
+        # One-liner install: download from GitHub
+        try {
+            Invoke-WebRequest -Uri "$RepoBase/adapters/$adapterFile" -OutFile $destPath -UseBasicParsing -ErrorAction Stop
+        } catch {
+            Write-Host "  Warning: Could not download adapter $adapterFile" -ForegroundColor Yellow
+            continue
+        }
     }
+    Unblock-File -Path $destPath -ErrorAction SilentlyContinue
 }
 Write-Host "  Installed $($adapterFiles.Count) adapter scripts to $adaptersDir"
 


### PR DESCRIPTION
Fixes #292 — Windows installation failures after adding PowerShell adapters.

## Changes

**Bug 1: Empty string error**
- Changed `$PSScriptRoot` to `$ScriptDir` for adapter path construction
- `$PSScriptRoot` is empty when piped via `Invoke-Expression` (one-liner install)

**Bug 2: Execution policy blocking unsigned scripts**
- Added `Unblock-File` call after both copy and download paths
- Removes the Zone.Identifier alternate data stream (internet download mark)
- Works without requiring admin rights or global execution policy changes

**For one-liner installs:**
- Added GitHub download fallback when local adapter files don't exist
- Graceful warning if individual adapter downloads fail

## Testing
- Local install: adapter copy path still works
- One-liner install: download fallback + Unblock-File should resolve both reported errors