### PR TITLE
feat: add mute/unmute as aliases for pause/resume

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,8 @@ Other CLI commands:
 ```bash
 peon pause                # Mute sounds
 peon resume               # Unmute sounds
+peon mute                 # Alias for 'pause'
+peon unmute               # Alias for 'resume'
 peon status               # Check if paused or active
 peon volume               # Show current volume
 peon volume 0.7           # Set volume (0.0–1.0)

--- a/README_ko.md
+++ b/README_ko.md
@@ -119,6 +119,8 @@ peon-ping은 [코딩 이벤트 사운드 팩 표준 (CESP)](https://github.com/P
 ```bash
 peon pause                # 소리 끄기
 peon resume               # 소리 켜기
+peon mute                 # 'pause'의 별칭
+peon unmute               # 'resume'의 별칭
 peon status               # 일시정지/활성 상태 확인
 peon volume               # 현재 볼륨 확인
 peon volume 0.7           # 볼륨 설정 (0.0–1.0)

--- a/README_zh.md
+++ b/README_zh.md
@@ -114,11 +114,13 @@ peon-ping 实现了 [编码事件语音包规范（CESP）](https://github.com/P
 
 ```bash
 peon pause                # 静音
+peon mute                 # 'pause' 的别名
 peon volume               # 查看当前音量
 peon volume 0.7           # 设置音量（0.0–1.0）
 peon rotation             # 查看当前轮换模式
 peon rotation random      # 设置轮换模式（random|round-robin|session_override）
 peon resume               # 取消静音
+peon unmute               # 'resume' 的别名
 peon status               # 查看暂停或活动状态
 peon packs list           # 列出已安装的语音包
 peon packs list --registry # 浏览注册表中所有可用语音包

--- a/completions.bash
+++ b/completions.bash
@@ -66,7 +66,7 @@ _peon_completions() {
   fi
 
   # Top-level commands
-  COMPREPLY=( $(compgen -W "pause resume toggle status volume rotation packs notifications mobile relay help" -- "$cur") )
+  COMPREPLY=( $(compgen -W "pause resume mute unmute toggle status volume rotation packs notifications mobile relay help" -- "$cur") )
   return 0
 }
 

--- a/completions.fish
+++ b/completions.fish
@@ -24,6 +24,8 @@ complete -c peon -f
 # Top-level commands (only when no subcommand given)
 complete -c peon -n __peon_no_subcommand -a pause -d "Mute sounds"
 complete -c peon -n __peon_no_subcommand -a resume -d "Unmute sounds"
+complete -c peon -n __peon_no_subcommand -a mute -d "Alias for 'pause' — mute sounds"
+complete -c peon -n __peon_no_subcommand -a unmute -d "Alias for 'resume' — unmute sounds"
 complete -c peon -n __peon_no_subcommand -a toggle -d "Toggle mute on/off"
 complete -c peon -n __peon_no_subcommand -a status -d "Show current status"
 complete -c peon -n __peon_no_subcommand -a volume -d "Get or set volume level"

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -126,7 +126,7 @@ Independent Controls:
 ## CLI Commands
 
 ```bash
-peon pause / resume / status
+peon pause / resume / mute / unmute / status
 peon volume [0.0-1.0]
 peon rotation [random|round-robin|session_override]
 peon packs list / use / install / next / remove

--- a/install.ps1
+++ b/install.ps1
@@ -349,14 +349,14 @@ if ($Command) {
             Write-Host "peon-ping: $state" -ForegroundColor Cyan
             return
         }
-        "^--pause$" {
+        "^--(pause|mute)$" {
             $raw = Get-Content $ConfigPath -Raw
             $raw = $raw -replace '"enabled"\s*:\s*(true|false)', '"enabled": false'
             Set-Content $ConfigPath -Value $raw -Encoding UTF8
             Write-Host "peon-ping: PAUSED" -ForegroundColor Yellow
             return
         }
-        "^--resume$" {
+        "^--(resume|unmute)$" {
             $raw = Get-Content $ConfigPath -Raw
             $raw = $raw -replace '"enabled"\s*:\s*(true|false)', '"enabled": true'
             Set-Content $ConfigPath -Value $raw -Encoding UTF8
@@ -473,6 +473,8 @@ if ($Command) {
             Write-Host "  --toggle       Toggle enabled/paused"
             Write-Host "  --pause        Pause sounds"
             Write-Host "  --resume       Resume sounds"
+            Write-Host "  --mute         Alias for --pause"
+            Write-Host "  --unmute       Alias for --resume"
             Write-Host "  --status       Show current status"
             Write-Host "  --packs        List available sound packs"
             Write-Host "  --pack [name]  Switch pack (or cycle)"
@@ -1245,6 +1247,8 @@ if ($Updating) {
     Write-Host "    peon --volume N   Set volume (0.0-1.0)"
     Write-Host "    peon --pause      Mute sounds"
     Write-Host "    peon --resume     Unmute sounds"
+    Write-Host "    peon --mute       Alias for --pause"
+    Write-Host "    peon --unmute     Alias for --resume"
     Write-Host "    peon --toggle     Toggle on/off"
     Write-Host ""
     Write-Host "  Start Claude Code and you'll hear: `"Ready to work?`"" -ForegroundColor Yellow

--- a/peon.sh
+++ b/peon.sh
@@ -793,8 +793,8 @@ sync_adapter_paused() {
 }
 
 case "${1:-}" in
-  pause)   touch "$PAUSED_FILE"; sync_adapter_paused; echo "peon-ping: sounds paused (run 'peon toggle' to unpause)"; exit 0 ;;
-  resume)  rm -f "$PAUSED_FILE"; sync_adapter_paused; echo "peon-ping: sounds resumed"; exit 0 ;;
+  pause|mute)   touch "$PAUSED_FILE"; sync_adapter_paused; echo "peon-ping: sounds paused (run 'peon toggle' to unpause)"; exit 0 ;;
+  resume|unmute)  rm -f "$PAUSED_FILE"; sync_adapter_paused; echo "peon-ping: sounds resumed"; exit 0 ;;
   toggle)
     if [ -f "$PAUSED_FILE" ]; then rm -f "$PAUSED_FILE"; echo "peon-ping: sounds resumed"
     else touch "$PAUSED_FILE"; echo "peon-ping: sounds paused (run 'peon toggle' to unpause)"; fi
@@ -2326,6 +2326,8 @@ Usage: peon <command>
 Commands:
   pause                Mute sounds
   resume               Unmute sounds
+  mute                 Alias for 'pause'
+  unmute               Alias for 'resume'
   toggle               Toggle mute on/off
   status               Check if paused or active
   volume [0.0-1.0]     Get or set volume level

--- a/tests/peon.bats
+++ b/tests/peon.bats
@@ -645,6 +645,21 @@ JSON
   [ ! -f "$TEST_DIR/.paused" ]
 }
 
+@test "mute creates .paused file" {
+  run bash "$PEON_SH" mute
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"sounds paused"* ]]
+  [ -f "$TEST_DIR/.paused" ]
+}
+
+@test "unmute removes .paused file" {
+  touch "$TEST_DIR/.paused"
+  run bash "$PEON_SH" unmute
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"sounds resumed"* ]]
+  [ ! -f "$TEST_DIR/.paused" ]
+}
+
 @test "status reports paused when .paused exists" {
   touch "$TEST_DIR/.paused"
   run bash "$PEON_SH" status


### PR DESCRIPTION
## Summary

- Adds `peon mute` / `peon unmute` as first-class aliases for `peon pause` / `peon resume`
- Uses bash case pattern matching (`pause|mute)`) to share the same code path — zero duplication
- `pause` and `resume` already describe themselves as "Mute sounds" and "Unmute sounds" in help text; this makes the CLI more intuitive

## Changes

- **peon.sh** — case patterns + help text
- **completions.bash** — added to command list
- **completions.fish** — added completion entries
- **install.ps1** — `--mute`/`--unmute` flags + help text (3 locations)
- **tests/peon.bats** — 2 new tests (`mute creates .paused file`, `unmute removes .paused file`)
- **README.md / README_zh.md / README_ko.md** — CLI reference
- **docs/public/llms.txt** — updated CLI command list

## Test plan

- [x] All 255 BATS tests pass (including the 2 new alias tests)
- [ ] CI: BATS on macOS + Pester on Windows