### PR TITLE
fix: don't mark adapter threads idle during cooldown

### DIFF
--- a/adapters/amp.sh
+++ b/adapters/amp.sh
@@ -201,7 +201,6 @@ check_idle_threads() {
       local last_stop
       last_stop=$(stop_time_get "$tid")
       if [ "$((now - last_stop))" -lt "$STOP_COOLDOWN" ]; then
-        thread_set "$tid" "idle"
         continue
       fi
 

--- a/adapters/antigravity.sh
+++ b/adapters/antigravity.sh
@@ -172,7 +172,6 @@ check_idle_sessions() {
       local last_stop
       last_stop=$(stop_time_get "$guid")
       if [ "$((now - last_stop))" -lt "$STOP_COOLDOWN" ]; then
-        guid_set "$guid" "idle"
         continue
       fi
 


### PR DESCRIPTION
## Bug

In `amp.sh` and `antigravity.sh`, the cooldown branch (which prevents
duplicate Stop events from firing too quickly) incorrectly marked the
thread/guid as `"idle"` before skipping:

```sh
if [ "$((now - last_stop))" -lt "$STOP_COOLDOWN" ]; then
  thread_set "$tid" "idle"   # ← bug
  continue
fi
```

Because `check_idle_threads` only processes `"active"` threads (line 188),
marking it `"idle"` here means: if an agent starts and completes a second
task within `STOP_COOLDOWN` (10s) of the previous Stop, the idle checker
marks it idle and skips it forever — the Stop event for the second
completion is permanently lost.

## Fix

Remove the premature status change and just `continue`, keeping the thread
`"active"` so it gets re-checked once the cooldown expires. This matches
the correct behavior already in `kimi.sh`.

## Verification

- Traced step by step: agent finishes task 1 (Stop emitted, T=0), starts
  task 2 (marked active, T=2), finishes task 2 (T=4). At T=5 the cooldown
  branch fires — without the fix, thread becomes idle and Stop is dropped;
  with the fix, thread stays active and Stop fires at T=10 when cooldown
  clears.
- All 17 `bats tests/amp.bats` tests pass including the cooldown test.