### PR TITLE
fix: kill orphaned mac-overlay processes on SessionEnd

### DIFF
--- a/peon.sh
+++ b/peon.sh
@@ -3055,6 +3055,7 @@ elif event == 'SessionEnd':
     state_dirty = True
     os.makedirs(os.path.dirname(state_file) or '.', exist_ok=True)
     json.dump(state, open(state_file, 'w'))
+    print('EVENT=' + q(event))
     print('PEON_EXIT=true')
     sys.exit(0)
 else:
@@ -3307,7 +3308,13 @@ print('TAB_COLOR_RGB=' + q(tab_color_rgb))
 " <<< "$INPUT" 2>/dev/null)"
 
 # If Python signalled early exit (disabled, agent, unknown event), bail out
-[ "${PEON_EXIT:-true}" = "true" ] && exit 0
+if [ "${PEON_EXIT:-true}" = "true" ]; then
+  # On session end, kill any lingering overlay popups (macOS only)
+  if [ "${EVENT:-}" = "SessionEnd" ] && [ "$PLATFORM" = "mac" ]; then
+    pkill -f "mac-overlay" 2>/dev/null || true
+  fi
+  exit 0
+fi
 
 HEADPHONES_DETECTED=true
 if [ "${HEADPHONES_ONLY:-false}" = "true" ]; then


### PR DESCRIPTION
Fixes #299

## Problem

`osascript` processes running `mac-overlay.js` are launched in the background by `notify.sh`. When Claude Code exits, the `sessionEnd` hook fires and `peon.sh` exits early (via `PEON_EXIT=true`) without cleaning them up — leaving orphaned overlay processes running indefinitely (or until the dismiss timer fires, if one was set).

## Fix

Two small changes to `peon.sh`:

1. The Python `SessionEnd` early-exit path now outputs `EVENT=SessionEnd` before `PEON_EXIT=true`, making the event type available to the shell.
2. The shell early-exit check now calls `pkill -f "mac-overlay"` when it's a `SessionEnd` on macOS, clearing any lingering overlay popups.

```sh
if [ "${PEON_EXIT:-true}" = "true" ]; then
  if [ "${EVENT:-}" = "SessionEnd" ] && [ "$PLATFORM" = "mac" ]; then
    pkill -f "mac-overlay" 2>/dev/null || true
  fi
  exit 0
fi
```

All 255 `bats tests/peon.bats` tests pass.