### PR TITLE
Suppress subagent PermissionRequest notifications

### DIFF
--- a/peon.sh
+++ b/peon.sh
@@ -3009,6 +3009,12 @@ elif event == 'Notification':
         print('PEON_EXIT=true')
         sys.exit(0)
 elif event == 'PermissionRequest':
+    # Suppress permission sound/notification for known sub-agent sessions
+    if suppress_subagent_complete and session_id in state.get('subagent_sessions', {}):
+        os.makedirs(os.path.dirname(state_file) or '.', exist_ok=True)
+        json.dump(state, open(state_file, 'w'))
+        print('PEON_EXIT=true')
+        sys.exit(0)
     category = 'input.required'
     status = 'needs approval'
     marker = '\u25cf '

--- a/tests/peon.bats
+++ b/tests/peon.bats
@@ -498,6 +498,35 @@ print('absent' if 'sub4' not in subs else 'present')
   [ "$result" = "absent" ]
 }
 
+@test "suppress_subagent_complete: subagent PermissionRequest is suppressed" {
+  cat > "$TEST_DIR/config.json" <<'JSON'
+{ "active_pack": "peon", "volume": 0.5, "enabled": true, "categories": {}, "suppress_subagent_complete": true, "pack_rotation": ["peon","peon"] }
+JSON
+  # Parent session gets a SubagentStart (records pending_subagent_pack)
+  run_peon '{"hook_event_name":"SubagentStart","cwd":"/tmp/myproject","session_id":"parent5","permission_mode":"default"}'
+  # Subagent session starts within 30s — marked as subagent
+  run_peon '{"hook_event_name":"SessionStart","cwd":"/tmp/myproject","session_id":"sub5","permission_mode":"default"}'
+  count_before=$(afplay_call_count)
+  # Subagent PermissionRequest should be suppressed — no additional afplay calls
+  run_peon '{"hook_event_name":"PermissionRequest","cwd":"/tmp/myproject","session_id":"sub5","permission_mode":"default","tool_name":"Bash"}'
+  [ "$PEON_EXIT" -eq 0 ]
+  count_after=$(afplay_call_count)
+  [ "$count_after" = "$count_before" ]
+}
+
+@test "suppress_subagent_complete: parent PermissionRequest still plays sound" {
+  cat > "$TEST_DIR/config.json" <<'JSON'
+{ "active_pack": "peon", "volume": 0.5, "enabled": true, "categories": {}, "suppress_subagent_complete": true, "pack_rotation": ["peon","peon"] }
+JSON
+  # Subagent flow: parent → SubagentStart → sub SessionStart
+  run_peon '{"hook_event_name":"SubagentStart","cwd":"/tmp/myproject","session_id":"parent6","permission_mode":"default"}'
+  run_peon '{"hook_event_name":"SessionStart","cwd":"/tmp/myproject","session_id":"sub6","permission_mode":"default"}'
+  # Parent session PermissionRequest should still play
+  run_peon '{"hook_event_name":"PermissionRequest","cwd":"/tmp/myproject","session_id":"parent6","permission_mode":"default","tool_name":"Bash"}'
+  [ "$PEON_EXIT" -eq 0 ]
+  afplay_was_called
+}
+
 # ============================================================
 # Update check
 # ============================================================


### PR DESCRIPTION
## Summary

Extends the existing `suppress_subagent_complete` guard to also cover `PermissionRequest` events. When a parent agent auto-handles subagent permissions, PeonPing no longer fires false-positive `input.required` sounds and desktop notifications.

- Adds the same `subagent_sessions` check from the `Stop` handler to `PermissionRequest`
- Adds two test cases mirroring the existing Stop suppression tests
- No new config keys — reuses `suppress_subagent_complete` since the intent is the same ("suppress subagent noise")

Fixes #306

## Test plan

- [x] `bats tests/peon.bats` — 257/257 pass
- [x] New test: subagent `PermissionRequest` is suppressed when `suppress_subagent_complete: true`
- [x] New test: parent `PermissionRequest` still plays sound (not accidentally suppressed)
- [x] Existing subagent Stop suppression tests unaffected