### PR TITLE
Add instructions that ffmpeg is required for WSL2 in Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ curl -fsSL https://raw.githubusercontent.com/PeonPing/peon-ping/main/install.sh 
 ⚠️ In WSL2, **ffmpeg** must be installed to use sound packs that use formats other than **WAV**. In Debian distros, install with
 
 ```sh
-sudo apt update; sudu apt install -y ffmpeg
+sudo apt update; sudo apt install -y ffmpeg
 ```
 
 ### Option 3: Installer for Windows

--- a/README_ko.md
+++ b/README_ko.md
@@ -56,7 +56,7 @@ curl -fsSL https://raw.githubusercontent.com/PeonPing/peon-ping/main/install.sh 
 ⚠️ WSL2에서는 **WAV** 이외 형식을 사용하는 사운드 팩을 사용하려면 **ffmpeg**를 설치해야 합니다. Debian 계열 배포판에서는 다음으로 설치하세요.
 
 ```sh
-sudo apt update; sudu apt install -y ffmpeg
+sudo apt update; sud0 apt install -y ffmpeg
 ```
 
 ### 방법 3: Windows 설치

--- a/README_zh.md
+++ b/README_zh.md
@@ -54,7 +54,7 @@ curl -fsSL https://raw.githubusercontent.com/PeonPing/peon-ping/main/install.sh 
 ⚠️ 在 WSL2 中，若要使用 **WAV** 以外格式的语音包，必须安装 **ffmpeg**。在 Debian 发行版中可使用以下命令安装：
 
 ```sh
-sudo apt update; sudu apt install -y ffmpeg
+sudo apt update; sudo apt install -y ffmpeg
 ```
 
 ### 方式三：Windows 安装


### PR DESCRIPTION
Fixes #308 

**ffmpeg** is required in WSL2 for all sound packs that are not in **WAV** format. See #308 for more info and for where this bug was introduced. Rather than a code fix, I figured noting it in the install info was the easiest fix.

I used AI to translate to ZH and KO then checked the translations in Google Translate.