### PR TITLE
Fix: Rovo Dev CLI installer handles empty events array and adds IDE detection

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1047,6 +1047,12 @@ eventHooks:
 ''' + peon_events
     with open(config_path, 'a') as f:
         f.write(hooks_block)
+elif 'events: []' in content or 'events:[]' in content:
+    # Empty events array — replace with our events
+    import re
+    content = re.sub(r'events:\s*\[\]', 'events:\n' + peon_events, content, count=1)
+    with open(config_path, 'w') as f:
+        f.write(content)
 else:
     # eventHooks exists — add rovodev.sh command to existing events,
     # or create new event entries for events that don't exist yet

--- a/peon.sh
+++ b/peon.sh
@@ -959,6 +959,25 @@ if os.path.isdir(opencode_dir):
     else:
         ides.append(('OpenCode', opencode_dir, 'detected (not set up)'))
 
+# Rovo Dev CLI: check if hooks are registered in config.yml
+rovodev_dir = os.path.join(home, '.rovodev')
+rovodev_config = os.path.join(rovodev_dir, 'config.yml')
+rovodev_config_yaml = os.path.join(rovodev_dir, 'config.yaml')
+if os.path.isdir(rovodev_dir):
+    config_file = rovodev_config if os.path.isfile(rovodev_config) else rovodev_config_yaml if os.path.isfile(rovodev_config_yaml) else None
+    if config_file:
+        try:
+            with open(config_file) as f:
+                content = f.read()
+            if 'rovodev.sh' in content:
+                ides.append(('Rovo Dev CLI', rovodev_dir, 'installed'))
+            else:
+                ides.append(('Rovo Dev CLI', rovodev_dir, 'detected (not set up)'))
+        except Exception:
+            ides.append(('Rovo Dev CLI', rovodev_dir, 'detected'))
+    else:
+        ides.append(('Rovo Dev CLI', rovodev_dir, 'detected (not set up)'))
+
 # Gemini CLI: check if hooks are registered in settings.json
 gemini_dir = os.environ.get('GEMINI_CONFIG_DIR', os.path.join(home, '.gemini'))
 gemini_settings = os.path.join(gemini_dir, 'settings.json')

--- a/tests/rovodev.bats
+++ b/tests/rovodev.bats
@@ -247,6 +247,25 @@ EOF
   teardown_install_env
 }
 
+@test "install: handles empty events array (events: [])" {
+  setup_install_env
+  mkdir -p "$INSTALL_HOME/.rovodev"
+  cat > "$INSTALL_HOME/.rovodev/config.yml" <<'EOF'
+eventHooks:
+  logFile: /Users/testuser/.rovodev/event_hooks.log
+  events: []
+EOF
+  bash "$CLONE_DIR/install.sh"
+  # events: [] should be replaced with actual events
+  ! grep -q 'events: \[\]' "$INSTALL_HOME/.rovodev/config.yml"
+  grep -q "rovodev.sh on_complete" "$INSTALL_HOME/.rovodev/config.yml"
+  grep -q "rovodev.sh on_error" "$INSTALL_HOME/.rovodev/config.yml"
+  grep -q "rovodev.sh on_tool_permission" "$INSTALL_HOME/.rovodev/config.yml"
+  # logFile preserved
+  grep -q "logFile:" "$INSTALL_HOME/.rovodev/config.yml"
+  teardown_install_env
+}
+
 @test "install: appends command to existing event, creates missing events" {
   setup_install_env
   mkdir -p "$INSTALL_HOME/.rovodev"


### PR DESCRIPTION
## Problem

The Rovo Dev CLI installer fails silently when the user's `~/.rovodev/config.yml` contains `events: []` (the default
config generated by Rovo Dev CLI). The Python YAML parser expects `- name:` entries but finds none, resulting in
events being inserted at the wrong position and corrupting the config.

Additionally, Rovo Dev CLI was not shown in the "Detected IDEs" list during `peon-ping-setup` or `peon status`.

## Fix

- **`install.sh`**: Added a new branch to detect `events: []` and replace the inline empty array with the peon-ping
event entries, preserving the rest of the config (e.g. `logFile`).
- **`peon.sh`**: Added Rovo Dev CLI to IDE detection — checks for `~/.rovodev/config.yml` or `config.yaml` and reports
whether hooks are installed, detected but not set up, or not found.
- **`tests/rovodev.bats`**: Added test case for the `events: []` scenario.

## Testing

All `bats tests/rovodev.bats` tests pass, including the new `events: []` test case. Manually verified on a real Rovo
Dev CLI installation.
```