### PR TITLE
fix: prevent /peon-ping-rename from bleeding across tabs in same project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Added
 - **`peon packs rotation clear`** — new subcommand to zero out the pack rotation in a single command. Sets `pack_rotation` to `[]` in config.json and syncs adapter configs. Closes #321.
 
+### Fixed
+- **`/peon-ping-rename` bleeds across tabs in same project** — names set in one terminal tab were appearing in all other tabs opened to the same project directory. Root cause: hooks run detached from the controlling terminal, so `tty` returned the same value across all tabs, collapsing the per-tab key. Switched to `$PPID` (Claude Code's process PID) as the stable tab identifier: different terminal tabs spawn separate Claude Code processes with different PIDs, while `/clear` within a tab reuses the same process. Composite key `ppid::cwd` replaces the previous `tty::cwd` key in `tty_names` state. Closes #325.
+
 
 ## v2.14.0 (2026-03-06)
 

--- a/peon.sh
+++ b/peon.sh
@@ -2727,8 +2727,9 @@ INPUT=$(cat)
 PAUSED=false
 [ -f "$PEON_DIR/.paused" ] && PAUSED=true
 
-# Capture TTY now (before stdin is consumed) so Python can store/read tty_names for rename persistence
-_PEON_HOOK_TTY="$(tty 2>/dev/null || true)"
+# Capture PPID before stdin is consumed — Claude Code's process PID, stable across /clear since the
+# process continues running. Different terminal tabs → different Claude Code processes → different PPIDs.
+_PEON_HOOK_PPID="${PPID:-}"
 
 # --- Single Python call: config, event parsing, agent detection, category routing, sound picking ---
 # Consolidates 5 separate python3 invocations into one for ~120-200ms faster hook response.
@@ -2741,7 +2742,7 @@ config_path = '$CONFIG_PY'
 state_file = '$STATE_PY'
 peon_dir = '$PEON_DIR_PY'
 paused = '$PAUSED' == 'true'
-hook_tty = '$_PEON_HOOK_TTY'
+hook_ppid = '$_PEON_HOOK_PPID'
 agent_modes = {'delegate'}
 state_dirty = False
 
@@ -2974,10 +2975,13 @@ if session_id:
     _sn_state = state.get('session_names', {}).get(session_id, '').strip()
     if _sn_state: project = re.sub(r'[^a-zA-Z0-9 ._-]', '', _sn_state[:50])
 
-# -0.5. TTY-based session name fallback — persists across /clear context resets in the same terminal
-if not project and hook_tty:
-    _sn_tty = state.get('tty_names', {}).get(hook_tty, '').strip()
-    if _sn_tty: project = re.sub(r'[^a-zA-Z0-9 ._-]', '', _sn_tty[:50])
+# -0.5. PPID-based session name fallback — persists across /clear (Claude Code process continues,
+# only session_id changes). Different terminal tabs spawn separate Claude Code processes → different PPIDs.
+# Composite key ppid::cwd adds project-level isolation as a safety net.
+hook_ppid_key = (hook_ppid + '::' + cwd) if hook_ppid else cwd
+if not project and hook_ppid_key:
+    _sn_ppid = state.get('tty_names', {}).get(hook_ppid_key, '').strip()
+    if _sn_ppid: project = re.sub(r'[^a-zA-Z0-9 ._-]', '', _sn_ppid[:50])
 
 # 0. CLAUDE_SESSION_NAME env var (per-terminal session override)
 if not project:

--- a/scripts/hook-handle-rename.sh
+++ b/scripts/hook-handle-rename.sh
@@ -24,8 +24,24 @@ except:
     print("default")
 ' 2>/dev/null || echo "default")
 
-# Capture TTY for persistent rename across context clears (/clear starts a new session_id)
-HOOK_TTY="$(tty 2>/dev/null || true)"
+# Capture PPID — Claude Code's process PID, stable across /clear (process continues, session_id changes).
+# Different terminal tabs spawn separate Claude Code processes → different PPIDs → no cross-tab bleed.
+HOOK_PPID="${PPID:-}"
+
+# Extract CWD from event JSON — combined with PPID for a composite key that isolates by process+project
+HOOK_CWD=$(echo "$INPUT" | python3 -c '
+import json, sys
+try:
+    data = json.load(sys.stdin)
+    cwd = data.get("cwd", "") or ""
+    roots = data.get("workspace_roots", [])
+    print(cwd or (roots[0] if roots else ""))
+except:
+    pass
+' 2>/dev/null || echo "")
+
+# Composite key: ppid::cwd (ppid for per-process isolation, cwd for project-level safety net)
+HOOK_PPID_KEY="${HOOK_PPID}${HOOK_CWD:+::${HOOK_CWD}}"
 
 # Extract prompt text
 PROMPT=$(echo "$INPUT" | python3 -c '
@@ -69,13 +85,13 @@ STATE="$PEON_DIR/.state.json"
 
 # Clear name if called with no argument (reset to auto-detect)
 if [ -z "$SESSION_NAME" ]; then
-  export PEON_ENV_STATE="$STATE" PEON_ENV_SESSION_ID="$SESSION_ID" PEON_ENV_HOOK_TTY="$HOOK_TTY"
+  export PEON_ENV_STATE="$STATE" PEON_ENV_SESSION_ID="$SESSION_ID" PEON_ENV_HOOK_PPID_KEY="$HOOK_PPID_KEY"
   python3 -c "
 import json, os
 
 state_path = os.environ.get('PEON_ENV_STATE', '')
 session_id = os.environ.get('PEON_ENV_SESSION_ID', '')
-hook_tty = os.environ.get('PEON_ENV_HOOK_TTY', '')
+hook_ppid_key = os.environ.get('PEON_ENV_HOOK_PPID_KEY', '')
 
 try:
     with open(state_path) as f:
@@ -85,13 +101,13 @@ except:
 
 if 'session_names' in state and session_id in state['session_names']:
     del state['session_names'][session_id]
-if hook_tty and 'tty_names' in state and hook_tty in state['tty_names']:
-    del state['tty_names'][hook_tty]
+if hook_ppid_key and 'tty_names' in state and hook_ppid_key in state['tty_names']:
+    del state['tty_names'][hook_ppid_key]
 with open(state_path, 'w') as f:
     json.dump(state, f, indent=2)
     f.write('\n')
 "
-  log "cleared name sessionId=$SESSION_ID tty=$HOOK_TTY"
+  log "cleared name sessionId=$SESSION_ID ppid_key=$HOOK_PPID_KEY"
   echo '{"continue": false, "user_message": "Session name cleared (auto-detect resumed)"}'
   exit 0
 fi
@@ -104,15 +120,15 @@ if [ -z "$SESSION_NAME" ]; then
   exit 0
 fi
 
-# Write session name to .state.json (by session_id AND tty for cross-clear-context persistence)
-export PEON_ENV_STATE="$STATE" PEON_ENV_SESSION_ID="$SESSION_ID" PEON_ENV_SESSION_NAME="$SESSION_NAME" PEON_ENV_HOOK_TTY="$HOOK_TTY"
+# Write session name to .state.json (by session_id AND ppid::cwd for cross-clear-context persistence)
+export PEON_ENV_STATE="$STATE" PEON_ENV_SESSION_ID="$SESSION_ID" PEON_ENV_SESSION_NAME="$SESSION_NAME" PEON_ENV_HOOK_PPID_KEY="$HOOK_PPID_KEY"
 python3 -c "
 import json, os
 
 state_path = os.environ.get('PEON_ENV_STATE', '')
 session_id = os.environ.get('PEON_ENV_SESSION_ID', '')
 session_name = os.environ.get('PEON_ENV_SESSION_NAME', '')
-hook_tty = os.environ.get('PEON_ENV_HOOK_TTY', '')
+hook_ppid_key = os.environ.get('PEON_ENV_HOOK_PPID_KEY', '')
 
 try:
     with open(state_path) as f:
@@ -124,11 +140,12 @@ if 'session_names' not in state:
     state['session_names'] = {}
 state['session_names'][session_id] = session_name
 
-# Also store by TTY so the name survives /clear (which generates a new session_id)
-if hook_tty:
+# Also store by ppid::cwd composite key so the name survives /clear (which generates a new session_id)
+# PPID isolates per Claude Code process; different terminal tabs have different PPIDs
+if hook_ppid_key:
     if 'tty_names' not in state:
         state['tty_names'] = {}
-    state['tty_names'][hook_tty] = session_name
+    state['tty_names'][hook_ppid_key] = session_name
 
 with open(state_path, 'w') as f:
     json.dump(state, f, indent=2)
@@ -138,6 +155,6 @@ with open(state_path, 'w') as f:
 # Immediately update tab title via ANSI escape (peon.sh will keep it updated on future events)
 printf '\033]0;%s\007' "• ${SESSION_NAME}: ready" > /dev/tty 2>/dev/null || true
 
-log "success name='$SESSION_NAME' sessionId=$SESSION_ID tty=$HOOK_TTY"
+log "success name='$SESSION_NAME' sessionId=$SESSION_ID ppid_key=$HOOK_PPID_KEY"
 echo "{\"continue\": false, \"user_message\": \"Session renamed to \\\"${SESSION_NAME}\\\"\"}"
 exit 0


### PR DESCRIPTION
Resolves merge conflict from PR #325 and applies the PPID-based tab isolation fix.

## What changed
- **Root cause**: Hooks run detached from the controlling terminal, so `tty` returned the same value for all tabs in the same Ghostty/iTerm window. With `tty::cwd` as the composite key, any two tabs in the same project directory shared the same `tty_names` entry — causing one tab's rename to appear in all others.
- **Fix**: Switched to `$PPID` (Claude Code's process PID) as the stable tab identifier in both `peon.sh` and `scripts/hook-handle-rename.sh`. Each terminal tab spawns a separate Claude Code process with a unique PID; `/clear` resets only the `session_id` while the process stays alive. New composite key: `ppid::cwd`.

## Tests
All 621 BATS tests pass.

Closes #325