### PR TITLE
fix: relay notification uses pack icon instead of hardcoded peon default

### DIFF
--- a/relay.sh
+++ b/relay.sh
@@ -399,7 +399,7 @@ def send_notification_on_host(title, message, color="red"):
     notify_script = os.path.join(PEON_DIR, "scripts", "notify.sh")
     if os.path.isfile(notify_script):
         config = load_config()
-        icon_path = os.path.join(PEON_DIR, "docs", "peon-icon.png")
+        icon_path = ""  # let notify.sh resolve pack icon via _resolve_pack_icon()
         env = os.environ.copy()
         env["PEON_PLATFORM"] = HOST_PLATFORM
         env["PEON_NOTIF_STYLE"] = config.get("notification_style", "overlay")


### PR DESCRIPTION
## Summary
- The relay's `send_notification_on_host()` hardcoded `peon-icon.png` as the notification icon, bypassing `notify.sh`'s `_resolve_pack_icon()` logic which resolves the active pack's icon from its `openpeon.json` manifest
- Pass an empty `icon_path` so `notify.sh` handles icon resolution itself (pack manifest icon → `icon.png` fallback → `peon-icon.png` fallback)

Follow-up to #326 which fixed the pack selection; this fixes the notification icon.

## Test plan
- [x] Set a non-default pack with a custom icon, send notification via relay (`curl -X POST "http://127.0.0.1:19998/notify" -H "Content-Type: application/json" -d '{"title":"test","message":"hello"}'`) — should show the active pack's icon, not the default peon icon

https://github.com/user-attachments/assets/0f0f616c-4e6a-4768-b243-2eb7ce193d6c

- [ ] Pack without a custom icon should still fall back to `peon-icon.png`