### PR TITLE
fix: peon ssh-audio reads/writes global config instead of project-local

### DIFF
--- a/peon.sh
+++ b/peon.sh
@@ -2202,7 +2202,7 @@ print('service=' + mn.get('service', ''))
       python3 -c "
 import json
 try:
-    cfg = json.load(open('$CONFIG_PY'))
+    cfg = json.load(open('$GLOBAL_CONFIG_PY'))
 except Exception:
     cfg = {}
 print('peon-ping: ssh audio mode ' + cfg.get('ssh_audio_mode', 'relay'))
@@ -2215,7 +2215,7 @@ print('peon-ping: ssh audio mode ' + cfg.get('ssh_audio_mode', 'relay'))
     fi
     python3 -c "
 import json
-config_path = '$CONFIG_PY'
+config_path = '$GLOBAL_CONFIG_PY'
 mode = '$SSH_MODE_ARG'
 try:
     cfg = json.load(open(config_path))


### PR DESCRIPTION
## Summary

- `peon ssh-audio [mode]` was reading and writing `$CONFIG_PY`, which resolves to a project-local `config.json` if one exists in the current working directory
- SSH audio routing mode is a per-machine preference, not per-project — it should use `$GLOBAL_CONFIG_PY` (the install-level config), consistent with other user-wide CLI commands (`peon trainer`, `peon mobile`, `peon packs rotation`)
- Without this fix, running `peon ssh-audio auto` from a project with a local config override silently writes the setting there, and the mode falls back to `relay` in all other projects