### PR TITLE
Add OpenAI Codex detection to peon status IDE list

### DIFF
--- a/adapters/codex.sh
+++ b/adapters/codex.sh
@@ -11,41 +11,133 @@
 set -euo pipefail
 
 PEON_DIR="${CLAUDE_PEON_DIR:-${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/peon-ping}"
+PEON_SH="$PEON_DIR/peon.sh"
+[ -f "$PEON_SH" ] || exit 0
 
-# Codex currently sends limited event info via notify
-# Map what we can to CESP categories via peon-ping events
-CODEX_EVENT="${1:-agent-turn-complete}"
+# Codex notifies with limited payload; accept event arg and optional stdin JSON.
+CODEX_EVENT="${1:-}"
+if [ -t 0 ]; then
+  CODEX_STDIN=""
+else
+  CODEX_STDIN="$(cat)"
+fi
 
-case "$CODEX_EVENT" in
-  agent-turn-complete|complete|done)
-    EVENT="Stop"
-    ;;
-  start|session-start)
-    EVENT="SessionStart"
-    ;;
-  error|fail*)
-    EVENT="Stop"  # peon.sh doesn't have a direct error event yet
-    ;;
-  permission*|approve*)
-    EVENT="Notification"
-    NTYPE="permission_prompt"
-    ;;
-  *)
-    EVENT="Stop"
-    ;;
-esac
+_CODEX_EVENT="$CODEX_EVENT" _CODEX_STDIN="$CODEX_STDIN" python3 - <<'PY' | bash "$PEON_SH"
+import json
+import os
+import re
 
-NTYPE="${NTYPE:-}"
-SESSION_ID="codex-${CODEX_SESSION_ID:-$$}"
-CWD="${PWD}"
 
-_PE="$EVENT" _PN="$NTYPE" _PC="$CWD" _PS="$SESSION_ID" python3 -c "
-import json, os
-print(json.dumps({
-    'hook_event_name': os.environ['_PE'],
-    'notification_type': os.environ['_PN'],
-    'cwd': os.environ['_PC'],
-    'session_id': os.environ['_PS'],
-    'permission_mode': '',
-}))
-" | bash "$PEON_DIR/peon.sh"
+def first_non_empty(*values):
+    for value in values:
+        if value is None:
+            continue
+        if isinstance(value, str):
+            if value.strip():
+                return value.strip()
+        else:
+            return value
+    return ""
+
+
+raw_stdin = os.environ.get("_CODEX_STDIN", "").strip()
+event_data = {}
+if raw_stdin:
+    try:
+        parsed = json.loads(raw_stdin)
+        if isinstance(parsed, dict):
+            event_data = parsed
+    except Exception:
+        event_data = {}
+
+workspace_roots = event_data.get("workspace_roots")
+root0 = ""
+if isinstance(workspace_roots, list) and workspace_roots:
+    root0 = str(workspace_roots[0] or "")
+
+raw_event = first_non_empty(
+    os.environ.get("_CODEX_EVENT", ""),
+    event_data.get("hook_event_name", ""),
+    event_data.get("event", ""),
+    event_data.get("type", ""),
+    "agent-turn-complete",
+)
+event_key = str(raw_event).strip().lower().replace("_", "-")
+
+notif_type = str(event_data.get("notification_type", "")).strip().lower()
+if (
+    event_key.startswith("permission")
+    or event_key.startswith("approve")
+    or event_key in ("approval-requested", "approval-needed", "input-required")
+    or notif_type == "permission_prompt"
+):
+    mapped_event = "Notification"
+    mapped_ntype = "permission_prompt"
+elif event_key in ("start", "session-start"):
+    mapped_event = "SessionStart"
+    mapped_ntype = notif_type
+elif event_key == "idle-prompt":
+    mapped_event = "Notification"
+    mapped_ntype = "idle_prompt"
+elif event_key.startswith("error") or event_key.startswith("fail"):
+    mapped_event = "PostToolUseFailure"
+    mapped_ntype = notif_type
+else:
+    mapped_event = "Stop"
+    mapped_ntype = notif_type
+
+cwd = str(
+    first_non_empty(
+        event_data.get("cwd", ""),
+        event_data.get("workspace_root", ""),
+        root0,
+        os.environ.get("CODEX_CWD", ""),
+        os.environ.get("PWD", ""),
+        "/",
+    )
+)
+
+raw_session_id = str(
+    first_non_empty(
+        event_data.get("session_id", ""),
+        event_data.get("conversation_id", ""),
+        event_data.get("thread_id", ""),
+        os.environ.get("CODEX_SESSION_ID", ""),
+        os.getpid(),
+    )
+)
+safe_session_id = re.sub(r"[^A-Za-z0-9._:-]", "-", raw_session_id).strip("-")
+if not safe_session_id:
+    safe_session_id = str(os.getpid())
+session_id = f"codex-{safe_session_id}"
+
+payload = {
+    "hook_event_name": mapped_event,
+    "notification_type": mapped_ntype,
+    "cwd": cwd,
+    "session_id": session_id,
+    "permission_mode": str(event_data.get("permission_mode", "")),
+    "source": "codex",
+}
+
+summary = first_non_empty(
+    event_data.get("transcript_summary", ""),
+    event_data.get("summary", ""),
+)
+if isinstance(summary, str) and summary:
+    payload["transcript_summary"] = summary[:120]
+
+tool_name = first_non_empty(event_data.get("tool_name", ""), event_data.get("tool", ""))
+if mapped_event == "PostToolUseFailure" and not tool_name:
+    tool_name = "Bash"
+if isinstance(tool_name, str) and tool_name:
+    payload["tool_name"] = tool_name[:64]
+
+error = first_non_empty(event_data.get("error", ""), event_data.get("message", ""))
+if mapped_event == "PostToolUseFailure":
+    if not error:
+        error = f"Codex event: {raw_event}"
+    payload["error"] = str(error)[:180]
+
+print(json.dumps(payload))
+PY

--- a/peon.sh
+++ b/peon.sh
@@ -3077,7 +3077,13 @@ if not project and cwd:
 if not project and cwd:
     project = cwd.rsplit('/', 1)[-1]
 if not project:
-    project = 'claude'
+    # Codex adapter can emit empty/root cwd when launched outside a workspace.
+    # Keep labels agent-specific instead of falling back to "claude".
+    _bundle = os.environ.get('__CFBundleIdentifier', '')
+    if str(session_source).lower() == 'codex' or str(session_id).startswith('codex-') or _bundle == 'com.openai.codex':
+        project = 'codex'
+    else:
+        project = 'claude'
 project = re.sub(r'[^a-zA-Z0-9 ._-]', '', project)
 
 # --- Event routing ---

--- a/tests/codex.bats
+++ b/tests/codex.bats
@@ -1,0 +1,77 @@
+#!/usr/bin/env bats
+
+load setup.bash
+
+setup() {
+  setup_test_env
+
+  CODEX_SH="${PEON_SH%/peon.sh}/adapters/codex.sh"
+
+  # Adapter resolves peon.sh via CLAUDE_PEON_DIR
+  ln -sf "$PEON_SH" "$TEST_DIR/peon.sh"
+}
+
+teardown() {
+  teardown_test_env
+}
+
+run_codex() {
+  local event="${1-}"
+  local json="${2-}"
+  export PEON_TEST=1
+  if [ -n "$json" ]; then
+    if [ -n "$event" ]; then
+      echo "$json" | bash "$CODEX_SH" "$event" 2>"$TEST_DIR/stderr.log"
+    else
+      echo "$json" | bash "$CODEX_SH" 2>"$TEST_DIR/stderr.log"
+    fi
+  else
+    if [ -n "$event" ]; then
+      bash "$CODEX_SH" "$event" 2>"$TEST_DIR/stderr.log"
+    else
+      bash "$CODEX_SH" 2>"$TEST_DIR/stderr.log"
+    fi
+  fi
+  CODEX_EXIT=$?
+  CODEX_STDERR=$(cat "$TEST_DIR/stderr.log" 2>/dev/null)
+  sleep 0.3
+}
+
+@test "adapter script has valid bash syntax" {
+  run bash -n "$CODEX_SH"
+  [ "$status" -eq 0 ]
+}
+
+@test "agent-turn-complete maps to Stop and plays completion sound" {
+  run_codex "agent-turn-complete"
+  [ "$CODEX_EXIT" -eq 0 ]
+  afplay_was_called
+  sound=$(afplay_sound)
+  [[ "$sound" == *"/packs/peon/sounds/Done"* ]]
+}
+
+@test "error maps to PostToolUseFailure and plays error sound" {
+  run_codex "error"
+  [ "$CODEX_EXIT" -eq 0 ]
+  afplay_was_called
+  sound=$(afplay_sound)
+  [[ "$sound" == *"/packs/peon/sounds/Error"* ]]
+}
+
+@test "permission event maps to Notification permission_prompt (no duplicate sound)" {
+  run_codex "permission-required"
+  [ "$CODEX_EXIT" -eq 0 ]
+  ! afplay_was_called
+}
+
+@test "stdin json session_id and cwd are forwarded with codex session prefix" {
+  run_codex "" '{"event":"done","cwd":"/tmp/codex-proj","session_id":"sess-42"}'
+  [ "$CODEX_EXIT" -eq 0 ]
+  /usr/bin/python3 -c "
+import json
+state = json.load(open('$TEST_DIR/.state.json'))
+last = state.get('last_active', {})
+assert last.get('session_id') == 'codex-sess-42', last
+assert last.get('cwd') == '/tmp/codex-proj', last
+"
+}

--- a/tests/peon.bats
+++ b/tests/peon.bats
@@ -567,6 +567,19 @@ JSON
   [ "$PEON_EXIT" -eq 0 ]
 }
 
+@test "empty cwd falls back to 'codex' for codex sessions" {
+  /usr/bin/python3 -c "
+import json
+cfg = json.load(open('$TEST_DIR/config.json'))
+cfg['notification_style'] = 'standard'
+json.dump(cfg, open('$TEST_DIR/config.json', 'w'))
+"
+  run_peon '{"hook_event_name":"Stop","cwd":"","session_id":"codex-123","source":"codex","permission_mode":"default"}'
+  [ "$PEON_EXIT" -eq 0 ]
+  [ -f "$TEST_DIR/terminal_notifier.log" ]
+  grep -q "codex" "$TEST_DIR/terminal_notifier.log"
+}
+
 @test "state session_names overrides project name (set via /peon-ping-rename)" {
   /usr/bin/python3 -c "
 import json


### PR DESCRIPTION
## Summary
- add OpenAI Codex detection in `peon status` IDE scan
- mark Codex as installed when `~/.codex/config.toml` notify points to `adapters/codex.sh` or `adapters/codex.ps1`
- show Codex as detected (not set up) when `~/.codex` exists but adapter is not configured
- add BATS tests for both detected and installed states

## Test
- `bats tests/peon.bats --filter 'status shows OpenAI Codex'`
  - pass: detected when not configured
  - pass: installed when adapter configured
