### PR TITLE
fix: avoid zsh warning in notifications test command

### DIFF
--- a/peon.sh
+++ b/peon.sh
@@ -1199,7 +1199,6 @@ print(f'peon-ping: label override set to \"{label}\"')
         sync_adapter_configs; exit 0 ;;
       test)
         # Read config to check if notifications are enabled and get style
-        local _py_out
         _py_out="$(python3 -c "
 import json, shlex, os
 q = shlex.quote


### PR DESCRIPTION
## Summary
- remove top-level `local _py_out` in `peon notifications test` branch
- keep behavior unchanged by using regular variable assignment

## Why
Using `local` outside a function causes zsh warning:
`local: can only be used in a function`

## Test
- run `peon notifications test` under zsh
- verify no warning is emitted and notification still appears