### PR TITLE
docs: add DeepAgents to llms.txt

### DIFF
--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -2,7 +2,7 @@
 
 > Game character voice lines + visual overlay notifications when your AI coding agent needs attention.
 
-peon-ping plays voice lines and shows bold on-screen overlay banners from Warcraft, StarCraft, Portal, Zelda, and 90+ other games when your AI coding agent finishes a task, needs permission, or hits an error. Works with Claude Code, Amp, GitHub Copilot, Cursor, OpenCode, Codex, Kiro, Kimi Code, Windsurf, and any MCP-compatible AI agent.
+peon-ping plays voice lines and shows bold on-screen overlay banners from Warcraft, StarCraft, Portal, Zelda, and 90+ other games when your AI coding agent finishes a task, needs permission, or hits an error. Works with Claude Code, Amp, GitHub Copilot, Cursor, OpenCode, Codex, Kiro, Kimi Code, Windsurf, DeepAgents, and any MCP-compatible AI agent.
 
 ## Links
 
@@ -77,6 +77,7 @@ MCP resources: `peon-ping://catalog`, `peon-ping://pack/{name}`
 - Google Antigravity
 - OpenClaw (via adapters/openclaw.sh — call with any CESP category or Claude Code event name)
 - Rovo Dev CLI (Atlassian — adapter for on_complete, on_error, on_tool_permission events)
+- DeepAgents (adapter — translates deepagents-cli events to CESP JSON)
 
 All adapters have native Windows PowerShell (.ps1) versions alongside the bash (.sh) originals. Filesystem watchers (Amp, Antigravity, Kimi) use .NET FileSystemWatcher on Windows instead of fswatch/inotifywait. The Windows installer (install.ps1) copies adapter scripts to ~/.claude/hooks/peon-ping/adapters/.
 


### PR DESCRIPTION
## Summary
- Follow-up to #327 — adds DeepAgents adapter to the `docs/public/llms.txt` supported IDEs list
- Gary's review noted missing doc updates; READMEs were handled in 3cc9e0a, this covers the remaining `llms.txt`

Thanks for the help @garysheng !

## Test plan
- [x] Verify `docs/public/llms.txt` includes DeepAgents in both the intro line and the IDEs list

🤖 Generated with [Claude Code](https://claude.com/claude-code)