### PR TITLE
fix: MSYS2 sound playback — CRLF strip, PYTHONUTF8, win-play.ps1 download

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -135,6 +135,7 @@ detect_platform() {
 PLATFORM=$(detect_platform)
 
 # MSYS2/MinGW: Windows Python can't read /c/... paths — convert to C:/... via cygpath
+# Also set PYTHONUTF8=1 to avoid cp932/cp1252 codec errors when settings.json contains Unicode
 py_path() {
   if [ "$PLATFORM" = "msys2" ]; then
     cygpath -m "$1"
@@ -142,6 +143,9 @@ py_path() {
     printf '%s' "$1"
   fi
 }
+if [ "$PLATFORM" = "msys2" ]; then
+  export PYTHONUTF8=1
+fi
 
 # --- Detect update vs fresh install ---
 UPDATING=false
@@ -400,6 +404,7 @@ else
   mkdir -p "$INSTALL_DIR/scripts"
   curl -fsSL "$REPO_BASE/scripts/hook-handle-use.sh" -o "$INSTALL_DIR/scripts/hook-handle-use.sh" 2>/dev/null || true
   curl -fsSL "$REPO_BASE/scripts/hook-handle-use.ps1" -o "$INSTALL_DIR/scripts/hook-handle-use.ps1" 2>/dev/null || true
+  curl -fsSL "$REPO_BASE/scripts/win-play.ps1" -o "$INSTALL_DIR/scripts/win-play.ps1" 2>/dev/null || true
   curl -fsSL "$REPO_BASE/scripts/hook-handle-rename.sh" -o "$INSTALL_DIR/scripts/hook-handle-rename.sh" 2>/dev/null || true
   curl -fsSL "$REPO_BASE/scripts/pack-download.sh" -o "$INSTALL_DIR/scripts/pack-download.sh" 2>/dev/null || true
   curl -fsSL "$REPO_BASE/scripts/mac-overlay.js" -o "$INSTALL_DIR/scripts/mac-overlay.js" 2>/dev/null || true

--- a/peon.sh
+++ b/peon.sh
@@ -141,7 +141,9 @@ GLOBAL_CONFIG="$PEON_DIR/config.json"
 STATE="$PEON_DIR/.state.json"
 
 # MSYS2/MinGW: Windows Python can't read /c/... paths — convert to C:/... via cygpath
+# Also set PYTHONUTF8=1 to avoid cp932/cp1252 codec errors when settings.json contains Unicode
 if [ "$PLATFORM" = "msys2" ]; then
+  export PYTHONUTF8=1
   CONFIG_PY="$(cygpath -m "$CONFIG")"
   GLOBAL_CONFIG_PY="$(cygpath -m "$GLOBAL_CONFIG")"
   STATE_PY="$(cygpath -m "$STATE")"

--- a/scripts/pack-download.sh
+++ b/scripts/pack-download.sh
@@ -321,6 +321,7 @@ print(len(seen))
     draw_progress "$PACK_INDEX" "$TOTAL_PACKS" "$pack" 0 "$SOUND_COUNT" 0
 
     while read -r sfile; do
+      sfile="${sfile%$'\r'}"  # strip Windows CRLF trailing CR (Python on Windows outputs \r\n)
       if ! is_safe_filename "$sfile"; then
         echo "  Warning: skipped unsafe filename in $pack: $sfile" >&2
         continue
@@ -382,6 +383,7 @@ for cat in m.get('categories', {}).values():
             seen.add(rel)
             print(rel)
 " | while read -r sfile; do
+      sfile="${sfile%$'\r'}"  # strip Windows CRLF trailing CR (Python on Windows outputs \r\n)
       if ! is_safe_filename "$sfile"; then
         echo "  Warning: skipped unsafe filename in $pack: $sfile" >&2
         continue


### PR DESCRIPTION
Fixes three bugs preventing sound playback on MSYS2/Git Bash (Windows), reported in #337.

## Changes

### 1. Strip CRLF in `pack-download.sh` read loops
Windows Python outputs `\r\n` line endings. The trailing `\r` caused `is_safe_filename()` to reject every filename with "Warning: skipped unsafe filename". Added `sfile="${sfile%$'\r'}"` after both `while read -r sfile` loops.

### 2. Export `PYTHONUTF8=1` for MSYS2 (`peon.sh` + `install.sh`)
Windows Python defaults to cp932/cp1252 encoding, causing `UnicodeDecodeError` when `settings.json` contains Unicode characters (e.g. Japanese text in hook commands). Setting `PYTHONUTF8=1` fixes all inline Python blocks in both scripts without hunting down individual `open()` calls.

### 3. Add `win-play.ps1` to the curl download list in `install.sh`
The installer downloaded all other scripts but never fetched `win-play.ps1`. Since MSYS2 has no native audio player, `play_sound()` falls back to `win-play.ps1` via `find_bundled_script()` — which failed silently because the file didn't exist. Added the curl line alongside the other PowerShell script download.

Closes #337