### PR TITLE
fix: pass semantic notify type to overlay themes (jarvis, glass, sakura)

### DIFF
--- a/peon.sh
+++ b/peon.sh
@@ -575,6 +575,7 @@ send_notification() {
         _resolve_session_tty
       fi
       export PEON_MSG_SUBTITLE="${MSG_SUBTITLE:-}"
+      export PEON_NOTIFY_TYPE="${NOTIFY_TYPE:-}"
       bash "$notify_script" "$msg" "$title" "$color" "$icon_path"
       ;;
     devcontainer|ssh)
@@ -3505,6 +3506,14 @@ print('STATUS=' + q(status))
 print('MARKER=' + q(marker))
 print('NOTIFY=' + q(notify))
 print('NOTIFY_COLOR=' + q(notify_color))
+_notify_type = ''
+if event == 'Stop': _notify_type = 'complete'
+elif event == 'PermissionRequest': _notify_type = 'permission'
+elif event == 'PreCompact': _notify_type = 'limit'
+elif event == 'Notification':
+    if ntype == 'idle_prompt': _notify_type = 'idle'
+    elif ntype == 'elicitation_dialog': _notify_type = 'question'
+print('NOTIFY_TYPE=' + q(_notify_type))
 print('MSG=' + q(msg))
 print('MSG_SUBTITLE=' + q(msg_subtitle))
 print('DESKTOP_NOTIF=' + ('true' if desktop_notif else 'false'))

--- a/scripts/mac-overlay-glass.js
+++ b/scripts/mac-overlay-glass.js
@@ -14,14 +14,24 @@ function run(argv) {
   if (isNaN(dismiss)) dismiss = 5;
   var bundleId   = argv[5] || '';
   var idePid     = parseInt(argv[6], 10) || 0;
-  var sessionTty = argv[7] || '';  // TTY of the Claude session (for window focus)
-  var subtitle   = argv[8] || '';  // Context subtitle (e.g. tool info, last message)
+  var sessionTty  = argv[7] || '';  // TTY of the Claude session (for window focus)
+  var subtitle    = argv[8] || '';  // Context subtitle (e.g. tool info, last message)
+  var notifType   = argv[10] || ''; // Semantic type: complete|permission|limit|idle|question
 
   // ── Type text ──
-  var typeText = 'INPUT REQUIRED';
-  if (color === 'red') typeText = 'LIMIT REACHED';
-  if (color === 'yellow') typeText = 'LIMIT REACHED';
-  if (color === 'green') typeText = 'TASK COMPLETE';
+  var typeText;
+  switch (notifType) {
+    case 'complete':   typeText = 'TASK COMPLETE';   break;
+    case 'permission': typeText = 'APPROVAL NEEDED'; break;
+    case 'limit':      typeText = 'LIMIT REACHED';   break;
+    case 'idle':       typeText = 'STANDING BY';     break;
+    case 'question':   typeText = 'INPUT REQUIRED';  break;
+    default:
+      // Fallback for relay.sh and other callers that don't set notifType
+      if (color === 'blue')   typeText = 'TASK COMPLETE';
+      else if (color === 'red' || color === 'yellow') typeText = 'LIMIT REACHED';
+      else                    typeText = 'INPUT REQUIRED';
+  }
 
   // ── Window dimensions ──
   var winW = 380, winH = 160;

--- a/scripts/mac-overlay-jarvis.js
+++ b/scripts/mac-overlay-jarvis.js
@@ -14,8 +14,9 @@ function run(argv) {
   if (isNaN(dismiss)) dismiss = 5;
   var bundleId   = argv[5] || '';
   var idePid     = parseInt(argv[6], 10) || 0;
-  var sessionTty = argv[7] || '';  // TTY of the Claude session (for window focus)
-  var subtitle   = argv[8] || '';  // Context subtitle (e.g. tool info, last message)
+  var sessionTty  = argv[7] || '';  // TTY of the Claude session (for window focus)
+  var subtitle    = argv[8] || '';  // Context subtitle (e.g. tool info, last message)
+  var notifType   = argv[10] || ''; // Semantic type: complete|permission|limit|idle|question
 
   var accentR = 0.0, accentG = 0.75, accentB = 1.0;
   switch (color) {
@@ -25,10 +26,19 @@ function run(argv) {
     case 'blue':   accentR = 0.0;  accentG = 0.75; accentB = 1.0;  break;
   }
 
-  var typeText = 'INPUT REQUIRED';
-  if (color === 'red') typeText = 'LIMIT REACHED';
-  if (color === 'yellow') typeText = 'LIMIT REACHED';
-  if (color === 'green') typeText = 'TASK COMPLETE';
+  var typeText;
+  switch (notifType) {
+    case 'complete':   typeText = 'TASK COMPLETE';   break;
+    case 'permission': typeText = 'APPROVAL NEEDED'; break;
+    case 'limit':      typeText = 'LIMIT REACHED';   break;
+    case 'idle':       typeText = 'STANDING BY';     break;
+    case 'question':   typeText = 'INPUT REQUIRED';  break;
+    default:
+      // Fallback for relay.sh and other callers that don't set notifType
+      if (color === 'blue')   typeText = 'TASK COMPLETE';
+      else if (color === 'red' || color === 'yellow') typeText = 'LIMIT REACHED';
+      else                    typeText = 'INPUT REQUIRED';
+  }
 
   var circleSize = 300;
   var padding = 20;

--- a/scripts/mac-overlay-sakura.js
+++ b/scripts/mac-overlay-sakura.js
@@ -14,16 +14,26 @@ function run(argv) {
   if (isNaN(dismiss)) dismiss = 5;
   var bundleId   = argv[5] || '';
   var idePid     = parseInt(argv[6], 10) || 0;
-  var sessionTty = argv[7] || '';  // TTY of the Claude session (for window focus)
-  var subtitle   = argv[8] || '';  // Context subtitle (e.g. tool info, last message)
+  var sessionTty  = argv[7] || '';  // TTY of the Claude session (for window focus)
+  var subtitle    = argv[8] || '';  // Context subtitle (e.g. tool info, last message)
+  var notifType   = argv[10] || ''; // Semantic type: complete|permission|limit|idle|question
 
   var PI = Math.PI, TAU = 2 * PI;
 
   // ── Type text ──
-  var typeText = 'INPUT REQUIRED';
-  if (color === 'red') typeText = 'LIMIT REACHED';
-  if (color === 'yellow') typeText = 'LIMIT REACHED';
-  if (color === 'green') typeText = 'TASK COMPLETE';
+  var typeText;
+  switch (notifType) {
+    case 'complete':   typeText = 'TASK COMPLETE';   break;
+    case 'permission': typeText = 'APPROVAL NEEDED'; break;
+    case 'limit':      typeText = 'LIMIT REACHED';   break;
+    case 'idle':       typeText = 'STANDING BY';     break;
+    case 'question':   typeText = 'INPUT REQUIRED';  break;
+    default:
+      // Fallback for relay.sh and other callers that don't set notifType
+      if (color === 'blue')   typeText = 'TASK COMPLETE';
+      else if (color === 'red' || color === 'yellow') typeText = 'LIMIT REACHED';
+      else                    typeText = 'INPUT REQUIRED';
+  }
 
   // ── Window dimensions ──
   var winW = 360, winH = 180;

--- a/scripts/notify.sh
+++ b/scripts/notify.sh
@@ -190,8 +190,9 @@ case "$PEON_PLATFORM" in
         local subtitle="${PEON_MSG_SUBTITLE:-}"
         local dismiss_secs="${PEON_NOTIF_DISMISS:-4}"
         local notif_position="${PEON_NOTIF_POSITION:-top-center}"
-        # argv[5]=bundle_id, argv[6]=ide_pid, argv[7]=session_tty, argv[8]=subtitle, argv[9]=position
-        osascript -l JavaScript "$overlay_script" "$msg" "$color" "$local_icon_arg" "$slot" "$dismiss_secs" "$bundle_id" "$ide_pid" "$session_tty" "$subtitle" "$notif_position" >/dev/null 2>&1 &
+        local notify_type="${PEON_NOTIFY_TYPE:-}"
+        # argv[5]=bundle_id, argv[6]=ide_pid, argv[7]=session_tty, argv[8]=subtitle, argv[9]=position, argv[10]=notify_type
+        osascript -l JavaScript "$overlay_script" "$msg" "$color" "$local_icon_arg" "$slot" "$dismiss_secs" "$bundle_id" "$ide_pid" "$session_tty" "$subtitle" "$notif_position" "$notify_type" >/dev/null 2>&1 &
         local _overlay_pid=$!
         # Shell-level watchdog: kill if JXA terminate timer doesn't fire (macOS regression)
         local _max_wait


### PR DESCRIPTION
## Problem

The themed overlay scripts (`mac-overlay-jarvis.js`, `mac-overlay-glass.js`, `mac-overlay-sakura.js`) all derive their `typeText` banner label from the notification **color** alone. However, multiple distinct events share the same color, so the label was frequently wrong:

| Event | Color | Was showing | Should show |
|-------|-------|-------------|-------------|
| `Stop` (task done) | `blue` | INPUT REQUIRED ❌ | TASK COMPLETE |
| `PermissionRequest` | `red` | LIMIT REACHED ❌ | APPROVAL NEEDED |
| `PreCompact` | `red` | LIMIT REACHED ✅ | LIMIT REACHED |
| Idle prompt | `yellow` | LIMIT REACHED ❌ | STANDING BY |
| `elicitation_dialog` | `blue` | INPUT REQUIRED ✅ | INPUT REQUIRED |

`green` was mapped to "TASK COMPLETE" but no event actually sends `green`, so that branch was dead code.

## Fix

Added a `NOTIFY_TYPE` semantic variable that flows through the stack:

1. **`peon.sh`** — Python event-routing block emits `NOTIFY_TYPE` (`complete` / `permission` / `limit` / `idle` / `question`) alongside `NOTIFY_COLOR`, then exports it as `PEON_NOTIFY_TYPE` before calling `send_notification`.
2. **`scripts/notify.sh`** — reads `PEON_NOTIFY_TYPE` and passes it as `argv[10]` to the overlay script.
3. **All three themed overlays** — switch on `argv[10]` (`notifType`) for the label, with a color-based fallback preserved for `relay.sh` and other callers that don't set `PEON_NOTIFY_TYPE`.

## Test plan

- [ ] Trigger a task completion (`Stop`) — overlay should show **TASK COMPLETE**
- [ ] Trigger a permission request — overlay should show **APPROVAL NEEDED**
- [ ] Trigger a `PreCompact` (context compacting) — overlay should show **LIMIT REACHED**
- [ ] Trigger an idle prompt — overlay should show **STANDING BY**
- [ ] Trigger an elicitation dialog (`/ask`) — overlay should show **INPUT REQUIRED**
- [ ] Verify relay.sh path still works (color-based fallback for callers that omit `argv[10]`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)