### PR TITLE
docs: add missing 'name' field to Kiro setup config

### DIFF
--- a/README.md
+++ b/README.md
@@ -744,6 +744,7 @@ Create `~/.kiro/agents/peon-ping.json`:
 
 ```json
 {
+  "name": "peon-ping",
   "hooks": {
     "agentSpawn": [
       { "command": "bash ~/.claude/hooks/peon-ping/adapters/kiro.sh" }


### PR DESCRIPTION
Fixes error when loading Kiro agent configuration: Error: Json supplied at ~/.kiro/agents/peon-ping.json is invalid: missing field `name` at line 13 column 1

The Kiro agent configuration requires a 'name' field at the top level. This adds the required field to match the working configuration format.