### PR TITLE
Fix aplay usage for non-WAV files (MP3/OGG support)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -823,7 +823,11 @@ except Exception:
       elif command -v mpv &>/dev/null; then
         mpv --no-video --volume=30 "$TEST_SOUND" 2>/dev/null
       elif command -v aplay &>/dev/null; then
-        aplay -q "$TEST_SOUND" 2>/dev/null
+        if [[ "$TEST_SOUND" == *.wav ]]; then
+          aplay -q "$TEST_SOUND" 2>/dev/null
+        else
+          echo "Warning: aplay found but test sound is not WAV. Install pw-play, paplay, ffplay, mpv, or play (SoX)."
+        fi
       fi
     fi
     echo "Sound working!"

--- a/peon.sh
+++ b/peon.sh
@@ -132,6 +132,14 @@ play_linux_sound() {
       fi
       ;;
     aplay)
+      if [[ "$file" != *.wav ]]; then
+        # aplay only supports WAV (and raw). If we try to play mp3/ogg, it will likely fail or play static.
+        if [ -z "${WARNED_APLAY_FORMAT:-}" ]; then
+          echo "Warning: aplay can only play WAV files, but '$file' is not a WAV. Install pw-play, paplay, ffplay, mpv, or play (SoX) for better support." >&2
+          WARNED_APLAY_FORMAT=1
+        fi
+        return 0
+      fi
       if [ "$use_bg" = true ]; then
         nohup aplay -q "$file" >/dev/null 2>&1 &
       else


### PR DESCRIPTION
Added file extension check in `peon.sh` and `install.sh` to warn if `aplay` attempts to play non-WAV files (which fails or produces static). Also improved `install.sh` test sound logic.

---
*Automated PR created by OpenClaw daily-pr routine (Backlog queue).*