### PR TITLE
feat(nix): support custom pack sources in installPacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+### Added
+- **Nix/Home Manager: custom pack sources** — `installPacks` now accepts both simple strings (for og-packs) and attribute sets with `name` and `src` fields to install packs from any source. The `src` field accepts any Nix fetcher result (e.g., `pkgs.fetchFromGitHub`), enabling community packs from the [openpeon.com registry](https://openpeon.com/) that aren't in og-packs while maintaining full reproducibility.
+
 ## v2.15.1 (2026-03-09)
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -148,7 +148,23 @@ in {
       };
     };
 
-    installPacks = [ "peon" "glados" "sc_kerrigan" ];
+    # Install packs from og-packs (simple string notation)
+    # and custom sources (attrset with name + src)
+    installPacks = [
+      "peon"
+      "glados"
+      "sc_kerrigan"
+      # Custom pack from GitHub (openpeon.com registry)
+      {
+        name = "mr_meeseeks";
+        src = pkgs.fetchFromGitHub {
+          owner = "kasperhendriks";
+          repo = "openpeon-mrmeeseeks";
+          rev = "main";  # or use a commit hash for reproducibility
+          sha256 = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+        };
+      }
+    ];
     enableZshIntegration = true;
   };
 
@@ -163,7 +179,24 @@ in {
 }
 ```
 
-Note: peon-ping Home Manager module will not setup your IDE hooks to avoid conflicting updates. You must define these hooks yourself (see example above) depending on how you usually manage your IDE configuration.
+**Sound pack installation**: The `installPacks` option supports two formats:
+- **Simple strings** (e.g., `"peon"`, `"glados"`) — fetched from the [og-packs](https://github.com/PeonPing/og-packs) repository
+- **Custom sources** — attrset with `name` and `src` fields, where `src` can be any Nix fetcher result (e.g., `pkgs.fetchFromGitHub`)
+
+For packs listed on [openpeon.com](https://openpeon.com/), find the GitHub repository link and use `pkgs.fetchFromGitHub`:
+```nix
+{
+  name = "pack_name";
+  src = pkgs.fetchFromGitHub {
+    owner = "github-owner";
+    repo = "repo-name";
+    rev = "main";  # or a commit hash/tag
+    sha256 = "";   # Leave empty first, Nix will tell you the correct hash
+  };
+}
+```
+
+**IDE hooks**: peon-ping Home Manager module will not setup your IDE hooks to avoid conflicting updates. You must define these hooks yourself (see example above) depending on how you usually manage your IDE configuration.
 - peon-ping provide adapters scripts for various IDE such as `cursor.sh` - see [`adapters/`](https://github.com/PeonPing/peon-ping/tree/main/adapters)
 - You need to call them as your hook such command like
   ```sh

--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -60,13 +60,47 @@ in
     };
 
     installPacks = mkOption {
-      type = types.listOf types.str;
+      type = types.listOf (types.either types.str (types.submodule {
+        options = {
+          name = mkOption {
+            type = types.str;
+            description = "Name of the sound pack (used as directory name in ~/.openpeon/packs/)";
+          };
+          src = mkOption {
+            type = types.either types.package types.path;
+            description = ''
+              Source for the pack. Can be:
+              - A path to a local directory
+              - Result of fetchFromGitHub, fetchzip, etc.
+            '';
+          };
+        };
+      }));
       default = [ ];
       description = ''
-        List of sound pack names to install automatically - fetched from the og-packs repository.
-        Common packs: peon, glados, sc_kerrigan, murloc, witcher
+        List of sound packs to install automatically.
+
+        Can be either:
+        - A string (pack name from og-packs): "peon", "glados", etc.
+        - An attrset with name and src fields for custom packs
+
+        Common og-packs: peon, glados, sc_kerrigan, murloc, witcher
       '';
-      example = literalExpression ''[ "peon" "glados" ]'';
+      example = literalExpression ''
+        [
+          "peon"
+          "glados"
+          {
+            name = "mr_meeseeks";
+            src = pkgs.fetchFromGitHub {
+              owner = "kasperhendriks";
+              repo = "openpeon-mrmeeseeks";
+              rev = "main";  # or a commit hash
+              sha256 = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+            };
+          }
+        ]
+      '';
     };
 
     enableZshIntegration = mkOption {
@@ -107,11 +141,17 @@ in
     # Overrides any config.json that may be present in the package.
     home.file.".openpeon/config.json".source = jsonFormat.generate "peon-ping-config" cfg.settings;
 
-    # Install sound packs directly from og-packs repository
-    home.file.".openpeon/packs" = lib.mkIf (cfg.installPacks != [ ]) {
+    # Install sound packs from og-packs and/or custom sources
+    home.file.".openpeon/packs" = lib.mkIf (cfg.installPacks != [ ]) (let
+      # Separate string pack names (og-packs) from custom pack specs
+      ogPacks = lib.filter (p: lib.isString p) cfg.installPacks;
+      customPacks = lib.filter (p: lib.isAttrs p) cfg.installPacks;
+    in {
       source = pkgs.runCommand "peon-packs" { } ''
         set -euo pipefail
         mkdir -p $out
+
+        # Install packs from og-packs
         ${lib.concatMapStringsSep "\n" (packName: ''
           if [ -d "${ogPacksSrc}/og-packs-${ogPacksVersion}/${packName}" ]; then
             cp -r "${ogPacksSrc}/og-packs-${ogPacksVersion}/${packName}" $out/
@@ -119,9 +159,19 @@ in
             echo "Error: Pack '${packName}' not found in og-packs" >&2
             exit 1
           fi
-        '') cfg.installPacks}
+        '') ogPacks}
+
+        # Install custom packs
+        ${lib.concatMapStringsSep "\n" (pack: ''
+          if [ -d "${pack.src}" ]; then
+            cp -r "${pack.src}" "$out/${pack.name}"
+          else
+            echo "Error: Custom pack '${pack.name}' source not found" >&2
+            exit 1
+          fi
+        '') customPacks}
       '';
-    };
+    });
 
     # Shell completions
     programs.zsh.initExtra = mkIf cfg.enableZshIntegration ''


### PR DESCRIPTION
installPacks now accepts both strings (og-packs) and attrsets with name + src fields (any Nix fetcher). Enables community packs from openpeon.com while maintaining reproducibility.

Example:
```nix
installPacks = [
  "peon"  # From og-packs
  {
    name = "mr_meeseeks";
    src = pkgs.fetchFromGitHub {
      owner = "kasperhendriks";
      repo = "openpeon-mrmeeseeks";
      rev = "main";
      sha256 = "sha256-...";
    };
  }
];
```