### PR TITLE
fix: download pack icon assets referenced by manifests

### DIFF
--- a/scripts/pack-download.sh
+++ b/scripts/pack-download.sh
@@ -295,6 +295,23 @@ for p in data.get('packs', []):
   # Download sound files
   manifest="$PEON_DIR/packs/$pack/openpeon.json"
   manifest_py="$(py_path "$manifest")"
+  ICON_LIST=$(python3 -c "
+import json
+m = json.load(open('$manifest_py'))
+seen = []
+def add(v):
+    if not isinstance(v, str) or not v or v.startswith(('http://', 'https://')):
+        return
+    if v not in seen:
+        seen.append(v)
+add(m.get('icon'))
+for cat in m.get('categories', {}).values():
+    add(cat.get('icon'))
+    for s in cat.get('sounds', []):
+        add(s.get('icon'))
+for v in seen:
+    print(v)
+" 2>/dev/null || true)
   SOUND_COUNT=$(python3 -c "
 import json, posixpath
 m = json.load(open('$manifest_py'))
@@ -313,6 +330,22 @@ print(len(seen))
 
   CHECKSUMS_FILE="$PEON_DIR/packs/$pack/.checksums"
   touch "$CHECKSUMS_FILE"
+
+  if [ -n "$ICON_LIST" ]; then
+    while read -r ifile; do
+      ifile="${ifile%$'\r'}"  # strip Windows CRLF trailing CR (Python on Windows outputs \r\n)
+      [ -z "$ifile" ] && continue
+      if ! is_safe_filename "$ifile"; then
+        echo "  Warning: skipped unsafe icon path in $pack: $ifile" >&2
+        continue
+      fi
+      mkdir -p "$PEON_DIR/packs/$pack/$(dirname "$ifile")"
+      if ! curl -fsSL "$PACK_BASE/$(urlencode_filename "$ifile")" \
+           -o "$PEON_DIR/packs/$pack/$ifile" </dev/null 2>/dev/null; then
+        echo "  Warning: failed to download $pack/$ifile" >&2
+      fi
+    done <<< "$ICON_LIST"
+  fi
 
   if [ "$IS_TTY" = true ] && [ "$SOUND_COUNT" != "?" ]; then
     local_file_count=0


### PR DESCRIPTION
## Summary
- download icon assets referenced by pack, category, or sound-level manifest fields
- keep existing sound download flow unchanged
- preserve the existing filename safety and URL encoding checks

## Repro
1. Install a pack whose manifest contains a root-level icon asset, e.g. `high_elf_builder_ru` with `"icon": "icon.webp"`
2. Inspect `~/.claude/hooks/peon-ping/packs/high_elf_builder_ru/`
3. Before this patch, `openpeon.json` references `icon.webp` but the file is not downloaded

## After this patch
- manifest-referenced icon assets are downloaded alongside the pack contents, so pack icons resolve correctly in notifications

## Verified locally
- removed `high_elf_builder_ru`
- reinstalled it from the registry
- confirmed `openpeon.json` still references `icon.webp`
- confirmed `~/.claude/hooks/peon-ping/packs/high_elf_builder_ru/icon.webp` is now downloaded automatically
