### PR TITLE
fix: register hooks in project-level settings for --local installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,11 +71,11 @@ Useful installer flags:
 
 - `--all` — install all available packs
 - `--packs=peon,sc_kerrigan,...` — install specific packs only
-- `--local` — install packs and config into `./.claude/` for the current project (hooks are always registered globally in `~/.claude/settings.json`)
+- `--local` — install packs, config, and hooks into `./.claude/` for the current project
 - `--global` — explicit global install (same as default)
 - `--init-local-config` — create `./.claude/hooks/peon-ping/config.json` only
 
-`--local` does not modify your shell rc files (no global `peon` alias/completion injection). Hooks are always written to the global `~/.claude/settings.json` with absolute paths so they work from any project directory.
+`--local` does not modify your shell rc files (no global `peon` alias/completion injection). Hooks are registered in the project-level `./.claude/settings.json` with absolute paths so they work from any working directory within the project.
 
 Examples:
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -69,11 +69,11 @@ Invoke-WebRequest -Uri "https://raw.githubusercontent.com/PeonPing/peon-ping/mai
 
 - `--all` — 安装所有可用语音包
 - `--packs=peon,sc_kerrigan,...` — 仅安装指定语音包
-- `--local` — 将语音包和配置安装到当前项目的 `./.claude/` 目录（钩子始终全局注册到 `~/.claude/settings.json`）
+- `--local` — 将语音包、配置和钩子安装到当前项目的 `./.claude/` 目录
 - `--global` — 显式全局安装（与默认相同）
 - `--init-local-config` — 仅创建 `./.claude/hooks/peon-ping/config.json`
 
-`--local` 不会修改你的 shell rc 文件（不注入全局 `peon` 别名/补全）。钩子始终写入全局 `~/.claude/settings.json` 并使用绝对路径，因此在任何项目目录下都能工作。
+`--local` 不会修改你的 shell rc 文件（不注入全局 `peon` 别名/补全）。钩子注册到项目级 `./.claude/settings.json` 并使用绝对路径，因此在项目内的任何工作目录下都能工作。
 
 示例：
 

--- a/install.sh
+++ b/install.sh
@@ -929,13 +929,19 @@ OCSKILL
 fi
 
 # --- Update settings.json ---
-# Always write hooks to GLOBAL settings — hooks need absolute paths and
-# must work regardless of which project directory Claude Code runs in.
+# Use BASE_DIR so --local installs register hooks in the project-level
+# settings.json, while global installs use ~/.claude/settings.json.
+# All paths are absolute either way (BASE_DIR is already absolute).
 echo ""
 echo "Updating Claude Code hooks in settings.json..."
 
-HOOK_CMD="$GLOBAL_BASE/hooks/peon-ping/peon.sh"
-HOOK_SETTINGS="$GLOBAL_BASE/settings.json"
+if [ "$LOCAL_MODE" = true ]; then
+  HOOK_CMD="$BASE_DIR/hooks/peon-ping/peon.sh"
+  HOOK_SETTINGS="$BASE_DIR/settings.json"
+else
+  HOOK_CMD="$GLOBAL_BASE/hooks/peon-ping/peon.sh"
+  HOOK_SETTINGS="$GLOBAL_BASE/settings.json"
+fi
 
 python3 -c "
 import json, os, sys
@@ -1236,12 +1242,16 @@ print('  Hooks registered for: ' + ', '.join(events))
 "
 fi
 
-# --- Remove peon-ping hooks from project-level settings to prevent doubles ---
-# Since hooks are always written to global settings now, clean any stale
-# project-level hooks that may exist from older installs.
-OTHER_SETTINGS="$LOCAL_BASE/settings.json"
+# --- Remove peon-ping hooks from the OTHER settings scope to prevent doubles ---
+# Global installs clean stale project-level hooks; local installs clean stale
+# global hooks. Skip when both scopes resolve to the same file.
+if [ "$LOCAL_MODE" = true ]; then
+  OTHER_SETTINGS="$GLOBAL_BASE/settings.json"
+else
+  OTHER_SETTINGS="$LOCAL_BASE/settings.json"
+fi
 
-if [ -f "$OTHER_SETTINGS" ] && [ "$OTHER_SETTINGS" != "$HOOK_SETTINGS" ]; then
+if [ "$OTHER_SETTINGS" != "$HOOK_SETTINGS" ] && [ -f "$OTHER_SETTINGS" ]; then
   python3 -c "
 import json, os
 

--- a/tests/install.bats
+++ b/tests/install.bats
@@ -204,14 +204,14 @@ print('OK')
   [ -f "$LOCAL_INSTALL_DIR/packs/peon/openpeon.json" ]
 }
 
-@test "--local registers hooks in global settings.json" {
+@test "--local registers hooks in project-level settings.json" {
   cd "$PROJECT_DIR"
   bash "$CLONE_DIR/install.sh" --local
-  # Hooks are always written to global settings (HOME/.claude/settings.json)
-  [ -f "$TEST_HOME/.claude/settings.json" ]
+  # Hooks should be written to the project-level settings (PROJECT_DIR/.claude/settings.json)
+  [ -f "$PROJECT_DIR/.claude/settings.json" ]
   /usr/bin/python3 -c "
 import json
-s = json.load(open('$TEST_HOME/.claude/settings.json'))
+s = json.load(open('$PROJECT_DIR/.claude/settings.json'))
 hooks = s.get('hooks', {})
 for event in ['SessionStart', 'UserPromptSubmit', 'Stop', 'Notification', 'PermissionRequest']:
     assert event in hooks, f'{event} not in hooks'
@@ -241,17 +241,17 @@ print('OK')
   cd "$PROJECT_DIR"
   bash "$CLONE_DIR/install.sh" --local
   [ -f "$LOCAL_INSTALL_DIR/peon.sh" ]
-  # Hooks are in global settings
-  [ -f "$TEST_HOME/.claude/settings.json" ]
+  # Hooks are in project-level settings
+  [ -f "$PROJECT_DIR/.claude/settings.json" ]
   [ -d "$PROJECT_DIR/.claude/skills/peon-ping-toggle" ]
 
   # Run uninstall (non-interactive — no notify.sh restore prompt for local)
   bash "$LOCAL_INSTALL_DIR/uninstall.sh"
 
-  # Hook entries removed from global settings.json
+  # Hook entries removed from project-level settings.json
   /usr/bin/python3 -c "
 import json
-s = json.load(open('$TEST_HOME/.claude/settings.json'))
+s = json.load(open('$PROJECT_DIR/.claude/settings.json'))
 hooks = s.get('hooks', {})
 for event, entries in hooks.items():
     for entry in entries:
@@ -262,6 +262,25 @@ print('OK')
   # Install and skill directories removed
   [ ! -d "$LOCAL_INSTALL_DIR" ]
   [ ! -d "$PROJECT_DIR/.claude/skills/peon-ping-toggle" ]
+}
+
+@test "--local hook paths point to project directory not global" {
+  cd "$PROJECT_DIR"
+  bash "$CLONE_DIR/install.sh" --local
+  # Every peon.sh hook command should reference the project path, not ~/.claude
+  /usr/bin/python3 -c "
+import json
+s = json.load(open('$PROJECT_DIR/.claude/settings.json'))
+hooks = s.get('hooks', {})
+for event, entries in hooks.items():
+    for entry in entries:
+        for h in entry.get('hooks', []):
+            cmd = h.get('command', '')
+            if 'peon.sh' in cmd:
+                assert '$PROJECT_DIR' in cmd, f'Hook for {event} points outside project: {cmd}'
+                assert '$TEST_HOME/.claude' not in cmd, f'Hook for {event} points to global: {cmd}'
+print('OK')
+"
 }
 
 @test "--local fails without .claude directory" {


### PR DESCRIPTION
When installing with `--local` and no global install present, hooks were registered pointing to `~/.claude/hooks/peon-ping/peon.sh` which didn't exist & the files are at `.claude/hooks/peon-ping/` inside the project.

- Route `HOOK_CMD` and `HOOK_SETTINGS` through `$BASE_DIR` in `--local` mode (`$BASE_DIR` is already absolute, so no relative path issues)
- Fix cleanup block to target the correct opposite scope instead of always stripping project-level hooks
- Update tests to verify hooks land in project-level settings.json
- Add test asserting hook paths reference the project directory

Fixes #355