### PR TITLE
sprint/HOOKBUG: fix Windows hook deadlock and atomic state writes

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -320,6 +320,17 @@ param(
     [string]$Arg2 = ""
 )
 
+# 8-second self-timeout safety net — kills this process if anything blocks unexpectedly.
+# Uses System.Timers.Timer (not Forms.Timer) so it works in headless PowerShell without a message pump.
+# Must fire before ANY I/O (config read, state read, stdin read).
+if (-not $Command) {
+    $safetyTimer = New-Object System.Timers.Timer
+    $safetyTimer.Interval = 8000
+    $safetyTimer.AutoReset = $false
+    Register-ObjectEvent -InputObject $safetyTimer -EventName Elapsed -Action { [Environment]::Exit(1) } | Out-Null
+    $safetyTimer.Start()
+}
+
 # Raw config read; repair is done at install/update time, so hook only needs plain read.
 function Get-PeonConfigRaw {
     param([string]$Path)
@@ -786,41 +797,14 @@ try {
     $state | ConvertTo-Json -Depth 3 | Set-Content $StatePath -Encoding UTF8
 } catch {}
 
-# --- Play the sound inline ---
+# --- Delegate audio to win-play.ps1 in a detached process ---
 $volume = $config.volume
 if (-not $volume) { $volume = 0.5 }
 
-# Background jobs are terminated when this short-lived hook process exits.
-# Inline playback is deterministic and keeps behavior consistent.
-try {
-    if ($soundPath -match '\.wav$') {
-        Add-Type -AssemblyName System.Windows.Forms
-        $sp = New-Object System.Media.SoundPlayer $soundPath
-        $sp.PlaySync()
-        $sp.Dispose()
-    } else {
-        Add-Type -AssemblyName PresentationCore
-        $player = New-Object System.Windows.Media.MediaPlayer
-        $player.Open([Uri]::new("file:///$($soundPath -replace '\\','/')"))
-        $player.Volume = $volume
-        Start-Sleep -Milliseconds 150
-        $player.Play()
-        $timeout = 50
-        while ($timeout -gt 0 -and $player.Position.TotalMilliseconds -eq 0) {
-            Start-Sleep -Milliseconds 100
-            $timeout--
-        }
-        if ($player.NaturalDuration.HasTimeSpan) {
-            $remaining = $player.NaturalDuration.TimeSpan.TotalMilliseconds - $player.Position.TotalMilliseconds
-            if ($remaining -gt 0 -and $remaining -lt 5000) {
-                Start-Sleep -Milliseconds ([int]$remaining + 100)
-            }
-        } else {
-            Start-Sleep -Seconds 2
-        }
-        $player.Close()
-    }
-} catch {}
+$winPlayScript = Join-Path $InstallDir "scripts\win-play.ps1"
+if (Test-Path $winPlayScript) {
+    Start-Process -FilePath "powershell.exe" -ArgumentList "-NoProfile", "-NonInteractive", "-File", $winPlayScript, "-path", $soundPath, "-vol", $volume -WindowStyle Hidden | Out-Null
+}
 
 exit 0
 '@
@@ -1295,6 +1279,12 @@ if ($Updating) {
     Write-Host ""
     Write-Host "  Start Claude Code and you'll hear: `"Ready to work?`"" -ForegroundColor Yellow
     Write-Host ""
+    # Recommend ffmpeg for MP3/OGG support if ffplay is not on PATH
+    if (-not (Get-Command ffplay -ErrorAction SilentlyContinue)) {
+        Write-Host "  Tip: For MP3/OGG sound support, install ffmpeg:" -ForegroundColor Yellow
+        Write-Host "    winget install ffmpeg" -ForegroundColor DarkGray
+        Write-Host ""
+    }
     Write-Host "  To install specific packs: .\install.ps1 -Packs peon,glados,peasant" -ForegroundColor DarkGray
     Write-Host "  To install ALL packs: .\install.ps1 -All" -ForegroundColor DarkGray
     Write-Host "  To uninstall: powershell -File `"$InstallDir\uninstall.ps1`"" -ForegroundColor DarkGray

--- a/install.ps1
+++ b/install.ps1
@@ -569,20 +569,48 @@ function ConvertTo-Hashtable {
     return $obj
 }
 
-# Read state
-$state = @{}
-try {
-    if (Test-Path $StatePath) {
-        $raw = Get-Content $StatePath -Raw
-        if ($raw -and $raw.Trim().Length -gt 0) {
-            $stateObj = $raw | ConvertFrom-Json
-            $converted = ConvertTo-Hashtable $stateObj
-            if ($converted -is [hashtable]) { $state = $converted }
+# --- Atomic state I/O helpers ---
+function Write-StateAtomic {
+    param([hashtable]$State, [string]$Path)
+    $dir = Split-Path $Path -Parent
+    if ($dir -and -not (Test-Path $dir)) { New-Item -ItemType Directory -Path $dir -Force | Out-Null }
+    $tmp = "$Path.$PID.tmp"
+    try {
+        $State | ConvertTo-Json -Depth 3 | Set-Content $tmp -Encoding UTF8
+        # [System.IO.File]::Move with overwrite requires .NET Core (PS 7+).
+        # For PS 5.1 compat: delete target then move (atomic on NTFS same-volume).
+        if (Test-Path $Path) { [System.IO.File]::Delete($Path) }
+        [System.IO.File]::Move($tmp, $Path)
+    } catch {
+        Remove-Item $tmp -ErrorAction SilentlyContinue
+    }
+}
+
+function Read-StateWithRetry {
+    param([string]$Path)
+    $delays = @(50, 100, 200)
+    for ($i = 0; $i -le $delays.Count; $i++) {
+        try {
+            if (Test-Path $Path) {
+                $raw = Get-Content $Path -Raw
+                if ($raw -and $raw.Trim().Length -gt 0) {
+                    $stateObj = $raw | ConvertFrom-Json
+                    $converted = ConvertTo-Hashtable $stateObj
+                    if ($converted -is [hashtable]) { return $converted }
+                }
+            }
+            return @{}
+        } catch {
+            if ($i -lt $delays.Count) {
+                Start-Sleep -Milliseconds $delays[$i]
+            }
         }
     }
-} catch {
-    $state = @{}
+    return @{}
 }
+
+# Read state
+$state = Read-StateWithRetry -Path $StatePath
 
 # --- Session cleanup: expire old sessions ---
 $now = [DateTimeOffset]::UtcNow.ToUnixTimeSeconds()
@@ -677,7 +705,7 @@ switch ($hookEvent) {
 
 # Save state
 try {
-    $state | ConvertTo-Json -Depth 3 | Set-Content $StatePath -Encoding UTF8
+    Write-StateAtomic -State $state -Path $StatePath
 } catch {}
 
 if (-not $category) { exit 0 }
@@ -794,7 +822,7 @@ if ($iconCandidate) {
 # Save last played
 $state[$lastKey] = $soundFile
 try {
-    $state | ConvertTo-Json -Depth 3 | Set-Content $StatePath -Encoding UTF8
+    Write-StateAtomic -State $state -Path $StatePath
 } catch {}
 
 # --- Delegate audio to win-play.ps1 in a detached process ---

--- a/install.ps1
+++ b/install.ps1
@@ -803,7 +803,7 @@ if (-not $volume) { $volume = 0.5 }
 
 $winPlayScript = Join-Path $InstallDir "scripts\win-play.ps1"
 if (Test-Path $winPlayScript) {
-    Start-Process -FilePath "powershell.exe" -ArgumentList "-NoProfile", "-NonInteractive", "-File", $winPlayScript, "-path", $soundPath, "-vol", $volume -WindowStyle Hidden | Out-Null
+    Start-Process -FilePath "powershell.exe" -ArgumentList "-NoProfile", "-NonInteractive", "-File", $winPlayScript, "-path", $soundPath, "-vol", $volume -WindowStyle Hidden
 }
 
 exit 0

--- a/peon.sh
+++ b/peon.sh
@@ -2568,10 +2568,34 @@ json.dump(cfg, open(config_path, 'w'), indent=2)
         exit 0 ;;
       status)
         python3 -c "
-import json, datetime, sys
+import json, datetime, sys, os, time, tempfile
 
 config_path = '$CONFIG_PY'
 state_path = '$STATE_PY'
+
+def _write_state(st, path, indent=None):
+    d = os.path.dirname(path) or '.'
+    os.makedirs(d, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=d, suffix='.tmp')
+    try:
+        with os.fdopen(fd, 'w') as f:
+            json.dump(st, f, indent=indent)
+        os.replace(tmp, path)
+    except Exception:
+        try: os.unlink(tmp)
+        except OSError: pass
+        raise
+
+def _read_state(path):
+    delays = [0.05, 0.1, 0.2]
+    for attempt in range(len(delays) + 1):
+        try:
+            with open(path) as f:
+                return json.load(f)
+        except Exception:
+            if attempt < len(delays):
+                time.sleep(delays[attempt])
+    return {}
 
 try:
     cfg = json.load(open(config_path))
@@ -2586,10 +2610,7 @@ if not trainer_cfg.get('enabled', False):
 
 exercises = trainer_cfg.get('exercises', {'pushups': 300, 'squats': 300})
 
-try:
-    state = json.load(open(state_path))
-except Exception:
-    state = {}
+state = _read_state(state_path)
 
 trainer_state = state.get('trainer', {})
 today = datetime.date.today().isoformat()
@@ -2598,7 +2619,7 @@ today = datetime.date.today().isoformat()
 if trainer_state.get('date', '') != today:
     trainer_state = {'date': today, 'reps': {k: 0 for k in exercises}, 'last_reminder_ts': 0}
     state['trainer'] = trainer_state
-    json.dump(state, open(state_path, 'w'), indent=2)
+    _write_state(state, state_path, indent=2)
 
 reps = trainer_state.get('reps', {})
 
@@ -2630,12 +2651,36 @@ for ex, goal in exercises.items():
           ''|*[!0-9]*) echo "peon-ping: count must be a number" >&2; exit 1 ;;
         esac
         python3 -c "
-import json, datetime, sys
+import json, datetime, sys, os, time, tempfile
 
 config_path = '$CONFIG_PY'
 state_path = '$STATE_PY'
 count = int('$COUNT')
 exercise = '$EXERCISE'
+
+def _write_state(st, path, indent=None):
+    d = os.path.dirname(path) or '.'
+    os.makedirs(d, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=d, suffix='.tmp')
+    try:
+        with os.fdopen(fd, 'w') as f:
+            json.dump(st, f, indent=indent)
+        os.replace(tmp, path)
+    except Exception:
+        try: os.unlink(tmp)
+        except OSError: pass
+        raise
+
+def _read_state(path):
+    delays = [0.05, 0.1, 0.2]
+    for attempt in range(len(delays) + 1):
+        try:
+            with open(path) as f:
+                return json.load(f)
+        except Exception:
+            if attempt < len(delays):
+                time.sleep(delays[attempt])
+    return {}
 
 try:
     cfg = json.load(open(config_path))
@@ -2654,10 +2699,7 @@ if exercise not in exercises:
 
 goal = exercises[exercise]
 
-try:
-    state = json.load(open(state_path))
-except Exception:
-    state = {}
+state = _read_state(state_path)
 
 trainer_state = state.get('trainer', {})
 today = datetime.date.today().isoformat()
@@ -2671,7 +2713,7 @@ reps[exercise] = reps.get(exercise, 0) + count
 trainer_state['reps'] = reps
 trainer_state['date'] = today
 state['trainer'] = trainer_state
-json.dump(state, open(state_path, 'w'), indent=2)
+_write_state(state, state_path, indent=2)
 
 done = reps[exercise]
 pct = min(done / goal, 1.0) if goal > 0 else 0
@@ -2798,7 +2840,7 @@ _PEON_HOOK_TTY=$(_peon_walk_tty)
 # Consolidates 5 separate python3 invocations into one for ~120-200ms faster hook response.
 # Outputs shell variables consumed by the bash play/notify/title logic below.
 _PEON_PYOUT=$(python3 -c "
-import sys, json, os, re, random, time, shlex
+import sys, json, os, re, random, time, shlex, tempfile
 q = shlex.quote
 
 config_path = '$CONFIG_PY'
@@ -2808,6 +2850,35 @@ paused = '$PAUSED' == 'true'
 hook_tty = '$_PEON_HOOK_TTY'
 agent_modes = {'delegate'}
 state_dirty = False
+
+# --- Atomic state I/O helpers ---
+def write_state(st, path, indent=None):
+    \"\"\"Atomically write state dict to path via temp+rename.\"\"\"
+    d = os.path.dirname(path) or '.'
+    os.makedirs(d, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=d, suffix='.tmp')
+    try:
+        with os.fdopen(fd, 'w') as f:
+            json.dump(st, f, indent=indent)
+        os.replace(tmp, path)
+    except Exception:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+def read_state(path):
+    \"\"\"Read state dict from path with retry on transient failures.\"\"\"
+    delays = [0.05, 0.1, 0.2]
+    for attempt in range(len(delays) + 1):
+        try:
+            with open(path) as f:
+                return json.load(f)
+        except Exception:
+            if attempt < len(delays):
+                time.sleep(delays[attempt])
+    return {}
 
 # --- Load config ---
 try:
@@ -2871,10 +2942,7 @@ perm_mode = event_data.get('permission_mode', '')
 session_source = event_data.get('source', '')
 
 # --- Load state ---
-try:
-    state = json.load(open(state_file))
-except Exception:
-    state = {}
+state = read_state(state_file)
 
 # --- Agent detection ---
 agent_sessions = set(state.get('agent_sessions', []))
@@ -2883,8 +2951,7 @@ if perm_mode and perm_mode in agent_modes:
     state['agent_sessions'] = list(agent_sessions)
     state_dirty = True
     print('PEON_EXIT=true')
-    os.makedirs(os.path.dirname(state_file) or '.', exist_ok=True)
-    json.dump(state, open(state_file, 'w'))
+    write_state(state, state_file)
     sys.exit(0)
 elif session_id in agent_sessions:
     print('PEON_EXIT=true')
@@ -3157,8 +3224,7 @@ elif event == 'Stop':
     category = 'task.complete'
     # Suppress completion sound/notification for known sub-agent sessions
     if suppress_subagent_complete and session_id in state.get('subagent_sessions', {}):
-        os.makedirs(os.path.dirname(state_file) or '.', exist_ok=True)
-        json.dump(state, open(state_file, 'w'))
+        write_state(state, state_file)
         print('PEON_EXIT=true')
         sys.exit(0)
     silent = False
@@ -3208,8 +3274,7 @@ elif event == 'Notification':
 elif event == 'PermissionRequest':
     # Suppress permission sound/notification for known sub-agent sessions
     if suppress_subagent_complete and session_id in state.get('subagent_sessions', {}):
-        os.makedirs(os.path.dirname(state_file) or '.', exist_ok=True)
-        json.dump(state, open(state_file, 'w'))
+        write_state(state, state_file)
         print('PEON_EXIT=true')
         sys.exit(0)
     category = 'input.required'
@@ -3238,8 +3303,7 @@ elif event == 'SubagentStart':
     # Record parent's pack so spawned subagent sessions inherit it, then stay silent
     state['pending_subagent_pack'] = dict(ts=time.time(), pack=active_pack)
     state_dirty = True
-    os.makedirs(os.path.dirname(state_file) or '.', exist_ok=True)
-    json.dump(state, open(state_file, 'w'))
+    write_state(state, state_file)
     # Maintain parent's tab title while subagent runs (no sound)
     print('PROJECT=' + q(project or ''))
     print('STATUS=working')
@@ -3264,8 +3328,7 @@ elif event == 'SessionEnd':
     agent_sessions.discard(session_id)
     state['agent_sessions'] = list(agent_sessions)
     state_dirty = True
-    os.makedirs(os.path.dirname(state_file) or '.', exist_ok=True)
-    json.dump(state, open(state_file, 'w'))
+    write_state(state, state_file)
     print('EVENT=' + q(event))
     print('PEON_EXIT=true')
     sys.exit(0)
@@ -3440,8 +3503,7 @@ if trainer_cfg.get('enabled', False):
 
 # --- Write state once ---
 if state_dirty:
-    os.makedirs(os.path.dirname(state_file) or '.', exist_ok=True)
-    json.dump(state, open(state_file, 'w'))
+    write_state(state, state_file)
     # --- Relay state push ---
     if state.get('last_active'):
         import urllib.request as _ureq

--- a/scripts/win-play.ps1
+++ b/scripts/win-play.ps1
@@ -5,41 +5,56 @@ param(
     [double]$vol
 )
 
-# WAV files: use SoundPlayer directly, which works correctly in hidden/detached
-# processes. MediaPlayer (WPF) silently fails without a message pump — it reports
-# HasAudio: False and never plays, so we bypass it entirely for .wav files.
-# See: https://github.com/PeonPing/peon-ping/issues/252
+# WAV files: use SoundPlayer (works correctly in hidden/detached processes)
 if ($path -match "\.wav$") {
     try {
-        Add-Type -AssemblyName System.Windows.Forms
         $sp = New-Object System.Media.SoundPlayer $path
         $sp.PlaySync()
         $sp.Dispose()
     } catch {}
-    return
+    exit 0
 }
 
-# Non-WAV formats (mp3, ogg, etc.): use WPF MediaPlayer
-try {
-    Add-Type -AssemblyName PresentationCore
-    $player = New-Object System.Windows.Media.MediaPlayer
-    $player.Open([Uri]::new("file:///$($path -replace '\\','/')"))
-    $player.Volume = $vol
-    Start-Sleep -Milliseconds 150
-    $player.Play()
-    $timeout = 50
-    while ($timeout -gt 0 -and $player.Position.TotalMilliseconds -eq 0) {
-        Start-Sleep -Milliseconds 100
-        $timeout--
-    }
-    if ($player.NaturalDuration.HasTimeSpan) {
-        $remaining = $player.NaturalDuration.TimeSpan.TotalMilliseconds - $player.Position.TotalMilliseconds
-        if ($remaining -gt 0 -and $remaining -lt 5000) {
-            Start-Sleep -Milliseconds ([int]$remaining + 100)
-        }
-    } else {
-        Start-Sleep -Seconds 2
-    }
-    $player.Close()
-} catch {}
+# Non-WAV formats (mp3, ogg, etc.): CLI player priority chain
+# ffplay -> mpv -> vlc (no MediaPlayer — it deadlocks in headless PowerShell)
 
+# ffplay: volume 0-100 integer scale
+$ffplay = Get-Command ffplay -ErrorAction SilentlyContinue
+if ($ffplay) {
+    $ffVol = [math]::Max(0, [math]::Min(100, [int]($vol * 100)))
+    & $ffplay.Source -nodisp -autoexit -volume $ffVol $path 2>$null
+    exit 0
+}
+
+# mpv: volume 0-100 integer scale
+$mpv = Get-Command mpv -ErrorAction SilentlyContinue
+if ($mpv) {
+    $mpvVol = [math]::Max(0, [math]::Min(100, [int]($vol * 100)))
+    & $mpv.Source --no-video --volume=$mpvVol $path 2>$null
+    exit 0
+}
+
+# vlc: volume 0.0-2.0 gain multiplier (1.0 = 100%)
+$vlc = Get-Command vlc -ErrorAction SilentlyContinue
+if (-not $vlc) {
+    # Check common install locations
+    $vlcPaths = @(
+        "$env:ProgramFiles\VideoLAN\VLC\vlc.exe",
+        "${env:ProgramFiles(x86)}\VideoLAN\VLC\vlc.exe"
+    )
+    foreach ($p in $vlcPaths) {
+        if (Test-Path $p) {
+            $vlc = Get-Item $p
+            break
+        }
+    }
+}
+if ($vlc) {
+    $vlcGain = [math]::Round($vol * 2.0, 2).ToString([System.Globalization.CultureInfo]::InvariantCulture)
+    $vlcPath = if ($vlc -is [System.Management.Automation.ApplicationInfo]) { $vlc.Source } else { $vlc.FullName }
+    & $vlcPath --intf dummy --play-and-exit --gain $vlcGain $path 2>$null
+    exit 0
+}
+
+# No CLI player found — exit silently
+exit 0

--- a/tests/adapters-windows.Tests.ps1
+++ b/tests/adapters-windows.Tests.ps1
@@ -539,26 +539,47 @@ Describe "win-play.ps1 Audio Backend" {
         $script:winPlayContent | Should -Match 'PlaySync'
     }
 
-    It "uses MediaPlayer for non-WAV files" {
-        $script:winPlayContent | Should -Match 'System\.Windows\.Media\.MediaPlayer'
-        $script:winPlayContent | Should -Match '\.Play\(\)'
+    It "contains zero references to MediaPlayer or PresentationCore" {
+        $script:winPlayContent | Should -Not -Match 'System\.Windows\.Media\.MediaPlayer'
+        $script:winPlayContent | Should -Not -Match 'PresentationCore'
     }
 
-    It "sets volume on MediaPlayer" {
-        $script:winPlayContent | Should -Match '\$player\.Volume = \$vol'
+    It "uses ffplay as first CLI player choice" {
+        $script:winPlayContent | Should -Match 'ffplay'
+        $script:winPlayContent | Should -Match '-nodisp'
+        $script:winPlayContent | Should -Match '-autoexit'
+    }
+
+    It "uses mpv as second CLI player choice" {
+        $script:winPlayContent | Should -Match 'mpv'
+        $script:winPlayContent | Should -Match '--no-video'
+    }
+
+    It "uses vlc as third CLI player choice" {
+        $script:winPlayContent | Should -Match 'vlc'
+        $script:winPlayContent | Should -Match '--play-and-exit'
+    }
+
+    It "normalizes volume for ffplay (0-100 scale)" {
+        $script:winPlayContent | Should -Match '\$vol \* 100'
+    }
+
+    It "normalizes volume for mpv (0-100 scale)" {
+        $script:winPlayContent | Should -Match 'volume=\$mpvVol'
+    }
+
+    It "normalizes volume for vlc (0.0-2.0 gain multiplier)" {
+        $script:winPlayContent | Should -Match '\$vol \* 2\.0'
+        $script:winPlayContent | Should -Match '--gain'
+    }
+
+    It "exits silently (exit 0) if no CLI player found" {
+        # The last line before the end should be exit 0
+        $script:winPlayContent | Should -Match 'exit 0'
     }
 
     It "disposes SoundPlayer after playback" {
         $script:winPlayContent | Should -Match '\$sp\.Dispose\(\)'
-    }
-
-    It "closes MediaPlayer after playback" {
-        $script:winPlayContent | Should -Match '\$player\.Close\(\)'
-    }
-
-    It "waits for duration before closing (no premature exit)" {
-        $script:winPlayContent | Should -Match 'NaturalDuration'
-        $script:winPlayContent | Should -Match 'remaining'
     }
 }
 
@@ -842,15 +863,27 @@ Describe "Embedded peon.ps1 Hook Script" {
         $script:peonHookContent | Should -Match '\$volume.*0\.5'
     }
 
-    # --- Audio Playback (mirrors BATS: platform-specific audio) ---
+    # --- Self-Timeout Safety Net ---
 
-    It "uses SoundPlayer for WAV files inline" {
-        $script:peonHookContent | Should -Match 'System\.Media\.SoundPlayer'
-        $script:peonHookContent | Should -Match '\.wav\$'
+    It "registers an 8-second self-timeout timer before any I/O" {
+        $script:peonHookContent | Should -Match 'System\.Timers\.Timer'
+        $script:peonHookContent | Should -Match '8000'
+        $script:peonHookContent | Should -Match '\[Environment\]::Exit\(1\)'
     }
 
-    It "uses MediaPlayer for non-WAV files inline" {
-        $script:peonHookContent | Should -Match 'System\.Windows\.Media\.MediaPlayer'
+    # --- Audio Delegation (detached process via win-play.ps1) ---
+
+    It "contains zero references to MediaPlayer, PresentationCore, SoundPlayer, or System.Windows.Forms" {
+        $script:peonHookContent | Should -Not -Match 'MediaPlayer'
+        $script:peonHookContent | Should -Not -Match 'PresentationCore'
+        $script:peonHookContent | Should -Not -Match 'SoundPlayer'
+        $script:peonHookContent | Should -Not -Match 'System\.Windows\.Forms'
+    }
+
+    It "delegates audio to win-play.ps1 via Start-Process with -WindowStyle Hidden" {
+        $script:peonHookContent | Should -Match 'Start-Process'
+        $script:peonHookContent | Should -Match 'win-play\.ps1'
+        $script:peonHookContent | Should -Match 'WindowStyle Hidden'
     }
 
     # --- CLI Commands (mirrors BATS: peon --toggle/--pause/--resume/--status) ---
@@ -993,5 +1026,10 @@ Describe "install.ps1 Default Config" {
 
     It "blocks path traversal in source ref and path" {
         $script:installContent | Should -Match '\.\.'
+    }
+
+    It "prints ffmpeg recommendation if ffplay not found" {
+        $script:installContent | Should -Match 'ffplay'
+        $script:installContent | Should -Match 'winget install ffmpeg'
     }
 }

--- a/tests/adapters-windows.Tests.ps1
+++ b/tests/adapters-windows.Tests.ps1
@@ -928,7 +928,7 @@ Describe "Embedded peon.ps1 Hook Script" {
 
     It "reads and writes .state.json" {
         $script:peonHookContent | Should -Match '\.state\.json'
-        $script:peonHookContent | Should -Match 'ConvertTo-Json.*Set-Content \$StatePath'
+        $script:peonHookContent | Should -Match 'Write-StateAtomic'
     }
 
     It "reads stdin JSON via StreamReader (UTF-8 BOM-safe)" {

--- a/tests/hookbug-integration.ps1
+++ b/tests/hookbug-integration.ps1
@@ -1,0 +1,130 @@
+# HOOKBUG integration tests — validates async audio and atomic state on Windows
+# Run: pwsh -NoProfile -File tests/hookbug-integration.ps1
+# Exit code 0 = all pass, 1 = failure
+
+$ErrorActionPreference = 'Stop'
+$failed = 0
+$passed = 0
+$InstallDir = Join-Path $HOME ".claude\hooks\peon-ping"
+$peonScript = Join-Path $InstallDir "peon.ps1"
+$stateFile = Join-Path $InstallDir ".state.json"
+
+function Test-Case {
+    param([string]$Name, [scriptblock]$Block)
+    try {
+        & $Block
+        Write-Host "  PASS: $Name" -ForegroundColor Green
+        $script:passed++
+    } catch {
+        Write-Host "  FAIL: $Name — $_" -ForegroundColor Red
+        $script:failed++
+    }
+}
+
+Write-Host "`n=== HOOKBUG Integration Tests ===" -ForegroundColor Cyan
+
+# --- 1. All hook events exit cleanly under timeout ---
+Write-Host "`nHook event dispatch:" -ForegroundColor Yellow
+$events = @("SessionStart","Stop","Notification","PermissionRequest","PostToolUseFailure","SubagentStart","PreCompact","UserPromptSubmit")
+foreach ($event in $events) {
+    Test-Case "$event exits cleanly" {
+        $json = "{`"hook_event_name`":`"$event`",`"session_id`":`"integration-test`"}"
+        $proc = Start-Process -FilePath "pwsh" -ArgumentList "-NoProfile","-NonInteractive","-Command","'$json' | & '$peonScript'" -NoNewWindow -Wait -PassThru
+        if ($proc.ExitCode -ne 0) { throw "exit code $($proc.ExitCode)" }
+    }
+}
+
+# --- 2. No event exceeds 5 seconds ---
+Write-Host "`nPerformance (5s budget):" -ForegroundColor Yellow
+foreach ($event in $events) {
+    Test-Case "$event under 5s" {
+        $json = "{`"hook_event_name`":`"$event`",`"session_id`":`"perf-test`"}"
+        $sw = [System.Diagnostics.Stopwatch]::StartNew()
+        $proc = Start-Process -FilePath "pwsh" -ArgumentList "-NoProfile","-NonInteractive","-Command","'$json' | & '$peonScript'" -NoNewWindow -Wait -PassThru
+        $sw.Stop()
+        if ($sw.ElapsedMilliseconds -gt 5000) { throw "$($sw.ElapsedMilliseconds)ms" }
+    }
+}
+
+# --- 3. Concurrent Stop events don't corrupt state ---
+Write-Host "`nConcurrency:" -ForegroundColor Yellow
+Test-Case "5 concurrent Stop events produce valid state" {
+    # Ensure clean state before concurrency test
+    if (Test-Path $stateFile) {
+        try { $null = Get-Content $stateFile -Raw | ConvertFrom-Json } catch {
+            Set-Content $stateFile -Value '{}' -Encoding UTF8
+        }
+    }
+    $jobs = 1..5 | ForEach-Object {
+        Start-Process -FilePath "pwsh" -ArgumentList "-NoProfile","-NonInteractive","-Command","'{`"hook_event_name`":`"Stop`",`"session_id`":`"concurrent-$_`"}' | & '$peonScript'" -NoNewWindow -PassThru
+    }
+    $jobs | ForEach-Object { $_.WaitForExit(10000) }
+    $raw = Get-Content $stateFile -Raw
+    $null = $raw | ConvertFrom-Json  # throws if invalid
+}
+
+Test-Case "No orphan .tmp files after concurrent writes" {
+    $tmps = Get-ChildItem -Path $InstallDir -Filter "*.tmp" -ErrorAction SilentlyContinue
+    if ($tmps) { throw "Found $($tmps.Count) orphan temp files" }
+}
+
+# --- 4. Corrupted state recovery ---
+Write-Host "`nResilience:" -ForegroundColor Yellow
+Test-Case "Recovers from corrupted state file" {
+    $backup = $null
+    if (Test-Path $stateFile) { $backup = Get-Content $stateFile -Raw }
+    Set-Content $stateFile -Value "NOT{JSON" -Encoding UTF8
+    $json = '{"hook_event_name":"SessionStart","session_id":"corrupt-test"}'
+    $proc = Start-Process -FilePath "pwsh" -ArgumentList "-NoProfile","-NonInteractive","-Command","'$json' | & '$peonScript'" -NoNewWindow -Wait -PassThru
+    # Hook must not crash on corrupted state
+    if ($proc.ExitCode -ne 0) { throw "exit code $($proc.ExitCode)" }
+    # State file should now be valid JSON (overwritten by Write-StateAtomic)
+    $raw = Get-Content $stateFile -Raw
+    try { $null = $raw | ConvertFrom-Json } catch {
+        # If state wasn't rewritten (e.g., category disabled), that's OK — the hook survived
+        Write-Host "    (state not rewritten — hook survived but category may be disabled)" -ForegroundColor DarkGray
+    }
+    if ($backup) { Set-Content $stateFile -Value $backup -Encoding UTF8 }
+}
+
+# --- 5. win-play.ps1 exits without MediaPlayer ---
+Write-Host "`nAudio backend:" -ForegroundColor Yellow
+Test-Case "win-play.ps1 contains no MediaPlayer code" {
+    $content = Get-Content (Join-Path $InstallDir "scripts\win-play.ps1") -Raw
+    # Exclude comments — only check executable lines
+    $codeLines = ($content -split "`n") | Where-Object { $_ -notmatch '^\s*#' }
+    $code = $codeLines -join "`n"
+    if ($code -match 'MediaPlayer|PresentationCore') { throw "MediaPlayer still referenced in code" }
+}
+
+Test-Case "peon.ps1 contains no inline audio playback" {
+    $content = Get-Content $peonScript -Raw
+    if ($content -match 'MediaPlayer|PresentationCore') { throw "MediaPlayer still referenced" }
+    if ($content -match 'Add-Type.*PresentationCore') { throw "PresentationCore assembly load still present" }
+}
+
+Test-Case "peon.ps1 uses Write-StateAtomic" {
+    $content = Get-Content $peonScript -Raw
+    if ($content -notmatch 'Write-StateAtomic') { throw "Write-StateAtomic not found" }
+}
+
+Test-Case "peon.ps1 uses Read-StateWithRetry" {
+    $content = Get-Content $peonScript -Raw
+    if ($content -notmatch 'Read-StateWithRetry') { throw "Read-StateWithRetry not found" }
+}
+
+Test-Case "peon.ps1 has safety timer" {
+    $content = Get-Content $peonScript -Raw
+    if ($content -notmatch 'System\.Timers\.Timer') { throw "Safety timer not found" }
+}
+
+Test-Case "peon.ps1 delegates audio via Start-Process" {
+    $content = Get-Content $peonScript -Raw
+    if ($content -notmatch 'Start-Process') { throw "Start-Process delegation not found" }
+    if ($content -notmatch 'win-play\.ps1') { throw "win-play.ps1 reference not found" }
+}
+
+# --- Summary ---
+$total = $passed + $failed
+Write-Host "`n=== Results: $passed/$total passed" -ForegroundColor $(if ($failed -eq 0) { "Green" } else { "Red" })
+if ($failed -gt 0) { exit 1 }

--- a/tests/peon.bats
+++ b/tests/peon.bats
@@ -3662,3 +3662,34 @@ json.dump(c, open('$TEST_DIR/config.json', 'w'))
   sound=$(afplay_sound)
   [[ "$sound" == *"/packs/sc_kerrigan/sounds/"* ]]
 }
+
+# ============================================================
+# Atomic state I/O
+# ============================================================
+
+@test "corrupted state.json does not crash the hook - continues with defaults" {
+  # Write corrupted JSON to state file
+  echo '{invalid json garbage!!!' > "$TEST_DIR/.state.json"
+  run_peon '{"hook_event_name":"SessionStart","cwd":"/tmp/myproject","session_id":"corrupt1","permission_mode":"default"}'
+  [ "$PEON_EXIT" -eq 0 ]
+  afplay_was_called
+  sound=$(afplay_sound)
+  [[ "$sound" == *"/packs/peon/sounds/Hello"* ]]
+  # State file should now be valid JSON (written atomically after event)
+  /usr/bin/python3 -c "import json; json.load(open('$TEST_DIR/.state.json'))"
+}
+
+@test "concurrent Stop events produce valid JSON state" {
+  # Fire multiple Stop events rapidly to test atomic write safety
+  for i in 1 2 3 4 5; do
+    echo '{"hook_event_name":"Stop","cwd":"/tmp/proj","session_id":"concurrent'$i'","permission_mode":"default"}' \
+      | bash "$PEON_SH" 2>/dev/null &
+  done
+  wait
+  # State file must be valid JSON after all concurrent writes
+  /usr/bin/python3 -c "
+import json
+state = json.load(open('$TEST_DIR/.state.json'))
+assert isinstance(state, dict), 'State should be a dict'
+"
+}


### PR DESCRIPTION
## Motivation

The Windows `peon.ps1` hook deadlocked on `Stop` events. `MediaPlayer` (WPF's `PresentationCore`) blocked PowerShell's process exit, causing indefinite hangs that froze Claude Code sessions — some lasting 7+ hours. The `Stop` hook was disabled as a workaround. Separately, concurrent hook invocations could corrupt `.state.json` through non-atomic writes on both platforms.

This is the clean HOOKBUG-only branch split from #361 per @garysheng's review feedback. The two CI failures on #361 (`config.json defaults` and `status shows active path rule`) were both SMARTPACK-related and are not present here. SMARTPACK work lands in a separate PR.

## Approach

Two independent fixes, both cross-platform:

1. **Remove the deadlock source entirely** rather than working around it. `MediaPlayer`/`PresentationCore` are gone from both `peon.ps1` and `win-play.ps1`. Audio is delegated to a detached process, mirroring the Unix `nohup &` pattern. An 8-second safety timer guarantees the hook process exits even if something unexpected blocks.

2. **Make state writes atomic** using temp-file-then-rename on both platforms. Reads retry with exponential backoff (50/100/200ms) so concurrent hooks don't see partial writes. This covers both the Python path (`peon.sh`) and the PowerShell path (`peon.ps1`).

## What changed

### Async audio delegation (Windows)

- `peon.ps1` (embedded in `install.ps1`): removed all `MediaPlayer`, `PresentationCore`, `SoundPlayer`, and `System.Windows.Forms` references. Audio is now delegated to `win-play.ps1` via `Start-Process -WindowStyle Hidden` in a detached window.
- `win-play.ps1`: removed `MediaPlayer` entirely. WAV files use `SoundPlayer` directly. Non-WAV formats fall through a CLI player chain: `ffplay` -> `mpv` -> `vlc`, each with correct volume normalization for its scale. Exits silently if no player is found.
- 8-second `System.Timers.Timer` safety net fires before any I/O in hook mode — kills the process if anything blocks. Uses `System.Timers.Timer` (not `Forms.Timer`) so it works without a message pump.
- `install.ps1` now prints an ffmpeg recommendation when `ffplay` is not on PATH.

### Atomic state writes (both platforms)

- **Python** (`peon.sh`): new `write_state()` uses `tempfile.mkstemp()` + `os.replace()` (atomic on POSIX). `read_state()` retries 3x with 50/100/200ms backoff, falls back to `{}`. All 8 raw `json.dump(state, open(...))` call sites replaced.
- **PowerShell** (`peon.ps1`): new `Write-StateAtomic` uses `$Path.$PID.tmp` + `[System.IO.File]::Delete()` + `Move()` (PS 5.1 compatible, atomic on NTFS same-volume). `Read-StateWithRetry` with matching retry logic. Both `Set-Content $StatePath` call sites replaced.

## Verification

**BATS** (Unix, CI): 2 new tests — corrupted state recovery and concurrent Stop events producing valid JSON. All existing tests unaffected.

**Pester** (Windows, CI): 204/204 pass. Assertions updated for the new architecture: no MediaPlayer references, `Write-StateAtomic` present, `Start-Process` delegation, CLI player chain with per-player volume normalization.

**Integration** (`tests/hookbug-integration.ps1`): 25/25 pass on Windows. Covers:
- All 8 hook event types exit cleanly, each under 5s
- 5 concurrent `Stop` events produce valid JSON state with no orphan temp files
- Corrupted state file recovery (hook survives, does not crash)
- Absence of `MediaPlayer`/`PresentationCore` in executable code
- Presence of `Write-StateAtomic`, `Read-StateWithRetry`, safety timer, `Start-Process` delegation

**Manual**: `Stop` event returns in <1s (previously deadlocked indefinitely).

## Risks and limitations

- Non-WAV playback requires a CLI player (`ffplay`, `mpv`, or `vlc`) on PATH. WAV works unconditionally via `SoundPlayer`. Most packs ship WAV files; the installer now recommends `winget install ffmpeg` when `ffplay` is missing.
- `_write_state`/`_read_state` are duplicated across three inline `python3 -c` blocks in `peon.sh` (the trainer `status` and `log` commands each have their own copy). This is a structural constraint of the inline-Python architecture — tracked as a follow-up refactor.
- `read_state()` retries add up to 350ms on a truly missing state file (clean first run). Negligible in practice.

## How to review

5 commits, 6 files changed (+414/-120). No gitban infrastructure, no SMARTPACK code.

| File | Focus |
|:-----|:------|
| `scripts/win-play.ps1` | MediaPlayer removal, CLI player chain, volume normalization per player |
| `install.ps1` (~lines 320-840) | Embedded `peon.ps1`: safety timer, `Write-StateAtomic`/`Read-StateWithRetry`, `Start-Process` delegation |
| `peon.sh` | `write_state()`/`read_state()` helpers replacing all raw `json.dump` calls |
| `tests/adapters-windows.Tests.ps1` | Updated Pester assertions matching new architecture |
| `tests/hookbug-integration.ps1` | New 25-test integration suite (Windows-only) |
| `tests/peon.bats` | 2 new BATS tests for atomic state I/O |

## Deferred work

- Diagnostic logging for silent audio failures (empty catch blocks in `win-play.ps1`, missing player guard)
- DRY up triplicated `_write_state`/`_read_state` across `peon.sh` inline Python blocks

Supersedes #361.