### PR TITLE
fix: suppress sounds in non-interactive Claude sessions

### DIFF
--- a/peon.sh
+++ b/peon.sh
@@ -2762,6 +2762,12 @@ TRAINER_HELP
     echo "Run 'peon help' for usage." >&2; exit 1 ;;
 esac
 
+# Skip non-interactive Claude sessions (claude -p).
+# CLAUDE_CODE_ENTRYPOINT is undocumented; if unset or unrecognised, do nothing.
+if [ "${PEON_ALLOW_HEADLESS:-0}" != "1" ] && [ "${CLAUDE_CODE_ENTRYPOINT:-}" = "sdk-cli" ]; then
+  exit 0
+fi
+
 # If no CLI arg was given and stdin is a terminal (not a pipe from Claude Code),
 # the user likely ran `peon` bare — show help instead of blocking on cat.
 if [ -t 0 ]; then

--- a/tests/peon.bats
+++ b/tests/peon.bats
@@ -212,6 +212,35 @@ JSON
 }
 
 # ============================================================
+# Non-interactive mode suppression
+# ============================================================
+
+@test "sdk-cli suppresses sound" {
+  CLAUDE_CODE_ENTRYPOINT=sdk-cli run_peon '{"hook_event_name":"SessionStart","cwd":"/tmp/myproject","session_id":"s1","permission_mode":"default"}'
+  [ "$PEON_EXIT" -eq 0 ]
+  ! afplay_was_called
+}
+
+@test "interactive mode (cli) still plays sound" {
+  CLAUDE_CODE_ENTRYPOINT=cli run_peon '{"hook_event_name":"SessionStart","cwd":"/tmp/myproject","session_id":"s1","permission_mode":"default"}'
+  [ "$PEON_EXIT" -eq 0 ]
+  afplay_was_called
+}
+
+@test "unset CLAUDE_CODE_ENTRYPOINT still plays sound" {
+  unset CLAUDE_CODE_ENTRYPOINT
+  run_peon '{"hook_event_name":"SessionStart","cwd":"/tmp/myproject","session_id":"s1","permission_mode":"default"}'
+  [ "$PEON_EXIT" -eq 0 ]
+  afplay_was_called
+}
+
+@test "PEON_ALLOW_HEADLESS=1 overrides sdk-cli suppression" {
+  CLAUDE_CODE_ENTRYPOINT=sdk-cli PEON_ALLOW_HEADLESS=1 run_peon '{"hook_event_name":"SessionStart","cwd":"/tmp/myproject","session_id":"s1","permission_mode":"default"}'
+  [ "$PEON_EXIT" -eq 0 ]
+  afplay_was_called
+}
+
+# ============================================================
 # Missing config (defaults)
 # ============================================================
 


### PR DESCRIPTION
## Summary

- Skip sound playback when Claude Code runs in non-interactive mode (`claude -p` / `claude --print`) by checking the undocumented `CLAUDE_CODE_ENTRYPOINT` env var
- Only matches the exact value `sdk-cli`; if the env var is missing, removed, or has a different value, peon-ping runs normally
- Users who want sounds in headless mode can set `PEON_ALLOW_HEADLESS=1`

Closes #339

`CLAUDE_CODE_ENTRYPOINT` is not documented by Anthropic. The check is intentionally conservative: it only matches the exact value `sdk-cli` and defaults to normal behavior in all other cases. If Anthropic removes or changes this env var, the only consequence is that sounds return in `claude -p`, which is the same behavior as before this change.