### PR TITLE
fix: add pactl fallback for meeting detection on Linux

### DIFF
--- a/peon.sh
+++ b/peon.sh
@@ -98,6 +98,12 @@ detect_meeting() {
         local sources
         sources=$(wpctl status 2>/dev/null | grep -A50 "Audio/Source" | grep "RUNNING") || true
         [ -n "$sources" ] && return 0
+      elif command -v pactl &>/dev/null; then
+        # pactl: any source-output that isn't a peak detector means mic is in use
+        local total peak
+        total=$(pactl list source-outputs 2>/dev/null | grep -c 'Source Output #') || true
+        peak=$(pactl list source-outputs 2>/dev/null | grep -c 'media\.name = "Peak detect"') || true
+        [ "${total:-0}" -gt "${peak:-0}" ] && return 0
       fi
       return 1
       ;;


### PR DESCRIPTION
## Summary
- `detect_meeting()` on Linux only checked `wpctl` (PipeWire) for active audio sources
- On PulseAudio-only systems (no PipeWire), meeting detection silently failed — sounds played during calls even with `meeting_detect: true`
- Adds `pactl` fallback: counts `source-outputs` and subtracts passive "Peak detect" entries (e.g. GNOME Volume Control). If any real mic consumers remain (Teams, Zoom, Chrome WebRTC, etc.), the user is treated as in a meeting

## Test plan
- [x] Tested on Ubuntu with PulseAudio (no PipeWire/wpctl)
- [x] No meeting: only "Peak detect" source-output present → `in_meeting=no`
- [x] In meeting (Chromium WebRTC): "RecordStream" source-output appears → `in_meeting=yes`
- [ ] Verify no regression on PipeWire systems (wpctl path unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)