### PR TITLE
fix: clear needs_approval tab color on tool use events

### DIFF
--- a/peon.sh
+++ b/peon.sh
@@ -3356,8 +3356,11 @@ elif event == 'SessionEnd':
     print('EVENT=' + q(event))
     print('PEON_EXIT=true')
     sys.exit(0)
+elif event in ('PreToolUse', 'PostToolUse'):
+    # Tool use events indicate Claude is actively working — clear needs_approval tab color
+    status = 'working'
 else:
-    # Unknown event (e.g. PreToolUse, PostToolUse, plan mode events) — no sound, but maintain tab title
+    # Unknown event (plan mode, etc.) — no sound, but maintain tab title
     print('PROJECT=' + q(project or ''))
     print('STATUS=working')
     print('MARKER=')


### PR DESCRIPTION
## Problem

After a `PermissionRequest` sets the tab color to `needs_approval` (e.g. red), the color stays stuck until the next `Stop` event. This is because `PreToolUse` and `PostToolUse` events are handled by the early-exit path which updates the tab **title** but skips the tab **color** escape sequences (OSC 6).

In practice, after a user approves a permission prompt, the tab stays red for the entire duration of Claude's response instead of transitioning back to the `working` color.

## Fix

Handle `PreToolUse` and `PostToolUse` as proper events that set `status='working'` and flow through to the tab color logic. No sound is triggered since `category` stays empty.

**Flow after fix:**
```
PermissionRequest → needs_approval (red tab)
User approves → tool runs → PostToolUse → working (amber tab)
Claude finishes → Stop → done (green tab)
```

## Testing

1. Configure distinct tab colors for `needs_approval` and `working`
2. Run Claude Code, trigger a permission prompt
3. Approve the permission
4. Tab color should transition from `needs_approval` to `working` immediately after approval