### PR TITLE
feat: use MediaPlayer with volume control for WAV playback on Windows

### DIFF
--- a/scripts/win-play.ps1
+++ b/scripts/win-play.ps1
@@ -8,12 +8,47 @@ param(
 # Diagnostic logging: set PEON_DEBUG=1 to surface silent failure diagnostics on stderr
 $peonDebug = $env:PEON_DEBUG -eq "1"
 
-# WAV files: use SoundPlayer (works correctly in hidden/detached processes)
+# WAV files: use MediaPlayer with volume control
+# (MediaPlayer is WPF/PresentationCore — safe in this detached process, not in the hook itself)
 if ($path -match "\.wav$") {
     try {
-        $sp = New-Object System.Media.SoundPlayer $path
-        $sp.PlaySync()
-        $sp.Dispose()
+        Add-Type -AssemblyName PresentationCore
+        $player = [System.Windows.Media.MediaPlayer]::new()
+        $player.Volume = $vol
+
+        Register-ObjectEvent -InputObject $player -EventName MediaOpened -SourceIdentifier MediaOpened | Out-Null
+        Register-ObjectEvent -InputObject $player -EventName MediaFailed -SourceIdentifier MediaFailed | Out-Null
+        $player.Open([uri]::new($path))
+        $player.Play()
+
+        # Pump WPF dispatcher so MediaOpened/MediaFailed events fire in this console process
+        $deadline = [datetime]::UtcNow.AddSeconds(5)
+        $failed = $false
+        while ([datetime]::UtcNow -lt $deadline) {
+            [System.Windows.Threading.Dispatcher]::CurrentDispatcher.Invoke(
+                [System.Windows.Threading.DispatcherPriority]::Background,
+                [Action]{ }
+            )
+            $failEvt = Get-Event -SourceIdentifier MediaFailed -ErrorAction SilentlyContinue
+            if ($failEvt) {
+                $failed = $true
+                if ($peonDebug) { Write-Warning "peon-ping: WAV playback failed for '$path': $($failEvt.SourceEventArgs.ErrorException)" }
+                break
+            }
+            $evt = Get-Event -SourceIdentifier MediaOpened -ErrorAction SilentlyContinue
+            if ($evt) { break }
+            Start-Sleep -Milliseconds 50
+        }
+
+        # Wait for playback to finish (only if opened successfully)
+        if (-not $failed -and $player.NaturalDuration.HasTimeSpan) {
+            $secs = $player.NaturalDuration.TimeSpan.TotalSeconds
+            Start-Sleep -Seconds ([math]::Ceiling($secs))
+        }
+
+        Unregister-Event -SourceIdentifier MediaOpened -ErrorAction SilentlyContinue
+        Unregister-Event -SourceIdentifier MediaFailed -ErrorAction SilentlyContinue
+        $player.Close()
     } catch {
         if ($peonDebug) { Write-Warning "peon-ping: WAV playback failed for '$path': $_" }
     }
@@ -21,7 +56,7 @@ if ($path -match "\.wav$") {
 }
 
 # Non-WAV formats (mp3, ogg, etc.): CLI player priority chain
-# ffplay -> mpv -> vlc (no MediaPlayer — it deadlocks in headless PowerShell)
+# ffplay -> mpv -> vlc (MediaPlayer only handles WAV above; CLI players for other formats)
 
 # ffplay: volume 0-100 integer scale
 $ffplay = Get-Command ffplay -ErrorAction SilentlyContinue

--- a/tests/adapters-windows.Tests.ps1
+++ b/tests/adapters-windows.Tests.ps1
@@ -729,15 +729,17 @@ Describe "win-play.ps1 Audio Backend" {
         $script:winPlayContent | Should -Match '\[double\]\$vol'
     }
 
-    It "uses SoundPlayer for WAV files" {
+    It "uses MediaPlayer for WAV files with volume control" {
         $script:winPlayContent | Should -Match '\.wav\$'
-        $script:winPlayContent | Should -Match 'System\.Media\.SoundPlayer'
-        $script:winPlayContent | Should -Match 'PlaySync'
+        $script:winPlayContent | Should -Match 'PresentationCore'
+        $script:winPlayContent | Should -Match 'System\.Windows\.Media\.MediaPlayer'
+        $script:winPlayContent | Should -Match '\$player\.Volume = \$vol'
     }
 
-    It "contains zero references to MediaPlayer or PresentationCore" {
-        $script:winPlayContent | Should -Not -Match 'System\.Windows\.Media\.MediaPlayer'
-        $script:winPlayContent | Should -Not -Match 'PresentationCore'
+    It "uses MediaPlayer event subscription for playback duration" {
+        $script:winPlayContent | Should -Match 'Register-ObjectEvent'
+        $script:winPlayContent | Should -Match 'MediaOpened'
+        $script:winPlayContent | Should -Match 'NaturalDuration'
     }
 
     It "uses ffplay as first CLI player choice" {
@@ -774,8 +776,8 @@ Describe "win-play.ps1 Audio Backend" {
         $script:winPlayContent | Should -Match 'exit 0'
     }
 
-    It "disposes SoundPlayer after playback" {
-        $script:winPlayContent | Should -Match '\$sp\.Dispose\(\)'
+    It "closes MediaPlayer after playback" {
+        $script:winPlayContent | Should -Match '\$player\.Close\(\)'
     }
 }
 


### PR DESCRIPTION
Replace System.Media.SoundPlayer (which ignores volume) with System.Windows.Media.MediaPlayer in win-play.ps1. Subscribe to MediaOpened event via dispatcher pump to wait for playback duration.

I, a certified human, have manually verified that it works well in my environment!