### PR TITLE
fix: preserve multi-line YAML command values in rovodev hook installer

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -124,7 +124,21 @@ else:
         elif in_events and current_event and stripped.startswith('- command:'):
             if cmd_indent is None:
                 cmd_indent = len(line) - len(stripped)
-            event_map[current_event]['last_cmd_idx'] = i
+            cmd_line_indent = len(line) - len(stripped)
+            # Scan past YAML continuation lines (more deeply indented than the
+            # '- command:' key and not starting a new YAML key at the same or
+            # lesser indent).  This handles multi-line command values such as
+            # osascript strings that wrap across lines.
+            end = i
+            for j in range(i + 1, len(lines)):
+                cline = lines[j]
+                if not cline or not cline.strip():
+                    break
+                cline_indent = len(cline) - len(cline.lstrip())
+                if cline_indent <= cmd_line_indent:
+                    break
+                end = j
+            event_map[current_event]['last_cmd_idx'] = end
         elif in_events and line and not line.startswith(' ') and not line.startswith('\t'):
             break
 

--- a/tests/rovodev.bats
+++ b/tests/rovodev.bats
@@ -346,6 +346,47 @@ EOF
   teardown_install_env
 }
 
+@test "install: preserves multi-line command values when appending hooks" {
+  setup_install_env
+  mkdir -p "$INSTALL_HOME/.rovodev"
+  cat > "$INSTALL_HOME/.rovodev/config.yml" <<'EOF'
+eventHooks:
+  logFile: /Users/testuser/.rovodev/event_hooks.log
+  events:
+  - name: on_tool_permission
+    commands:
+    - command: osascript -e 'display notification "Rovo Dev CLI needs permission to
+        use tools to continue." with title "Rovo Dev CLI"'
+  - name: on_complete
+    commands:
+    - command: osascript -e 'display notification "on_complete" with title "Rovo Dev
+        CLI"'
+  - name: on_error
+    commands:
+    - command: osascript -e 'display notification "on_error" with title "Rovo Dev
+        CLI"'
+EOF
+  bash "$CLONE_DIR/install.sh"
+  local cfg="$INSTALL_HOME/.rovodev/config.yml"
+  # Multi-line osascript commands must remain intact (continuation lines not split)
+  grep -q 'use tools to continue." with title "Rovo Dev CLI"' "$cfg"
+  # The peon-ping command must appear AFTER the continuation line, not before it
+  local perm_cmd_line
+  perm_cmd_line=$(grep -n 'rovodev.sh on_tool_permission' "$cfg" | head -1 | cut -d: -f1)
+  local continuation_line
+  continuation_line=$(grep -n 'use tools to continue' "$cfg" | head -1 | cut -d: -f1)
+  [ "$perm_cmd_line" -gt "$continuation_line" ]
+  # rovodev.sh commands added for all events
+  grep -q "rovodev.sh on_complete" "$cfg"
+  grep -q "rovodev.sh on_error" "$cfg"
+  grep -q "rovodev.sh on_tool_permission" "$cfg"
+  # No duplicate events
+  [ "$(grep -c '\- name: on_complete' "$cfg")" -eq 1 ]
+  [ "$(grep -c '\- name: on_error' "$cfg")" -eq 1 ]
+  [ "$(grep -c '\- name: on_tool_permission' "$cfg")" -eq 1 ]
+  teardown_install_env
+}
+
 @test "install: detects config.yaml extension" {
   setup_install_env
   mkdir -p "$INSTALL_HOME/.rovodev"


### PR DESCRIPTION
### Problem
When setting up peon-ping into an existing `~/.rovodev/config.yml`, it breaks any commands whose YAML values span multiple lines.
The Python YAML parser tracked `last_cmd_idx` as the line number of the `- command:` key, but didn't account for plain scalar continuation lines. The new `- command: bash ... rovodev.sh` entry was inserted at `last_cmd_idx + 1`, which landed in the middle of the multi-line value — splitting the original command and corrupting both entries.

#### Before (valid config):
```
- command: osascript -e 'display notification "Rovo Dev CLI needs permission to
    use tools to continue." with title "Rovo Dev CLI"'
```
#### After install (broken):
```
- command: osascript -e 'display notification "Rovo Dev CLI needs permission to
- command: bash /Users/user/.claude/hooks/peon-ping/adapters/rovodev.sh on_tool_permission
    use tools to continue." with title "Rovo Dev CLI"'
```
### Fix
After finding a `- command:` line, the parser now scans forward past any YAML continuation lines (lines indented more deeply than the `- command:` key) before recording `last_cmd_idx`.