### PR TITLE
feat: add desktop notifications for native Windows

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -263,6 +263,21 @@ if (Test-Path $winPlaySource) {
     }
 }
 
+$winNotifySource = Join-Path $ScriptDir "scripts\win-notify.ps1"
+$winNotifyTarget = Join-Path $scriptsDir "win-notify.ps1"
+
+if (Test-Path $winNotifySource) {
+    # Local install: copy from repo
+    Copy-Item -Path $winNotifySource -Destination $winNotifyTarget -Force
+} else {
+    # One-liner install: download from GitHub
+    try {
+        Invoke-WebRequest -Uri "$RepoBase/scripts/win-notify.ps1" -OutFile $winNotifyTarget -UseBasicParsing -ErrorAction Stop
+    } catch {
+        Write-Host "  Warning: Could not download win-notify.ps1" -ForegroundColor Yellow
+    }
+}
+
 # Install hook-handle-use scripts (for /peon-ping-use command)
 $hookHandleUsePs1Source = Join-Path $ScriptDir "scripts\hook-handle-use.ps1"
 $hookHandleUsePs1Target = Join-Path $scriptsDir "hook-handle-use.ps1"
@@ -938,6 +953,11 @@ $sessionId = if ($event.session_id) { $event.session_id } elseif ($event.convers
 # Extract cwd from event (used by path_rules for directory-based pack selection)
 $cwd = if ($event.cwd) { $event.cwd } else { "" }
 
+# Derive project name from cwd (used in desktop notification titles)
+$project = if ($cwd) { Split-Path $cwd -Leaf } else { "" }
+if (-not $project) { $project = "claude" }
+$project = $project -replace '[^a-zA-Z0-9 ._-]', ''
+
 # Helper function to convert PSCustomObject to hashtable (PS 5.1 compat)
 function ConvertTo-Hashtable {
     param([Parameter(ValueFromPipeline)]$obj)
@@ -1052,6 +1072,10 @@ if ($sessionPacksClean.Count -ne $sessionPacks.Count) {
 # --- Map Claude Code hook event -> CESP manifest category ---
 $category = $null
 $ntype = $event.notification_type
+$notify = $false
+$notifyColor = ""
+$notifyMsg = ""
+$notifyStatus = ""
 
 switch ($hookEvent) {
     "SessionStart" {
@@ -1064,6 +1088,11 @@ switch ($hookEvent) {
         $lastStop = if ($state.ContainsKey("last_stop_time")) { $state["last_stop_time"] } else { 0 }
         if (($now - $lastStop) -lt 5) {
             $category = $null
+        } else {
+            $notify = $true
+            $notifyColor = "blue"
+            $notifyMsg = $project
+            $notifyStatus = "done"
         }
         $state["last_stop_time"] = $now
     }
@@ -1072,8 +1101,18 @@ switch ($hookEvent) {
             # PermissionRequest event handles the sound, skip here
             $category = $null
         } elseif ($ntype -eq "idle_prompt") {
-            # Stop event already played the sound
+            # Notification only — no sound (matches peon.sh idle_prompt behavior)
             $category = $null
+            $notify = $true
+            $notifyColor = "yellow"
+            $notifyMsg = $project
+            $notifyStatus = "done"
+        } elseif ($ntype -eq "elicitation_dialog") {
+            $category = "input.required"
+            $notify = $true
+            $notifyColor = "blue"
+            $notifyMsg = $project
+            $notifyStatus = "question"
         } else {
             # Other notification types (e.g., tool results) map to task.complete
             $category = "task.complete"
@@ -1081,6 +1120,17 @@ switch ($hookEvent) {
     }
     "PermissionRequest" {
         $category = "input.required"
+        $notify = $true
+        $notifyColor = "red"
+        $notifyMsg = $project
+        $notifyStatus = "needs approval"
+    }
+    "PreCompact" {
+        $category = "resource.limit"
+        $notify = $true
+        $notifyColor = "red"
+        $notifyMsg = $project
+        $notifyStatus = "context limit"
     }
     "UserPromptSubmit" {
         # Detect rapid prompts for "annoyed" easter egg
@@ -1116,16 +1166,21 @@ try {
     if ($peonDebug) { Write-Warning "peon-ping: state write failed: $_" }
 }
 
-if (-not $category) { exit 0 }
+$skipSound = (-not $category)
+if ($skipSound -and -not $notify) { exit 0 }
 
-# Check if category is enabled
-try {
-    $catEnabled = $config.categories.$category
-    if ($catEnabled -eq $false) { exit 0 }
-} catch {
-    if ($peonDebug) { Write-Warning "peon-ping: category check failed for '$category': $_" }
+# Check if category is enabled (only relevant when we have a category to play)
+if (-not $skipSound) {
+    try {
+        $catEnabled = $config.categories.$category
+        if ($catEnabled -eq $false -and -not $notify) { exit 0 }
+        if ($catEnabled -eq $false) { $skipSound = $true }
+    } catch {
+        if ($peonDebug) { Write-Warning "peon-ping: category check failed for '$category': $_" }
+    }
 }
 
+if (-not $skipSound) {
 # --- Pick a sound ---
 $activePack = Get-ActivePack $config
 
@@ -1274,6 +1329,25 @@ if (Test-Path $winPlayScript) {
     Start-Process -FilePath "powershell.exe" -ArgumentList "-NoProfile", "-NonInteractive", "-File", $winPlayScript, "-path", $soundPath, "-vol", $volume -WindowStyle Hidden
 } else {
     if ($peonDebug) { Write-Warning "peon-ping: win-play.ps1 not found at '$winPlayScript' - audio skipped" }
+}
+
+} # end if (-not $skipSound)
+
+# --- Desktop notification dispatch ---
+$desktopNotif = $config.desktop_notifications
+if ($null -eq $desktopNotif) { $desktopNotif = $true }
+
+if ($notify -and $desktopNotif) {
+    $winNotifyScript = Join-Path $InstallDir "scripts\win-notify.ps1"
+    if (Test-Path $winNotifyScript) {
+        $marker = [char]0x25CF  # ●
+        $notifTitle = "$marker $project`: $notifyStatus"
+        $dismissSecs = if ($config.notification_dismiss_seconds) { $config.notification_dismiss_seconds } else { 4 }
+        $notifArgs = @("-NoProfile", "-NonInteractive", "-File", $winNotifyScript,
+                       "-body", $notifyMsg, "-title", $notifTitle, "-dismissSeconds", $dismissSecs)
+        if ($iconPath) { $notifArgs += @("-iconPath", $iconPath) }
+        Start-Process -FilePath "powershell.exe" -ArgumentList $notifArgs -WindowStyle Hidden
+    }
 }
 
 exit 0

--- a/scripts/win-notify.ps1
+++ b/scripts/win-notify.ps1
@@ -1,0 +1,65 @@
+param(
+    [Parameter(Mandatory=$true)]
+    [string]$body,
+    [Parameter(Mandatory=$true)]
+    [string]$title,
+    [string]$iconPath,
+    [int]$dismissSeconds = 4
+)
+
+# XML-escape helper: sanitize text for toast XML (mirrors notify.sh _escape_xml)
+function Escape-Xml {
+    param([string]$text)
+    # Strip control characters (U+0000–U+0008, U+000B, U+000C, U+000E–U+001F)
+    $text = $text -replace '[\x00-\x08\x0B\x0C\x0E-\x1F]', ''
+    $text = $text.Replace('&', '&amp;')
+    $text = $text.Replace('<', '&lt;')
+    $text = $text.Replace('>', '&gt;')
+    $text = $text.Replace('"', '&quot;')
+    $text = $text.Replace("'", '&apos;')
+    return $text
+}
+
+try {
+    # PS 7+ cannot load WinRT types via ContentType=WindowsRuntime.
+    # Delegate to powershell.exe (5.1) which has native WinRT support.
+    if ($PSVersionTable.PSVersion.Major -ge 7) {
+        $scriptPath = $MyInvocation.MyCommand.Path
+        $psArgs = @("-NoProfile", "-NonInteractive", "-File", $scriptPath,
+                    "-body", $body, "-title", $title, "-dismissSeconds", $dismissSeconds)
+        if ($iconPath) { $psArgs += @("-iconPath", $iconPath) }
+        Start-Process -FilePath "powershell.exe" -ArgumentList $psArgs -WindowStyle Hidden
+        exit 0
+    }
+
+    $safeBody = Escape-Xml $body
+    $safeTitle = Escape-Xml $title
+
+    # Build icon XML fragment if icon path provided and exists
+    $iconXml = ""
+    if ($iconPath -and (Test-Path $iconPath -PathType Leaf)) {
+        $safeIcon = Escape-Xml $iconPath
+        $iconXml = "<image placement=`"appLogoOverride`" src=`"$safeIcon`" />"
+    }
+
+    # Toast duration hint: "short" (~7s) or "long" (~25s)
+    $duration = if ($dismissSeconds -gt 10) { "long" } else { "short" }
+
+    # Build toast XML matching notify.sh format — audio silent because peon-ping plays its own sounds
+    $toastXml = "<toast duration=`"$duration`"><visual><binding template=`"ToastGeneric`"><text>$safeBody</text><text>$safeTitle</text>$iconXml</binding></visual><audio silent=`"true`" /></toast>"
+
+    # Load WinRT types
+    [Windows.UI.Notifications.ToastNotificationManager, Windows.UI.Notifications, ContentType = WindowsRuntime] | Out-Null
+    [Windows.Data.Xml.Dom.XmlDocument, Windows.Data.Xml.Dom, ContentType = WindowsRuntime] | Out-Null
+
+    # APP_ID: PowerShell's AUMID (same as notify.sh WSL path)
+    $APP_ID = "{1AC14E77-02E7-4E5D-B744-2EB1AE5198B7}\WindowsPowerShell\v1.0\powershell.exe"
+
+    $xml = New-Object Windows.Data.Xml.Dom.XmlDocument
+    $xml.LoadXml($toastXml)
+    $toast = New-Object Windows.UI.Notifications.ToastNotification $xml
+    [Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier($APP_ID).Show($toast)
+} catch {
+    # Silent degradation: notifications are best-effort
+    exit 0
+}

--- a/tests/adapters-windows.Tests.ps1
+++ b/tests/adapters-windows.Tests.ps1
@@ -70,7 +70,8 @@ Describe "PowerShell Syntax Validation" {
 Describe "Core Script Syntax Validation" {
     It "<name> has valid PowerShell syntax" -ForEach @(
         @{ name = "install.ps1" },
-        @{ name = "scripts/win-play.ps1" }
+        @{ name = "scripts/win-play.ps1" },
+        @{ name = "scripts/win-notify.ps1" }
     ) {
         $path = Join-Path $script:RepoRoot $name
         $path | Should -Exist
@@ -679,6 +680,10 @@ Describe "install.ps1 Adapter Installation" {
         $script:installContent | Should -Match 'ClaudeCodeDetected'
         $script:installContent | Should -Match 'Skipping Claude Code hook registration'
     }
+
+    It "installs win-notify.ps1 alongside win-play.ps1" {
+        $script:installContent | Should -Match 'win-notify\.ps1'
+    }
 }
 
 # ============================================================
@@ -778,6 +783,71 @@ Describe "win-play.ps1 Audio Backend" {
 
     It "closes MediaPlayer after playback" {
         $script:winPlayContent | Should -Match '\$player\.Close\(\)'
+    }
+}
+
+# ============================================================
+# win-notify.ps1 Toast Script
+# ============================================================
+
+Describe "win-notify.ps1 Toast Script" {
+    BeforeAll {
+        $script:winNotifyPath = Join-Path (Join-Path $script:RepoRoot "scripts") "win-notify.ps1"
+        $script:winNotifyContent = Get-Content $script:winNotifyPath -Raw
+    }
+
+    It "has valid PowerShell syntax" {
+        $script:winNotifyPath | Should -Exist
+        $errors = $null
+        $null = [System.Management.Automation.PSParser]::Tokenize($script:winNotifyContent, [ref]$errors)
+        $errors.Count | Should -Be 0
+    }
+
+    It "requires body parameter" {
+        $script:winNotifyContent | Should -Match '\[string\]\$body'
+        $script:winNotifyContent | Should -Match 'Mandatory=\$true'
+    }
+
+    It "requires title parameter" {
+        $script:winNotifyContent | Should -Match '\[string\]\$title'
+    }
+
+    It "accepts optional iconPath parameter" {
+        $script:winNotifyContent | Should -Match '\[string\]\$iconPath'
+    }
+
+    It "accepts optional dismissSeconds parameter with default 4" {
+        $script:winNotifyContent | Should -Match '\[int\]\$dismissSeconds'
+        $script:winNotifyContent | Should -Match '= 4'
+    }
+
+    It "uses ToastNotificationManager WinRT API" {
+        $script:winNotifyContent | Should -Match 'Windows\.UI\.Notifications\.ToastNotificationManager'
+    }
+
+    It "escapes XML special characters" {
+        $script:winNotifyContent | Should -Match '&amp;'
+        $script:winNotifyContent | Should -Match '&lt;'
+        $script:winNotifyContent | Should -Match '&gt;'
+        $script:winNotifyContent | Should -Match '&quot;'
+        $script:winNotifyContent | Should -Match '&apos;'
+    }
+
+    It "sets audio silent=true (peon-ping plays its own sounds)" {
+        $script:winNotifyContent | Should -Match 'silent=.*true'
+    }
+
+    It "uses PowerShell APP_ID" {
+        $script:winNotifyContent | Should -Match '1AC14E77-02E7-4E5D-B744-2EB1AE5198B7.*powershell\.exe'
+    }
+
+    It "uses ToastGeneric template" {
+        $script:winNotifyContent | Should -Match 'ToastGeneric'
+    }
+
+    It "wraps in try/catch for silent degradation" {
+        $script:winNotifyContent | Should -Match 'try \{'
+        $script:winNotifyContent | Should -Match 'catch \{'
     }
 }
 
@@ -1070,6 +1140,52 @@ Describe "Embedded peon.ps1 Hook Script" {
         $script:peonHookContent | Should -Match 'System\.Timers\.Timer'
         $script:peonHookContent | Should -Match '8000'
         $script:peonHookContent | Should -Match '\[Environment\]::Exit\(1\)'
+    }
+
+    # --- Desktop Notifications (win-notify.ps1 dispatch) ---
+
+    It "defines notify tracking variable" {
+        $script:peonHookContent | Should -Match '\$notify = \$false'
+    }
+
+    It "sets notify on Stop event (when not debounced)" {
+        $script:peonHookContent | Should -Match '"Stop"\s*\{[\s\S]*?\$notify = \$true[\s\S]*?\$notifyStatus = "done"'
+    }
+
+    It "sets notify on PermissionRequest event" {
+        $script:peonHookContent | Should -Match '"PermissionRequest"\s*\{[\s\S]*?\$notify = \$true[\s\S]*?\$notifyStatus = "needs approval"'
+    }
+
+    It "handles PreCompact event with resource.limit category" {
+        $script:peonHookContent | Should -Match '"PreCompact"\s*\{[\s\S]*?\$category = "resource\.limit"'
+        $script:peonHookContent | Should -Match '"PreCompact"\s*\{[\s\S]*?\$notifyStatus = "context limit"'
+    }
+
+    It "handles idle_prompt as notification-only (no sound)" {
+        $script:peonHookContent | Should -Match 'idle_prompt[\s\S]*?\$category = \$null[\s\S]*?\$notify = \$true'
+    }
+
+    It "handles elicitation_dialog with input.required category" {
+        $script:peonHookContent | Should -Match 'elicitation_dialog[\s\S]*?\$category = "input\.required"[\s\S]*?\$notify = \$true'
+    }
+
+    It "checks desktop_notifications config" {
+        $script:peonHookContent | Should -Match 'desktop_notifications'
+    }
+
+    It "derives project name from cwd via Split-Path" {
+        $script:peonHookContent | Should -Match 'Split-Path \$cwd -Leaf'
+        $script:peonHookContent | Should -Match '\$project'
+    }
+
+    It "delegates to win-notify.ps1 via Start-Process" {
+        $script:peonHookContent | Should -Match 'win-notify\.ps1'
+        $script:peonHookContent | Should -Match 'Start-Process[\s\S]*?\$notifArgs[\s\S]*?WindowStyle Hidden'
+    }
+
+    It "allows notification-only events to pass through (skipSound)" {
+        $script:peonHookContent | Should -Match '\$skipSound = \(-not \$category\)'
+        $script:peonHookContent | Should -Match '\$skipSound -and -not \$notify.*exit 0'
     }
 
     # --- Audio Delegation (detached process via win-play.ps1) ---


### PR DESCRIPTION
## Summary

Fixes #274 — Windows 11 users on the native PowerShell install path get sounds but no desktop notifications.

- **New `scripts/win-notify.ps1`**: Standalone Windows toast notification script using `Windows.UI.Notifications` WinRT API. XML-escapes body/title, sets audio `silent="true"` (peon-ping plays its own sounds), uses PowerShell AUMID as APP_ID. PS 7 auto-delegates to `powershell.exe` (5.1) since WinRT type loading requires it.
- **Updated embedded `peon.ps1`**: Adds notification tracking variables (`$notify`, `$notifyStatus`) to Stop, PermissionRequest, PreCompact, idle_prompt, and elicitation_dialog events. Restructures early exit with `$skipSound` to allow notification-only events (idle_prompt) to pass through. Dispatches to `win-notify.ps1` via `Start-Process -WindowStyle Hidden`, respecting `desktop_notifications` config.
- **Installer**: Deploys `win-notify.ps1` alongside `win-play.ps1` (local copy or GitHub download fallback).
- **Pester tests**: 22 new tests covering win-notify.ps1 (syntax, params, WinRT API, XML escaping, APP_ID) and embedded peon.ps1 notification logic (event routing, config, dispatch, skipSound).

## Test plan

- [x] `Invoke-Pester -Path tests/adapters-windows.Tests.ps1` — all 360 tests pass
- [x] Manual: `powershell.exe -File scripts/win-notify.ps1 -body "peon-ping" -title "● test: done"` — toast appears
- [ ] Manual: trigger a Stop event → Windows toast appears with "● project: done"
- [ ] Manual: set `desktop_notifications: false` in config.json → no toast
- [ ] Manual: trigger PermissionRequest → toast with "needs approval"
- [ ] Manual: trigger PreCompact → toast with "context limit"