### PR TITLE
feat: notification template resolution for Windows

### DIFF
--- a/docs/designs/win-notification-templates.md
+++ b/docs/designs/win-notification-templates.md
@@ -1,0 +1,73 @@
+# Windows Notification Template Resolution Engine
+
+**Date**: 2026-03-24
+**Card**: kr62ia
+**Status**: Implementation
+
+## Overview
+
+Port the notification template resolution logic from `peon.sh` (Python block, lines 3698-3723) to PowerShell in `peon.ps1` (embedded in `install.ps1`). This achieves feature parity for Windows users.
+
+## Unix Reference Implementation (peon.sh:3698-3723)
+
+The Python block:
+1. Maps categories to template keys: `task.complete` -> `stop`, `task.error` -> `error`
+2. Applies event-specific overrides: `PermissionRequest` -> `permission`, `idle_prompt` -> `idle`, `elicitation_dialog` -> `question`
+3. Looks up template string from `config.notification_templates[key]`
+4. Substitutes variables using `format_map()` with a `defaultdict(str)` (unknown vars -> empty string)
+5. Truncates `transcript_summary` to 120 chars
+
+## PowerShell Implementation
+
+### Insertion Point
+
+After the sound-picking block closes (`} # end if (-not $skipSound)` at ~line 1342) and before the desktop notification dispatch section (~line 1344). This ensures `$notifyMsg` is overwritten with the resolved template before it reaches `win-notify.ps1`.
+
+### Template Key Mapping
+
+```powershell
+$tplKeyMap = @{ 'task.complete' = 'stop'; 'task.error' = 'error' }
+$tplKey = if ($category -and $tplKeyMap.ContainsKey($category)) { $tplKeyMap[$category] } else { $null }
+# Event-specific overrides
+if ($hookEvent -eq 'PermissionRequest') { $tplKey = 'permission' }
+if ($ntype -eq 'idle_prompt') { $tplKey = 'idle' }
+if ($ntype -eq 'elicitation_dialog') { $tplKey = 'question' }
+```
+
+### Variable Substitution
+
+Uses `[regex]::Replace` with a ScriptBlock evaluator (available since PS 2.0):
+
+```powershell
+$tplVars = @{
+    project   = $project
+    summary   = ($summaryRaw).Substring(0, [Math]::Min($summaryRaw.Length, 120))
+    tool_name = ($event.tool_name -as [string])
+    status    = $notifyStatus
+    event     = $hookEvent
+}
+$notifyMsg = [regex]::Replace($tpl, '\{(\w+)\}', {
+    param($m)
+    $key = $m.Groups[1].Value
+    if ($tplVars.ContainsKey($key)) { $tplVars[$key] } else { "" }
+})
+```
+
+### Fallback Behavior
+
+- Missing or empty `notification_templates` config: `$notifyMsg` retains its original value (project name)
+- Missing template key: no substitution, original `$notifyMsg` preserved
+- Unknown `{variable}`: replaced with empty string
+
+## Test Strategy
+
+8 Pester scenarios in `tests/win-notification-templates.Tests.ps1`:
+
+1. Stop with `{summary}` template
+2. Stop without `transcript_summary` (resolves to empty)
+3. PermissionRequest with `{tool_name}`
+4. No template configured (fallback to project name)
+5. Unknown variable renders as empty
+6. All five template keys map from correct events
+7. Summary truncation at 120 chars
+8. Special characters in project/tool names

--- a/install.ps1
+++ b/install.ps1
@@ -1723,6 +1723,40 @@ if ($trainerMsg) {
     }
 }
 
+# --- Notification message template resolution ---
+# Mirrors peon.sh Python block (lines 3698-3723): maps event to template key,
+# substitutes {variables} via regex, unknown vars become empty strings.
+if ($notify) {
+    $tplKeyMap = @{ 'task.complete' = 'stop'; 'task.error' = 'error' }
+    $tplKey = if ($category -and $tplKeyMap.ContainsKey($category)) { $tplKeyMap[$category] } else { $null }
+    # Event-specific overrides (matches Unix behavior)
+    if ($hookEvent -eq 'PermissionRequest') { $tplKey = 'permission' }
+    if ($ntype -eq 'idle_prompt') { $tplKey = 'idle' }
+    if ($ntype -eq 'elicitation_dialog') { $tplKey = 'question' }
+
+    $templates = $config.notification_templates
+    if ($tplKey -and $templates -and $templates.$tplKey) {
+        $tpl = $templates.$tplKey
+        $summaryRaw = ''
+        try { $summaryRaw = ($event.transcript_summary -as [string]) } catch {}
+        if (-not $summaryRaw) { $summaryRaw = '' }
+        $summaryRaw = $summaryRaw -replace '^\s+|\s+$', ''
+        if ($summaryRaw.Length -gt 120) { $summaryRaw = $summaryRaw.Substring(0, 120) }
+        $tplVars = @{
+            project   = $project
+            summary   = $summaryRaw
+            tool_name = if ($event.tool_name) { ($event.tool_name -as [string]) } else { '' }
+            status    = $notifyStatus
+            event     = $hookEvent
+        }
+        $notifyMsg = [regex]::Replace($tpl, '\{(\w+)\}', {
+            param($m)
+            $key = $m.Groups[1].Value
+            if ($tplVars.ContainsKey($key)) { $tplVars[$key] } else { '' }
+        })
+    }
+}
+
 # --- Desktop notification dispatch ---
 $desktopNotif = $config.desktop_notifications
 if ($null -eq $desktopNotif) { $desktopNotif = $true }

--- a/install.ps1
+++ b/install.ps1
@@ -1729,10 +1729,12 @@ if ($trainerMsg) {
 if ($notify) {
     $tplKeyMap = @{ 'task.complete' = 'stop'; 'task.error' = 'error' }
     $tplKey = if ($category -and $tplKeyMap.ContainsKey($category)) { $tplKeyMap[$category] } else { $null }
-    # Event-specific overrides (matches Unix behavior)
+    # Event-specific overrides (matches Unix behavior: peon.sh lines 3706-3710)
     if ($hookEvent -eq 'PermissionRequest') { $tplKey = 'permission' }
-    if ($ntype -eq 'idle_prompt') { $tplKey = 'idle' }
-    if ($ntype -eq 'elicitation_dialog') { $tplKey = 'question' }
+    if ($hookEvent -eq 'Notification') {
+        if ($ntype -eq 'idle_prompt') { $tplKey = 'idle' }
+        if ($ntype -eq 'elicitation_dialog') { $tplKey = 'question' }
+    }
 
     $templates = $config.notification_templates
     if ($tplKey -and $templates -and $templates.$tplKey) {

--- a/tests/win-notification-templates.Tests.ps1
+++ b/tests/win-notification-templates.Tests.ps1
@@ -1,0 +1,240 @@
+# Pester 5 tests for Windows notification template resolution engine
+# Run: Invoke-Pester -Path tests/win-notification-templates.Tests.ps1
+#
+# Strategy: Unit-test the template resolution logic in isolation.
+# We verify that the template block in install.ps1 (embedded peon.ps1)
+# correctly resolves templates given various inputs. Tests simulate the
+# variables that peon.ps1 sets before the template resolution block runs,
+# then execute the block and check $notifyMsg.
+
+BeforeAll {
+    $script:RepoRoot = Split-Path $PSScriptRoot -Parent
+    $script:InstallPs1 = Join-Path $script:RepoRoot "install.ps1"
+
+    # Extract the template resolution block from the embedded peon.ps1
+    function Get-TemplateResolutionBlock {
+        $content = Get-Content $script:InstallPs1 -Raw
+        # Extract between the markers
+        if ($content -match '(?s)# --- Notification message template resolution ---(.+?)# --- Desktop notification dispatch ---') {
+            return $Matches[1].Trim()
+        }
+        throw "Template resolution block not found in install.ps1"
+    }
+
+    # Build a test scriptblock that sets up variables, runs the template block,
+    # and returns $notifyMsg
+    function Invoke-TemplateResolution {
+        param(
+            [hashtable]$ConfigInput = @{},
+            [string]$HookEventName = "Stop",
+            [string]$CategoryName = "task.complete",
+            [string]$NotificationType = "",
+            [string]$ProjectName = "myproject",
+            [string]$NotifyStatusVal = "done",
+            [string]$NotifyMsgVal = "myproject",
+            [hashtable]$EventData = @{}
+        )
+
+        $tplBlock = Get-TemplateResolutionBlock
+
+        # Build the event properties (mimics ConvertFrom-Json output = PSCustomObject)
+        $eventProps = @{}
+        foreach ($key in $EventData.Keys) {
+            $eventProps[$key] = $EventData[$key]
+        }
+        if ($NotificationType) {
+            $eventProps["notification_type"] = $NotificationType
+        }
+
+        # Write config and event JSON to temp files to avoid quoting issues
+        $tmpDir = Join-Path ([System.IO.Path]::GetTempPath()) "peon-tpl-$([guid]::NewGuid().ToString('N').Substring(0,8))"
+        New-Item -ItemType Directory -Path $tmpDir -Force | Out-Null
+        try {
+            $configPath = Join-Path $tmpDir "config.json"
+            $eventPath = Join-Path $tmpDir "event.json"
+            $ConfigInput | ConvertTo-Json -Depth 5 | Set-Content -Path $configPath -Encoding UTF8
+            $eventProps | ConvertTo-Json -Depth 5 | Set-Content -Path $eventPath -Encoding UTF8
+
+            # Set up variables matching what peon.ps1 has at template resolution time
+            # Variable names must match exactly what the template block uses
+            $notify = $true
+            $hookEvent = $HookEventName
+            $category = $CategoryName
+            $ntype = $NotificationType
+            $project = $ProjectName
+            $notifyStatus = $NotifyStatusVal
+            $notifyMsg = $NotifyMsgVal
+            $config = Get-Content $configPath -Raw | ConvertFrom-Json
+            $event = Get-Content $eventPath -Raw | ConvertFrom-Json
+
+            # Execute the template resolution block
+            Invoke-Expression $tplBlock
+
+            return $notifyMsg
+        } finally {
+            Remove-Item -Path $tmpDir -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+}
+
+# ============================================================
+# Verify template block exists in install.ps1
+# ============================================================
+
+Describe "Template Block Presence" {
+    It "install.ps1 contains the template resolution block" {
+        $content = Get-Content $script:InstallPs1 -Raw
+        $content | Should -Match 'Notification message template resolution'
+        $content | Should -Match 'tplKeyMap'
+    }
+
+    It "template block is syntactically valid PowerShell" {
+        { Get-TemplateResolutionBlock } | Should -Not -Throw
+        $block = Get-TemplateResolutionBlock
+        $errors = $null
+        $null = [System.Management.Automation.PSParser]::Tokenize($block, [ref]$errors)
+        $errors.Count | Should -Be 0
+    }
+}
+
+# ============================================================
+# Template Resolution Tests
+# ============================================================
+
+Describe "Template Resolution: Stop with {summary}" {
+    It "includes project and transcript_summary in notification body" {
+        $result = Invoke-TemplateResolution -ConfigInput @{
+            notification_templates = @{
+                stop = "{project}: {summary}"
+            }
+        } -HookEventName "Stop" -CategoryName "task.complete" -ProjectName "myapp" -NotifyMsgVal "myapp" -EventData @{
+            transcript_summary = "Fixed the login bug and added tests"
+        }
+        $result | Should -Be "myapp: Fixed the login bug and added tests"
+    }
+}
+
+Describe "Template Resolution: Stop without transcript_summary" {
+    It "resolves {summary} to empty string when transcript_summary is missing" {
+        $result = Invoke-TemplateResolution -ConfigInput @{
+            notification_templates = @{
+                stop = "{project}: {summary}"
+            }
+        } -HookEventName "Stop" -CategoryName "task.complete" -ProjectName "myapp" -NotifyMsgVal "myapp"
+        $result | Should -Be "myapp: "
+    }
+}
+
+Describe "Template Resolution: PermissionRequest with {tool_name}" {
+    It "includes tool_name in notification body" {
+        $result = Invoke-TemplateResolution -ConfigInput @{
+            notification_templates = @{
+                permission = "{project} needs {tool_name}"
+            }
+        } -HookEventName "PermissionRequest" -CategoryName "input.required" -ProjectName "myapp" -NotifyMsgVal "myapp" -NotifyStatusVal "needs approval" -EventData @{
+            tool_name = "Bash"
+        }
+        $result | Should -Be "myapp needs Bash"
+    }
+}
+
+Describe "Template Resolution: No template configured" {
+    It "falls back to original notifyMsg when no notification_templates" {
+        $result = Invoke-TemplateResolution -ConfigInput @{} -HookEventName "Stop" -CategoryName "task.complete" -ProjectName "myapp" -NotifyMsgVal "myapp"
+        $result | Should -Be "myapp"
+    }
+}
+
+Describe "Template Resolution: Unknown variable" {
+    It "renders unknown {variables} as empty string" {
+        $result = Invoke-TemplateResolution -ConfigInput @{
+            notification_templates = @{
+                stop = "{project} {nonexistent} done"
+            }
+        } -HookEventName "Stop" -CategoryName "task.complete" -ProjectName "myapp" -NotifyMsgVal "myapp"
+        $result | Should -Be "myapp  done"
+    }
+}
+
+Describe "Template Resolution: All five template keys" {
+    It "maps Stop (task.complete) -> stop template key" {
+        $result = Invoke-TemplateResolution -ConfigInput @{
+            notification_templates = @{ stop = "STOP:{project}" }
+        } -HookEventName "Stop" -CategoryName "task.complete" -ProjectName "proj" -NotifyMsgVal "proj"
+        $result | Should -Be "STOP:proj"
+    }
+
+    It "maps PermissionRequest -> permission template key (overrides category)" {
+        $result = Invoke-TemplateResolution -ConfigInput @{
+            notification_templates = @{ permission = "PERM:{project}" }
+        } -HookEventName "PermissionRequest" -CategoryName "input.required" -ProjectName "proj" -NotifyMsgVal "proj"
+        $result | Should -Be "PERM:proj"
+    }
+
+    It "maps task.error -> error template key" {
+        $content = Get-Content $script:InstallPs1 -Raw
+        $content | Should -Match "'task\.error'\s*=\s*'error'"
+    }
+
+    It "maps idle_prompt Notification -> idle template key" {
+        $result = Invoke-TemplateResolution -ConfigInput @{
+            notification_templates = @{ idle = "IDLE:{project}" }
+        } -HookEventName "Notification" -CategoryName $null -NotificationType "idle_prompt" -ProjectName "proj" -NotifyMsgVal "proj"
+        $result | Should -Be "IDLE:proj"
+    }
+
+    It "maps elicitation_dialog Notification -> question template key" {
+        $result = Invoke-TemplateResolution -ConfigInput @{
+            notification_templates = @{ question = "Q:{project}" }
+        } -HookEventName "Notification" -CategoryName "input.required" -NotificationType "elicitation_dialog" -ProjectName "proj" -NotifyMsgVal "proj"
+        $result | Should -Be "Q:proj"
+    }
+}
+
+Describe "Template Resolution: Summary truncation" {
+    It "truncates transcript_summary to 120 characters" {
+        $longSummary = "A" * 200
+        $result = Invoke-TemplateResolution -ConfigInput @{
+            notification_templates = @{
+                stop = "{summary}"
+            }
+        } -HookEventName "Stop" -CategoryName "task.complete" -ProjectName "proj" -NotifyMsgVal "proj" -EventData @{
+            transcript_summary = $longSummary
+        }
+        $result.Length | Should -Be 120
+        $result | Should -Be ("A" * 120)
+    }
+}
+
+Describe "Template Resolution: Special characters" {
+    It "handles dots and hyphens in project name and spaces in tool_name" {
+        $result = Invoke-TemplateResolution -ConfigInput @{
+            notification_templates = @{
+                permission = "{project} wants {tool_name}"
+            }
+        } -HookEventName "PermissionRequest" -CategoryName "input.required" -ProjectName "my-app.v2" -NotifyMsgVal "my-app.v2" -EventData @{
+            tool_name = "Read File"
+        }
+        $result | Should -Be "my-app.v2 wants Read File"
+    }
+}
+
+Describe "Template Resolution: Variable substitution completeness" {
+    It "resolves {status} variable" {
+        $result = Invoke-TemplateResolution -ConfigInput @{
+            notification_templates = @{
+                stop = "{status}"
+            }
+        } -HookEventName "Stop" -CategoryName "task.complete" -ProjectName "proj" -NotifyMsgVal "proj" -NotifyStatusVal "done"
+        $result | Should -Be "done"
+    }
+
+    It "resolves {event} variable" {
+        $result = Invoke-TemplateResolution -ConfigInput @{
+            notification_templates = @{
+                stop = "{event}"
+            }
+        } -HookEventName "Stop" -CategoryName "task.complete" -ProjectName "proj" -NotifyMsgVal "proj"
+        $result | Should -Be "Stop"
+    }
+}

--- a/tests/win-notification-templates.Tests.ps1
+++ b/tests/win-notification-templates.Tests.ps1
@@ -171,9 +171,11 @@ Describe "Template Resolution: All five template keys" {
         $result | Should -Be "PERM:proj"
     }
 
-    It "maps task.error -> error template key" {
-        $content = Get-Content $script:InstallPs1 -Raw
-        $content | Should -Match "'task\.error'\s*=\s*'error'"
+    It "maps PostToolUseFailure (task.error) -> error template key" {
+        $result = Invoke-TemplateResolution -ConfigInput @{
+            notification_templates = @{ error = "ERR:{project}" }
+        } -HookEventName "PostToolUseFailure" -CategoryName "task.error" -ProjectName "proj" -NotifyMsgVal "proj"
+        $result | Should -Be "ERR:proj"
     }
 
     It "maps idle_prompt Notification -> idle template key" {
@@ -236,5 +238,48 @@ Describe "Template Resolution: Variable substitution completeness" {
             }
         } -HookEventName "Stop" -CategoryName "task.complete" -ProjectName "proj" -NotifyMsgVal "proj"
         $result | Should -Be "Stop"
+    }
+}
+
+# ============================================================
+# Guard Parity Tests (Unix/Windows alignment)
+# ============================================================
+# Verify that idle_prompt/elicitation_dialog overrides only fire
+# when $hookEvent -eq 'Notification', matching peon.sh lines 3706-3708.
+
+Describe "Guard Parity: idle_prompt override requires Notification hookEvent" {
+    It "applies idle template when hookEvent is Notification" {
+        $result = Invoke-TemplateResolution -ConfigInput @{
+            notification_templates = @{ idle = "IDLE:{project}" }
+        } -HookEventName "Notification" -CategoryName $null -NotificationType "idle_prompt" -ProjectName "proj" -NotifyMsgVal "proj"
+        $result | Should -Be "IDLE:proj"
+    }
+
+    It "does NOT apply idle template when hookEvent is not Notification" {
+        # Simulate a non-Notification event that somehow has ntype=idle_prompt
+        # (e.g., if event data were malformed). The guard must prevent override.
+        $result = Invoke-TemplateResolution -ConfigInput @{
+            notification_templates = @{ idle = "IDLE:{project}"; stop = "STOP:{project}" }
+        } -HookEventName "Stop" -CategoryName "task.complete" -NotificationType "idle_prompt" -ProjectName "proj" -NotifyMsgVal "proj"
+        # Should resolve via the category map (task.complete -> stop), not idle
+        $result | Should -Be "STOP:proj"
+    }
+}
+
+Describe "Guard Parity: elicitation_dialog override requires Notification hookEvent" {
+    It "applies question template when hookEvent is Notification" {
+        $result = Invoke-TemplateResolution -ConfigInput @{
+            notification_templates = @{ question = "Q:{project}" }
+        } -HookEventName "Notification" -CategoryName "input.required" -NotificationType "elicitation_dialog" -ProjectName "proj" -NotifyMsgVal "proj"
+        $result | Should -Be "Q:proj"
+    }
+
+    It "does NOT apply question template when hookEvent is not Notification" {
+        # Same guard check: non-Notification event with ntype=elicitation_dialog
+        $result = Invoke-TemplateResolution -ConfigInput @{
+            notification_templates = @{ question = "Q:{project}"; stop = "STOP:{project}" }
+        } -HookEventName "Stop" -CategoryName "task.complete" -NotificationType "elicitation_dialog" -ProjectName "proj" -NotifyMsgVal "proj"
+        # Should resolve via category map (task.complete -> stop), not question
+        $result | Should -Be "STOP:proj"
     }
 }


### PR DESCRIPTION
## Motivation

The `notification_templates` config key lets users customize desktop notification messages per event type — e.g., `"{project}: {summary}"` for task completion, or `"{project} needs {tool_name}"` for permission requests. On Unix, a Python block in `peon.sh` (lines 3698–3723) resolves these templates by mapping CESP events to template keys, substituting variables, and falling back gracefully when templates aren't configured.

Windows ignores all of this. The `notification_templates` config is silently skipped, and every notification shows the raw project name. Users who set up custom templates on macOS/Linux get no benefit when they switch to a Windows machine.

## Approach

The implementation is detailed in `docs/designs/win-notification-templates.md`. The core decision was how to handle Python's `format_map()` with `defaultdict(str)` — which silently resolves unknown `{variables}` to empty strings — in PowerShell. PowerShell's `-f` format operator throws on missing keys, and string interpolation requires `$` variables rather than `{braces}`. We use `[regex]::Replace` with a ScriptBlock evaluator, which has been available since PowerShell 2.0, to match the Python behavior exactly: known variables get substituted, unknown ones become empty strings, no exceptions thrown.

The template resolution block sits between sound selection and notification dispatch, overwriting `$notifyMsg` with the resolved template before it reaches `win-notify.ps1`. When no template is configured for the current event, `$notifyMsg` keeps its original value (the project name), preserving backward compatibility.

During code review, the `idle_prompt` and `elicitation_dialog` event-specific overrides were flagged as diverging from Unix. On Unix (`peon.sh:3706–3708`), these overrides are guarded behind `event == 'Notification'`, preventing a malformed event with `ntype=idle_prompt` on a non-Notification hook event from incorrectly overriding the category-based template key. The initial Windows implementation used flat `if` statements without this guard. The second commit corrects this to match Unix behavior.

## What changed

**Template resolution engine** (`install.ps1`, +36 lines at line 1725)

- Maps CESP categories to template keys: `task.complete` → `stop`, `task.error` → `error`
- Event-specific overrides: `PermissionRequest` → `permission`, `idle_prompt` → `idle`, `elicitation_dialog` → `question`
- `idle_prompt`/`elicitation_dialog` overrides gated behind `$hookEvent -eq 'Notification'`, matching Unix guard structure
- Variable substitution via `[regex]::Replace` ScriptBlock for five variables: `{project}`, `{summary}`, `{tool_name}`, `{status}`, `{event}`
- `transcript_summary` trimmed of whitespace and truncated to 120 characters
- Missing template or unconfigured key: no-op, original `$notifyMsg` preserved

**Pester test suite** (`tests/win-notification-templates.Tests.ps1`, 285 lines, new file)

The test helper `Invoke-TemplateResolution` extracts the template block from `install.ps1` source via regex, then evaluates it in an isolated scope with controlled inputs. This avoids mocking the full 1800-line hook script while still testing the actual production code path. Twenty tests across seven `Describe` blocks:

- Block presence and syntax validation (2 tests)
- All five template keys invoke-tested: stop, permission, error, idle, question (5 tests)
- Variable substitution for all five variables plus unknown variable fallback (4 tests)
- Summary truncation at 120 characters (1 test)
- Special characters in project/tool names (1 test)
- Graceful fallback when no template is configured (1 test)
- Guard parity: `idle_prompt` and `elicitation_dialog` overrides fire only on `Notification` hook events, with both positive and negative path assertions (4 tests)
- Variable completeness: `{status}` and `{event}` resolve correctly (2 tests)

**Design doc** (`docs/designs/win-notification-templates.md`, new file)

Documents the Unix reference implementation, PowerShell approach, insertion point rationale, variable substitution strategy, fallback behavior, and test plan.

## Verification

- **20/20** notification template Pester tests pass
- **360/360** `adapters-windows.Tests.ps1` regression tests pass
- Cherry-picked cleanly onto current `origin/main` (post-#390, post-#393) with no conflicts in the final result
- Guard parity confirmed against Unix source at `peon.sh:3706–3708`

---
Planned and tracked with [gitban](https://github.com/muunkky/gitban-mcp).

---

<details>
<summary>Gitban details</summary>

### Sprint: KR62IA

### Cards delivered

| ID | Type | Title | Key outcomes |
|----|------|-------|-------------|
| `kr62ia` | feature | Windows notification template resolution engine | Ported Unix Python template block to PowerShell; 16 Pester tests covering all 5 template keys, 5 variables, truncation, special chars, and fallback |
| `io43px` | test | Harden template test coverage and guard parity | Upgraded `task.error` from regex-only to invoke-based test (5/5 keys now invoke-tested); added `$hookEvent` guard on `idle_prompt`/`elicitation_dialog` overrides + 4 guard parity tests |

### Review insights

The kr62ia review approved the feature with two non-blocking observations: (1) the `task.error` template key was verified only via regex match on `install.ps1` source rather than by invoking the resolution engine like the other four keys, and (2) the `idle_prompt`/`elicitation_dialog` override structure diverged from Unix — flat `if` statements instead of being nested under a `$hookEvent` guard. Card io43px addressed both as a fast-follow. Clean approval on first review for both cards — no rework cycles.

### Sprint metrics

- **Completed**: 2 cards (1 feature, 1 test)
- **Deferred**: 0
- **Rework cycles**: 0

</details>