### PR TITLE
fix: suppress subagent sounds via SubagentStop hook

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -1278,7 +1278,7 @@ $cursorMap = @{
     "stop" = "Stop"
     "preToolUse" = "UserPromptSubmit"
     "postToolUse" = "Stop"
-    "subagentStop" = "Stop"
+    "subagentStop" = "SubagentStop"
     "subagentStart" = "SubagentStart"
     "preCompact" = "PreCompact"
 }
@@ -1416,6 +1416,13 @@ switch ($hookEvent) {
     }
     "SubagentStart" {
         $category = "task.acknowledge"
+    }
+    "SubagentStop" {
+        if ($suppressSubagentComplete) {
+            Write-StateAtomic -State $state -Path $StatePath
+            return
+        }
+        $category = "task.complete"
     }
 }
 
@@ -1862,7 +1869,7 @@ $peonEntry = [PSCustomObject]@{
     hooks = @($peonHook)
 }
 
-$events = @("SessionStart", "SessionEnd", "SubagentStart", "Stop", "Notification", "PermissionRequest", "PostToolUseFailure", "PreCompact")
+$events = @("SessionStart", "SessionEnd", "SubagentStart", "SubagentStop", "Stop", "Notification", "PermissionRequest", "PostToolUseFailure", "PreCompact")
 
 foreach ($evt in $events) {
     $eventHooks = @()

--- a/install.sh
+++ b/install.sh
@@ -999,7 +999,7 @@ peon_hook_async = {
 # SessionStart runs sync so stderr messages (update notice, pause status,
 # relay guidance) appear immediately. All other events run async.
 sync_events = ('SessionStart',)
-events = ['SessionStart', 'SessionEnd', 'SubagentStart', 'UserPromptSubmit', 'Stop', 'Notification', 'PermissionRequest', 'PostToolUseFailure', 'PreCompact']
+events = ['SessionStart', 'SessionEnd', 'SubagentStart', 'SubagentStop', 'UserPromptSubmit', 'Stop', 'Notification', 'PermissionRequest', 'PostToolUseFailure', 'PreCompact']
 
 # PostToolUseFailure only triggers on Bash failures — use matcher to limit scope
 bash_only_events = ('PostToolUseFailure',)

--- a/peon.sh
+++ b/peon.sh
@@ -3075,7 +3075,7 @@ _cursor_event_map = {
     'stop': 'Stop',
     'preToolUse': 'UserPromptSubmit',
     'postToolUse': 'Stop',
-    'subagentStop': 'Stop',
+    'subagentStop': 'SubagentStop',
     'subagentStart': 'SubagentStart',
     'preCompact': 'PreCompact',
 }
@@ -3447,6 +3447,23 @@ elif event == 'PostToolUseFailure':
         print('MARKER=')
         print('PEON_EXIT=true')
         sys.exit(0)
+elif event == 'SubagentStop':
+    # Subagent finished — suppress sound when configured, skip silently
+    if suppress_subagent_complete:
+        write_state(state, state_file)
+        print('PROJECT=' + q(project or ''))
+        print('STATUS=working')
+        print('MARKER=')
+        print('PEON_EXIT=true')
+        sys.exit(0)
+    # When not suppressed, fall through to sound logic as task.complete
+    category = 'task.complete'
+    status = 'done'
+    marker = '\u25cf '
+    notify = '1'
+    notify_color = 'blue'
+    msg = project
+    msg_subtitle = ''
 elif event == 'SubagentStart':
     # Record parent's pack so spawned subagent sessions inherit it, then stay silent
     state['pending_subagent_pack'] = dict(ts=time.time(), pack=active_pack)


### PR DESCRIPTION
## Problem

`suppress_subagent_complete` doesn't reliably suppress subagent completion sounds in Claude Code (and likely other adapters — see #336, #289).

The current approach relies on timing-based session tracking:
1. `SubagentStart` sets `pending_subagent_pack` (single slot)
2. The subagent's `SessionStart` must arrive within 30 seconds to register in `subagent_sessions`
3. `Stop` checks `subagent_sessions` to decide whether to suppress

This fails because:
- **Parallel subagents** overwrite the single `pending_subagent_pack` slot — only one gets registered
- **Timing** — the 30-second window may expire before the subagent's `SessionStart` arrives
- **Some adapters** may not fire `SessionStart` for subagents at all

In practice, `subagent_sessions` stays empty and every subagent completion plays a sound.

## Fix

Register a `SubagentStop` hook and handle it directly by event name — no session tracking needed.

- Map Cursor's `subagentStop` to `SubagentStop` instead of `Stop` in the event map
- Add a `SubagentStop` handler: suppress silently when `suppress_subagent_complete` is true, otherwise play `task.complete`
- Register `SubagentStop` in hook events (`install.sh` and `install.ps1`)

Claude Code fires `SubagentStop` as a distinct event (PascalCase, passes through the event map unchanged). Cursor fires `subagentStop` (camelCase), which the event map now correctly routes to `SubagentStop` instead of `Stop`.

## Testing

Tested with Claude Code on macOS:
- Single subagent — no completion sound (previously played)
- 3 parallel subagents — no completion sounds (previously at least 2 played)
- Main session completion — still plays sound correctly