### PR TITLE
fix: install peon PATH shim during global setup

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -830,6 +830,23 @@ if [ "$NO_RC" = false ]; then
   fi
 fi
 
+# --- Install PATH shim (global install) ---
+# Ensure `peon` works immediately even when shell rc files are not modified,
+# missing, or not yet reloaded in the current terminal session.
+if [ "$LOCAL_MODE" = false ]; then
+  USER_BIN="$HOME/.local/bin"
+  USER_SHIM="$USER_BIN/peon"
+  mkdir -p "$USER_BIN"
+  ln -sf "$INSTALL_DIR/peon.sh" "$USER_SHIM"
+  chmod +x "$INSTALL_DIR/peon.sh" "$USER_SHIM" 2>/dev/null || true
+  if command -v peon >/dev/null 2>&1; then
+    echo "Installed peon command at $USER_SHIM"
+  else
+    echo "Installed peon command at $USER_SHIM"
+    echo "Note: add $USER_BIN to PATH if 'peon' is not found in new terminals."
+  fi
+fi
+
 # --- Verify sounds are installed ---
 if [ -n "$CUSTOM_PACKS" ]; then
   VERIFY_PACKS=$(echo "$CUSTOM_PACKS" | tr ',' ' ')


### PR DESCRIPTION
## Summary
- add a global-install shim step that creates `~/.local/bin/peon` symlink to the installed `peon.sh`
- keep existing rc alias/completion behavior, but ensure command availability even when rc changes are skipped or not yet reloaded
- print a clear PATH hint when `peon` is still not discoverable in the current environment

## Repro
1. Run global installer in an environment where shell rc injection is skipped/not applied.
2. Installer reports success.
3. `peon status` fails with `command not found`.

## Tests
- [x] `bash -n install.sh`
- [x] `bats tests/install.bats` (43/43 passing)
- [ ] `bats tests/` currently hangs in `tests/codex.bats` in this environment (stalls after test 1)

Made with [Cursor](https://cursor.com)