### PR TITLE
fix: add wezterm's bundle id

### DIFF
--- a/peon.sh
+++ b/peon.sh
@@ -516,6 +516,7 @@ _mac_terminal_bundle_id() {
     WarpTerminal)   echo "dev.warp.Warp-Stable" ;;
     Apple_Terminal) echo "com.apple.Terminal" ;;
     zed)            echo "dev.zed.Zed" ;;
+    WezTerm)        echo "com.github.wez.wezterm" ;;
     vscode)
       # IDE embedded terminal (Cursor, VS Code, Windsurf all set TERM_PROGRAM=vscode).
       # Async hooks are orphaned from the process tree, so _mac_ide_pid() won't find


### PR DESCRIPTION
## Changelog
- fix: add WezTerm's bundle id to properly support click-to-focus on macOS

I pulled WezTerm's bundle id via `mdls -name kMDItemCFBundleIdentifier -r /Applications/WezTerm.app/`

closes #417 