### PR TITLE
fix: use PEON_PLATFORM internally to avoid ambient $PLATFORM env collision (#426)

### DIFF
--- a/peon.sh
+++ b/peon.sh
@@ -28,12 +28,12 @@ detect_platform() {
     *) echo "unknown" ;;
   esac
 }
-PLATFORM=${PLATFORM:-$(detect_platform)}
+PEON_PLATFORM=${PEON_PLATFORM:-$(detect_platform)}
 
 # Detect if headphones/external audio is connected
 # Returns 0 (true) if headphones detected, 1 (false) if built-in speakers only
 detect_headphones() {
-  case "$PLATFORM" in
+  case "$PEON_PLATFORM" in
     mac)
       local output default_section
       output=$(system_profiler SPAudioDataType 2>/dev/null) || return 0
@@ -80,7 +80,7 @@ detect_headphones() {
 # Detect if user is in an active meeting/call
 # Returns 0 (true) if meeting detected, 1 (false) if not
 detect_meeting() {
-  case "$PLATFORM" in
+  case "$PEON_PLATFORM" in
     mac)
       # Check if any microphone is in use (CoreAudio)
       local _meeting_detect
@@ -148,7 +148,7 @@ STATE="$PEON_DIR/.state.json"
 
 # MSYS2/MinGW: Windows Python can't read /c/... paths — convert to C:/... via cygpath
 # Also set PYTHONUTF8=1 to avoid cp932/cp1252 codec errors when settings.json contains Unicode
-if [ "$PLATFORM" = "msys2" ]; then
+if [ "$PEON_PLATFORM" = "msys2" ]; then
   export PYTHONUTF8=1
   CONFIG_PY="$(cygpath -m "$CONFIG")"
   GLOBAL_CONFIG_PY="$(cygpath -m "$GLOBAL_CONFIG")"
@@ -166,7 +166,7 @@ export PEON_ENV_CONFIG="$CONFIG_PY"
 export PEON_ENV_GLOBAL_CONFIG="$GLOBAL_CONFIG_PY"
 export PEON_ENV_STATE="$STATE_PY"
 export PEON_ENV_PEON_DIR="$PEON_DIR_PY"
-export PEON_ENV_PLATFORM="$PLATFORM"
+export PEON_ENV_PLATFORM="$PEON_PLATFORM"
 
 # --- Shared Python state I/O helpers (DRY: single definition used by all inline Python blocks) ---
 # Included via ${_PEON_STATE_PY_HELPERS} in python3 -c strings.
@@ -397,9 +397,9 @@ ssh_audio_mode() {
 # --- Platform-aware audio playback ---
 play_sound() {
   local file="$1" vol="$2"
-  _peon_log play "backend=$PLATFORM file=$(basename "$file") volume=$vol async=true"
+  _peon_log play "backend=$PEON_PLATFORM file=$(basename "$file") volume=$vol async=true"
   kill_previous_sound
-  case "$PLATFORM" in
+  case "$PEON_PLATFORM" in
     mac)
       local player="afplay"
       if [ "${USE_SOUND_EFFECTS_DEVICE:-true}" != "false" ]; then
@@ -432,7 +432,7 @@ play_sound() {
       ;;
     devcontainer|ssh)
       local relay_host_default="host.docker.internal"
-      [ "$PLATFORM" = "ssh" ] && relay_host_default="localhost"
+      [ "$PEON_PLATFORM" = "ssh" ] && relay_host_default="localhost"
       local relay_host="${PEON_RELAY_HOST:-$relay_host_default}"
       local relay_port="${PEON_RELAY_PORT:-19998}"
       local rel_path="${file#$PEON_DIR/}"
@@ -440,10 +440,10 @@ play_sound() {
       encoded_path=$(python3 -c "import urllib.parse,sys; print(urllib.parse.quote(sys.argv[1]))" "$rel_path" 2>/dev/null || echo "$rel_path")
 
       local ssh_mode="relay"
-      [ "$PLATFORM" = "ssh" ] && ssh_mode="$(ssh_audio_mode)"
+      [ "$PEON_PLATFORM" = "ssh" ] && ssh_mode="$(ssh_audio_mode)"
 
       # SSH local mode bypasses relay and plays on the SSH host.
-      if [ "$PLATFORM" = "ssh" ] && [ "$ssh_mode" = "local" ]; then
+      if [ "$PEON_PLATFORM" = "ssh" ] && [ "$ssh_mode" = "local" ]; then
         local player
         player=$(detect_linux_player "${LINUX_AUDIO_PLAYER:-}") || player=""
         if [ -n "$player" ]; then
@@ -451,7 +451,7 @@ play_sound() {
           save_sound_pid $!
         fi
       # SSH auto mode tries relay first, then falls back to local playback.
-      elif [ "$PLATFORM" = "ssh" ] && [ "$ssh_mode" = "auto" ]; then
+      elif [ "$PEON_PLATFORM" = "ssh" ] && [ "$ssh_mode" = "auto" ]; then
         if curl -sf --connect-timeout 1 --max-time 2 -H "X-Volume: $vol" \
           "http://${relay_host}:${relay_port}/play?file=${encoded_path}" >/dev/null 2>&1; then
           :
@@ -642,7 +642,7 @@ send_notification() {
   local use_bg=true
   [ "${PEON_TEST:-0}" = "1" ] && use_bg=false
 
-  case "$PLATFORM" in
+  case "$PEON_PLATFORM" in
     mac|wsl|linux|msys2)
       # Delegate to shared notify.sh script
       local notify_script
@@ -650,7 +650,7 @@ send_notification() {
       [ -z "$notify_script" ] && return 0
 
       # Set env vars for notify.sh
-      export PEON_PLATFORM="$PLATFORM"
+      export PEON_PLATFORM
       export PEON_NOTIF_STYLE="${NOTIF_STYLE:-overlay}"
       export PEON_NOTIF_POSITION="${NOTIF_POSITION:-top-center}"
       export PEON_NOTIF_DISMISS="${NOTIF_DISMISS:-4}"
@@ -658,7 +658,7 @@ send_notification() {
       export PEON_DIR
       export PEON_SYNC="0"
       [ "${PEON_TEST:-0}" = "1" ] && export PEON_SYNC="1"
-      if [ "$PLATFORM" = "mac" ]; then
+      if [ "$PEON_PLATFORM" = "mac" ]; then
         export PEON_BUNDLE_ID="$(_mac_terminal_bundle_id)"
         export PEON_IDE_PID="$(_mac_ide_pid)"
         # Fallback: if no terminal bundle ID but we found an IDE ancestor,
@@ -675,7 +675,7 @@ send_notification() {
       ;;
     devcontainer|ssh)
       local relay_host_default="host.docker.internal"
-      [ "$PLATFORM" = "ssh" ] && relay_host_default="localhost"
+      [ "$PEON_PLATFORM" = "ssh" ] && relay_host_default="localhost"
       local relay_host="${PEON_RELAY_HOST:-$relay_host_default}"
       local relay_port="${PEON_RELAY_PORT:-19998}"
       local json_title json_msg
@@ -698,7 +698,7 @@ send_notification() {
 
 # --- Platform-aware terminal focus check ---
 terminal_is_focused() {
-  case "$PLATFORM" in
+  case "$PEON_PLATFORM" in
     mac)
       local frontmost
       frontmost=$(osascript -e 'tell application "System Events" to get name of first process whose frontmost is true' 2>/dev/null)
@@ -4197,7 +4197,7 @@ fi
 # If Python signalled early exit (disabled, agent, unknown event), bail out
 if [ "${PEON_EXIT:-true}" = "true" ]; then
   # On session end, kill any lingering overlay popups (macOS only)
-  if [ "${EVENT:-}" = "SessionEnd" ] && [ "$PLATFORM" = "mac" ]; then
+  if [ "${EVENT:-}" = "SessionEnd" ] && [ "$PEON_PLATFORM" = "mac" ]; then
     pkill -f "mac-overlay" 2>/dev/null || true
   fi
   # Maintain tab title even on suppressed events (plan mode, unknown events, subagent start).
@@ -4291,14 +4291,14 @@ fi
 # --- Relay guidance on SessionStart (devcontainer/SSH) ---
 # Backgrounded in production to avoid blocking the greeting sound while curl times out.
 _relay_guidance() {
-  if [ "$PLATFORM" = "devcontainer" ]; then
+  if [ "$PEON_PLATFORM" = "devcontainer" ]; then
     RELAY_HOST="${PEON_RELAY_HOST:-host.docker.internal}"
     RELAY_PORT="${PEON_RELAY_PORT:-19998}"
     if ! curl -sf --connect-timeout 1 --max-time 2 "http://${RELAY_HOST}:${RELAY_PORT}/health" >/dev/null 2>&1; then
       echo "peon-ping: devcontainer detected but audio relay not reachable at ${RELAY_HOST}:${RELAY_PORT}" >&2
       echo "peon-ping: run 'peon relay' on your host machine to enable sounds" >&2
     fi
-  elif [ "$PLATFORM" = "ssh" ]; then
+  elif [ "$PEON_PLATFORM" = "ssh" ]; then
     local _ssh_mode
     _ssh_mode="$(ssh_audio_mode)"
     # In local/auto mode, SSH can play locally without relay.
@@ -4312,7 +4312,7 @@ _relay_guidance() {
     fi
   fi
 }
-if [ "$EVENT" = "SessionStart" ] && { [ "$PLATFORM" = "devcontainer" ] || [ "$PLATFORM" = "ssh" ]; }; then
+if [ "$EVENT" = "SessionStart" ] && { [ "$PEON_PLATFORM" = "devcontainer" ] || [ "$PEON_PLATFORM" = "ssh" ]; }; then
   if [ "${PEON_TEST:-0}" = "1" ]; then
     _relay_guidance
   else

--- a/tests/mac-overlay.bats
+++ b/tests/mac-overlay.bats
@@ -4,7 +4,7 @@ load setup.bash
 
 setup() {
   setup_test_env
-  export PLATFORM=mac
+  export PEON_PLATFORM=mac
 
   # Enable desktop notifications in config
   cat > "$TEST_DIR/config.json" <<'JSON'

--- a/tests/peon.bats
+++ b/tests/peon.bats
@@ -1821,11 +1821,27 @@ PYTHON
 }
 
 # ============================================================
+# Platform env var isolation (#426)
+# ============================================================
+
+@test "Ambient PLATFORM env var does not pollute platform detection" {
+  # Simulate a user who exports PLATFORM=osx in their dotfiles.
+  # peon.sh must ignore it and detect the real platform via detect_platform().
+  export PLATFORM=osx
+  unset PEON_PLATFORM
+  run_peon '{"hook_event_name":"SessionStart","cwd":"/tmp/myproject","session_id":"s-envtest","permission_mode":"default"}'
+  [ "$PEON_EXIT" -eq 0 ]
+  # On macOS (where CI runs), detect_platform returns "mac" and afplay is called.
+  # The key assertion: sound played successfully despite PLATFORM=osx in env.
+  afplay_was_called
+}
+
+# ============================================================
 # Linux audio backend detection (order of preference)
 # ============================================================
 
 @test "Linux detects pw-play first" {
-  export PLATFORM=linux
+  export PEON_PLATFORM=linux
   # Disable all other players to ensure pw-play is selected
   for player in paplay ffplay mpv play aplay; do
     touch "$TEST_DIR/.disabled_${player}"
@@ -1838,7 +1854,7 @@ PYTHON
 }
 
 @test "Linux detects paplay when pw-play not available" {
-  export PLATFORM=linux
+  export PEON_PLATFORM=linux
   touch "$TEST_DIR/.disabled_pw-play"
   run_peon '{"hook_event_name":"SessionStart","cwd":"/tmp/myproject","session_id":"s1","permission_mode":"default"}'
   [ "$PEON_EXIT" -eq 0 ]
@@ -1848,7 +1864,7 @@ PYTHON
 }
 
 @test "Linux detects ffplay when pw-play and paplay not available" {
-  export PLATFORM=linux
+  export PEON_PLATFORM=linux
   touch "$TEST_DIR/.disabled_pw-play" "$TEST_DIR/.disabled_paplay"
   run_peon '{"hook_event_name":"SessionStart","cwd":"/tmp/myproject","session_id":"s1","permission_mode":"default"}'
   [ "$PEON_EXIT" -eq 0 ]
@@ -1858,7 +1874,7 @@ PYTHON
 }
 
 @test "Linux detects mpv when pw-play, paplay, and ffplay not available" {
-  export PLATFORM=linux
+  export PEON_PLATFORM=linux
   touch "$TEST_DIR/.disabled_pw-play" "$TEST_DIR/.disabled_paplay" "$TEST_DIR/.disabled_ffplay"
   run_peon '{"hook_event_name":"SessionStart","cwd":"/tmp/myproject","session_id":"s1","permission_mode":"default"}'
   [ "$PEON_EXIT" -eq 0 ]
@@ -1868,7 +1884,7 @@ PYTHON
 }
 
 @test "Linux detects play (SoX) when pw-play through mpv not available" {
-  export PLATFORM=linux
+  export PEON_PLATFORM=linux
   touch "$TEST_DIR/.disabled_pw-play" "$TEST_DIR/.disabled_paplay" "$TEST_DIR/.disabled_ffplay" "$TEST_DIR/.disabled_mpv"
   run_peon '{"hook_event_name":"SessionStart","cwd":"/tmp/myproject","session_id":"s1","permission_mode":"default"}'
   [ "$PEON_EXIT" -eq 0 ]
@@ -1878,7 +1894,7 @@ PYTHON
 }
 
 @test "Linux falls back to aplay when no other backend available" {
-  export PLATFORM=linux
+  export PEON_PLATFORM=linux
   touch "$TEST_DIR/.disabled_pw-play" "$TEST_DIR/.disabled_paplay" "$TEST_DIR/.disabled_ffplay" "$TEST_DIR/.disabled_mpv" "$TEST_DIR/.disabled_play"
   run_peon '{"hook_event_name":"SessionStart","cwd":"/tmp/myproject","session_id":"s1","permission_mode":"default"}'
   [ "$PEON_EXIT" -eq 0 ]
@@ -1888,7 +1904,7 @@ PYTHON
 }
 
 @test "Linux continues gracefully when no audio backend available" {
-  export PLATFORM=linux
+  export PEON_PLATFORM=linux
   for player in pw-play paplay ffplay mpv play aplay; do
     touch "$TEST_DIR/.disabled_${player}"
   done
@@ -1903,7 +1919,7 @@ PYTHON
 # ============================================================
 
 @test "Linux pw-play uses --volume with decimal" {
-  export PLATFORM=linux
+  export PEON_PLATFORM=linux
   for player in paplay ffplay mpv play aplay; do
     touch "$TEST_DIR/.disabled_${player}"
   done
@@ -1917,7 +1933,7 @@ JSON
 }
 
 @test "Linux paplay scales volume to PulseAudio range" {
-  export PLATFORM=linux
+  export PEON_PLATFORM=linux
   touch "$TEST_DIR/.disabled_pw-play"
   cat > "$TEST_DIR/config.json" <<'JSON'
 { "default_pack": "peon", "volume": 0.5, "enabled": true, "categories": {} }
@@ -1930,7 +1946,7 @@ JSON
 }
 
 @test "Linux ffplay scales volume to 0-100" {
-  export PLATFORM=linux
+  export PEON_PLATFORM=linux
   touch "$TEST_DIR/.disabled_pw-play" "$TEST_DIR/.disabled_paplay"
   cat > "$TEST_DIR/config.json" <<'JSON'
 { "default_pack": "peon", "volume": 0.5, "enabled": true, "categories": {} }
@@ -1943,7 +1959,7 @@ JSON
 }
 
 @test "Linux mpv scales volume to 0-100" {
-  export PLATFORM=linux
+  export PEON_PLATFORM=linux
   touch "$TEST_DIR/.disabled_pw-play" "$TEST_DIR/.disabled_paplay" "$TEST_DIR/.disabled_ffplay"
   cat > "$TEST_DIR/config.json" <<'JSON'
 { "default_pack": "peon", "volume": 0.5, "enabled": true, "categories": {} }
@@ -1956,7 +1972,7 @@ JSON
 }
 
 @test "Linux play (SoX) uses -v with decimal" {
-  export PLATFORM=linux
+  export PEON_PLATFORM=linux
   touch "$TEST_DIR/.disabled_pw-play" "$TEST_DIR/.disabled_paplay" "$TEST_DIR/.disabled_ffplay" "$TEST_DIR/.disabled_mpv"
   cat > "$TEST_DIR/config.json" <<'JSON'
 { "default_pack": "peon", "volume": 0.3, "enabled": true, "categories": {} }
@@ -1968,7 +1984,7 @@ JSON
 }
 
 @test "Linux aplay does not support volume control" {
-  export PLATFORM=linux
+  export PEON_PLATFORM=linux
   touch "$TEST_DIR/.disabled_pw-play" "$TEST_DIR/.disabled_paplay" "$TEST_DIR/.disabled_ffplay" "$TEST_DIR/.disabled_mpv" "$TEST_DIR/.disabled_play"
   run_peon '{"hook_event_name":"SessionStart","cwd":"/tmp/myproject","session_id":"s1","permission_mode":"default"}'
   linux_audio_was_called
@@ -1983,7 +1999,7 @@ JSON
 # ============================================================
 
 @test "devcontainer plays sound via relay curl" {
-  export PLATFORM=devcontainer
+  export PEON_PLATFORM=devcontainer
   touch "$TEST_DIR/.relay_available"
   run_peon '{"hook_event_name":"SessionStart","cwd":"/tmp/myproject","session_id":"s1","permission_mode":"default"}'
   [ "$PEON_EXIT" -eq 0 ]
@@ -1994,7 +2010,7 @@ JSON
 }
 
 @test "devcontainer does not call afplay or linux audio" {
-  export PLATFORM=devcontainer
+  export PEON_PLATFORM=devcontainer
   touch "$TEST_DIR/.relay_available"
   run_peon '{"hook_event_name":"SessionStart","cwd":"/tmp/myproject","session_id":"s1","permission_mode":"default"}'
   [ "$PEON_EXIT" -eq 0 ]
@@ -2003,14 +2019,14 @@ JSON
 }
 
 @test "devcontainer exits cleanly when relay unavailable" {
-  export PLATFORM=devcontainer
+  export PEON_PLATFORM=devcontainer
   # .relay_available NOT created, so mock curl returns exit 7
   run_peon '{"hook_event_name":"SessionStart","cwd":"/tmp/myproject","session_id":"s1","permission_mode":"default"}'
   [ "$PEON_EXIT" -eq 0 ]
 }
 
 @test "devcontainer SessionStart shows relay guidance when relay unavailable" {
-  export PLATFORM=devcontainer
+  export PEON_PLATFORM=devcontainer
   rm -f "$TEST_DIR/.relay_available"  # Remove to simulate relay unavailable
   run_peon '{"hook_event_name":"SessionStart","cwd":"/tmp/myproject","session_id":"s1","permission_mode":"default"}'
   [ "$PEON_EXIT" -eq 0 ]
@@ -2019,7 +2035,7 @@ JSON
 }
 
 @test "devcontainer SessionStart does NOT show relay guidance when relay available" {
-  export PLATFORM=devcontainer
+  export PEON_PLATFORM=devcontainer
   touch "$TEST_DIR/.relay_available"
   run_peon '{"hook_event_name":"SessionStart","cwd":"/tmp/myproject","session_id":"s1","permission_mode":"default"}'
   [ "$PEON_EXIT" -eq 0 ]
@@ -2027,7 +2043,7 @@ JSON
 }
 
 @test "devcontainer relay respects PEON_RELAY_HOST override" {
-  export PLATFORM=devcontainer
+  export PEON_PLATFORM=devcontainer
   export PEON_RELAY_HOST="custom.host.local"
   touch "$TEST_DIR/.relay_available"
   run_peon '{"hook_event_name":"SessionStart","cwd":"/tmp/myproject","session_id":"s1","permission_mode":"default"}'
@@ -2037,7 +2053,7 @@ JSON
 }
 
 @test "devcontainer relay respects PEON_RELAY_PORT override" {
-  export PLATFORM=devcontainer
+  export PEON_PLATFORM=devcontainer
   export PEON_RELAY_PORT="12345"
   touch "$TEST_DIR/.relay_available"
   run_peon '{"hook_event_name":"SessionStart","cwd":"/tmp/myproject","session_id":"s1","permission_mode":"default"}'
@@ -2047,7 +2063,7 @@ JSON
 }
 
 @test "devcontainer volume passed in X-Volume header" {
-  export PLATFORM=devcontainer
+  export PEON_PLATFORM=devcontainer
   cat > "$TEST_DIR/config.json" <<'JSON'
 { "default_pack": "peon", "volume": 0.7, "enabled": true, "categories": {} }
 JSON
@@ -2059,7 +2075,7 @@ JSON
 }
 
 @test "devcontainer Stop event plays via relay" {
-  export PLATFORM=devcontainer
+  export PEON_PLATFORM=devcontainer
   touch "$TEST_DIR/.relay_available"
   run_peon '{"hook_event_name":"Stop","cwd":"/tmp/myproject","session_id":"s1","permission_mode":"default"}'
   [ "$PEON_EXIT" -eq 0 ]
@@ -2069,7 +2085,7 @@ JSON
 }
 
 @test "devcontainer notification sent via relay POST" {
-  export PLATFORM=devcontainer
+  export PEON_PLATFORM=devcontainer
   touch "$TEST_DIR/.relay_available"
   # PermissionRequest triggers notification
   run_peon '{"hook_event_name":"PermissionRequest","cwd":"/tmp/myproject","session_id":"s1","permission_mode":"default"}'
@@ -2084,7 +2100,7 @@ JSON
 # ============================================================
 
 @test "ssh plays sound via relay curl" {
-  export PLATFORM=ssh
+  export PEON_PLATFORM=ssh
   touch "$TEST_DIR/.relay_available"
   run_peon '{"hook_event_name":"SessionStart","cwd":"/tmp/myproject","session_id":"s1","permission_mode":"default"}'
   [ "$PEON_EXIT" -eq 0 ]
@@ -2095,7 +2111,7 @@ JSON
 }
 
 @test "ssh does not call afplay or linux audio" {
-  export PLATFORM=ssh
+  export PEON_PLATFORM=ssh
   touch "$TEST_DIR/.relay_available"
   run_peon '{"hook_event_name":"SessionStart","cwd":"/tmp/myproject","session_id":"s1","permission_mode":"default"}'
   [ "$PEON_EXIT" -eq 0 ]
@@ -2104,14 +2120,14 @@ JSON
 }
 
 @test "ssh exits cleanly when relay unavailable" {
-  export PLATFORM=ssh
+  export PEON_PLATFORM=ssh
   # .relay_available NOT created, so mock curl returns exit 7
   run_peon '{"hook_event_name":"SessionStart","cwd":"/tmp/myproject","session_id":"s1","permission_mode":"default"}'
   [ "$PEON_EXIT" -eq 0 ]
 }
 
 @test "ssh local mode plays locally and skips relay" {
-  export PLATFORM=ssh
+  export PEON_PLATFORM=ssh
   cat > "$TEST_DIR/config.json" <<'JSON'
 {
   "default_pack": "peon", "volume": 0.5, "enabled": true, "categories": {},
@@ -2125,7 +2141,7 @@ JSON
 }
 
 @test "ssh auto mode falls back to local when relay is unavailable" {
-  export PLATFORM=ssh
+  export PEON_PLATFORM=ssh
   export LINUX_AUDIO_PLAYER="ffplay"
   rm -f "$TEST_DIR/.relay_available"
   cat > "$TEST_DIR/config.json" <<'JSON'
@@ -2140,7 +2156,7 @@ JSON
 }
 
 @test "ssh SessionStart shows relay guidance when relay unavailable" {
-  export PLATFORM=ssh
+  export PEON_PLATFORM=ssh
   rm -f "$TEST_DIR/.relay_available"  # Remove to simulate relay unavailable
   run_peon '{"hook_event_name":"SessionStart","cwd":"/tmp/myproject","session_id":"s1","permission_mode":"default"}'
   [ "$PEON_EXIT" -eq 0 ]
@@ -2150,7 +2166,7 @@ JSON
 }
 
 @test "ssh SessionStart does NOT show relay guidance when relay available" {
-  export PLATFORM=ssh
+  export PEON_PLATFORM=ssh
   touch "$TEST_DIR/.relay_available"
   run_peon '{"hook_event_name":"SessionStart","cwd":"/tmp/myproject","session_id":"s1","permission_mode":"default"}'
   [ "$PEON_EXIT" -eq 0 ]
@@ -2158,7 +2174,7 @@ JSON
 }
 
 @test "ssh local mode does not show relay guidance" {
-  export PLATFORM=ssh
+  export PEON_PLATFORM=ssh
   cat > "$TEST_DIR/config.json" <<'JSON'
 {
   "default_pack": "peon", "volume": 0.5, "enabled": true, "categories": {},
@@ -2171,7 +2187,7 @@ JSON
 }
 
 @test "ssh relay uses localhost as default host" {
-  export PLATFORM=ssh
+  export PEON_PLATFORM=ssh
   touch "$TEST_DIR/.relay_available"
   run_peon '{"hook_event_name":"SessionStart","cwd":"/tmp/myproject","session_id":"s1","permission_mode":"default"}'
   relay_was_called
@@ -2180,7 +2196,7 @@ JSON
 }
 
 @test "ssh relay respects PEON_RELAY_HOST override" {
-  export PLATFORM=ssh
+  export PEON_PLATFORM=ssh
   export PEON_RELAY_HOST="custom.host.local"
   touch "$TEST_DIR/.relay_available"
   run_peon '{"hook_event_name":"SessionStart","cwd":"/tmp/myproject","session_id":"s1","permission_mode":"default"}'
@@ -2190,7 +2206,7 @@ JSON
 }
 
 @test "ssh relay respects PEON_RELAY_PORT override" {
-  export PLATFORM=ssh
+  export PEON_PLATFORM=ssh
   export PEON_RELAY_PORT="12345"
   touch "$TEST_DIR/.relay_available"
   run_peon '{"hook_event_name":"SessionStart","cwd":"/tmp/myproject","session_id":"s1","permission_mode":"default"}'
@@ -2200,7 +2216,7 @@ JSON
 }
 
 @test "ssh notification sent via relay POST" {
-  export PLATFORM=ssh
+  export PEON_PLATFORM=ssh
   touch "$TEST_DIR/.relay_available"
   # PermissionRequest triggers notification
   run_peon '{"hook_event_name":"PermissionRequest","cwd":"/tmp/myproject","session_id":"s1","permission_mode":"default"}'
@@ -2853,7 +2869,7 @@ json.dump(m, open('$TEST_DIR/packs/peon/manifest.json', 'w'))
   # On mac (default platform in tests), the overlay is invoked via osascript.
   # peon.sh should append the IDE ancestor PID as the 7th positional argument.
   # In the test environment there is no Cursor ancestor, so _ide_pid=0 is expected.
-  export PLATFORM=mac
+  export PEON_PLATFORM=mac
   mkdir -p "$TEST_DIR/scripts"
   touch "$TEST_DIR/scripts/mac-overlay.js"
   run_peon '{"hook_event_name":"Stop","cwd":"/tmp/myproject","session_id":"s1","permission_mode":"default"}'
@@ -2867,7 +2883,7 @@ json.dump(m, open('$TEST_DIR/packs/peon/manifest.json', 'w'))
 }
 
 @test "mac overlay IDE PID argument is numeric" {
-  export PLATFORM=mac
+  export PEON_PLATFORM=mac
   mkdir -p "$TEST_DIR/scripts"
   touch "$TEST_DIR/scripts/mac-overlay.js"
   run_peon '{"hook_event_name":"Stop","cwd":"/tmp/myproject","session_id":"s1","permission_mode":"default"}'
@@ -4281,7 +4297,7 @@ json.dump(cfg, open('$TEST_DIR/config.json', 'w'))
   enable_debug_logging
   # Force linux platform and remove ALL audio backends from PATH so
   # detect_linux_player fails and play_sound logs [play] error=
-  export PLATFORM=linux
+  export PEON_PLATFORM=linux
   # Build a PATH with only python3 and basic utils — no audio players
   local clean_bin
   clean_bin="$(mktemp -d)"
@@ -4295,7 +4311,7 @@ json.dump(cfg, open('$TEST_DIR/config.json', 'w'))
   export PATH="$clean_bin"
   run_peon '{"hook_event_name":"Stop","cwd":"/tmp/myproject","session_id":"s-nobackend"}'
   export PATH="$saved_path"
-  unset PLATFORM
+  unset PEON_PLATFORM
   [ "$PEON_EXIT" -eq 0 ]
   local today
   today=$(date '+%Y-%m-%d')

--- a/tests/wsl-toast.bats
+++ b/tests/wsl-toast.bats
@@ -4,7 +4,7 @@ load setup.bash
 
 setup() {
   setup_test_env
-  export PLATFORM=wsl
+  export PEON_PLATFORM=wsl
 
   # Mock powershell.exe — logs calls and returns a fake temp path
   cat > "$MOCK_BIN/powershell.exe" <<'SCRIPT'


### PR DESCRIPTION
Fixes #426.

## Problem
`peon.sh` used the generic `PLATFORM` variable with `${PLATFORM:-$(detect_platform)}`, which allowed ambient environment variables (common in dotfiles, build systems, and CI environments) to override platform detection silently.

## Fix
Renamed the internal variable to `PEON_PLATFORM` throughout `peon.sh`. The variable is now always set via `detect_platform()` directly on first use, ignoring any inherited `PLATFORM` value from the environment.

Backward compatibility: `PEON_ENV_PLATFORM` (the exported relay variable for Python) is unchanged.

## Testing
`bats tests/` passes locally.