### PR TITLE
feat: add shuffle rotation mode

### DIFF
--- a/completions.bash
+++ b/completions.bash
@@ -53,7 +53,7 @@ _peon_completions() {
         return 0 ;;
       rotation)
         if [ "$cword" -eq 2 ]; then
-          COMPREPLY=( $(compgen -W "random round-robin agentskill" -- "$cur") )
+          COMPREPLY=( $(compgen -W "random round-robin shuffle session_override" -- "$cur") )
         fi
         return 0 ;;
       status)

--- a/completions.fish
+++ b/completions.fish
@@ -124,7 +124,8 @@ complete -c peon -n "__peon_using_subcommand mobile" -a test -d "Send test notif
 # rotation subcommands
 complete -c peon -n "__peon_using_subcommand rotation" -a random -d "Pick a random pack each session (default)"
 complete -c peon -n "__peon_using_subcommand rotation" -a round-robin -d "Cycle through packs in order"
-complete -c peon -n "__peon_using_subcommand rotation" -a agentskill -d "Assign pack per session via /peon-ping-use"
+complete -c peon -n "__peon_using_subcommand rotation" -a shuffle -d "Pick a random pack for every sound event"
+complete -c peon -n "__peon_using_subcommand rotation" -a session_override -d "Assign pack per session via /peon-ping-use"
 
 # Helper: true when notifications subcommand is active and second arg matches
 function __peon_notif_subcommand

--- a/completions.zsh
+++ b/completions.zsh
@@ -84,7 +84,8 @@ _peon() {
   rotation_cmds=(
     'random:Pick a random pack each session (default)'
     'round-robin:Cycle through packs in order'
-    'agentskill:Assign pack per session via /peon-ping-use'
+    'shuffle:Pick a random pack for every sound event'
+    'session_override:Assign pack per session via /peon-ping-use'
   )
 
   logs_cmds=(

--- a/peon.sh
+++ b/peon.sh
@@ -1633,7 +1633,7 @@ except Exception:
       exit 0
     fi
     case "$ROT_ARG" in
-      random|round-robin|session_override|agentskill)
+      random|round-robin|shuffle|session_override|agentskill)
         export PEON_ENV_ROT_ARG="$ROT_ARG"
         python3 -c "
 import json, os
@@ -1652,11 +1652,12 @@ print('peon-ping: rotation mode set to ' + mode)
 "
         _rc=$?; [ $_rc -eq 0 ] && sync_adapter_configs; exit $_rc ;;
       *)
-        echo "Usage: peon rotation <random|round-robin|session_override>" >&2
+        echo "Usage: peon rotation <random|round-robin|shuffle|session_override>" >&2
         echo "" >&2
         echo "Modes:" >&2
         echo "  random           Pick a random pack each session (default)" >&2
         echo "  round-robin      Cycle through packs in order each session" >&2
+        echo "  shuffle          Pick a random pack for every sound event" >&2
         echo "  session_override Use /peon-ping-use to assign pack per session" >&2
         exit 1 ;;
     esac ;;
@@ -2835,7 +2836,7 @@ Commands:
   toggle               Toggle mute on/off
   status               Check if paused or active
   volume [0.0-1.0]     Get or set volume level
-  rotation [mode]      Get or set pack rotation mode (random|round-robin|session_override)
+  rotation [mode]      Get or set pack rotation mode (random|round-robin|shuffle|session_override)
   notifications on        Enable desktop notification popups (sounds continue playing)
   notifications off       Disable desktop notification popups (sounds continue playing)
   notifications overlay   Use large overlay banners (default)
@@ -3579,10 +3580,13 @@ if rotation_mode in ('session_override', 'agentskill'):
                 active_pack = _path_rule_pack or _default_pack
         else:
             active_pack = _path_rule_pack or _default_pack
-elif pack_rotation and rotation_mode in ('random', 'round-robin'):
+elif pack_rotation and rotation_mode in ('random', 'round-robin', 'shuffle'):
     if _path_rule_pack:
         # Path rule beats rotation
         active_pack = _path_rule_pack
+    elif rotation_mode == 'shuffle':
+        # Shuffle: pick a random pack for every sound event, no session caching
+        active_pack = random.choice(pack_rotation)
     else:
         # Automatic rotation — detect context resets (new session_id within seconds
         # of the last event, no Stop in between) and reuse the previous pack.

--- a/tests/peon.bats
+++ b/tests/peon.bats
@@ -1685,6 +1685,51 @@ PYTHON
   [[ "$sound" == *"/packs/sc_kerrigan/sounds/"* ]]
 }
 
+@test "shuffle mode picks from pack_rotation on every event" {
+  cat > "$TEST_DIR/config.json" <<'JSON'
+{
+  "default_pack": "peon", "volume": 0.5, "enabled": true,
+  "categories": {},
+  "pack_rotation": ["sc_kerrigan"],
+  "pack_rotation_mode": "shuffle"
+}
+JSON
+  # First event
+  run_peon '{"hook_event_name":"SessionStart","cwd":"/tmp/myproject","session_id":"shuf1","permission_mode":"default"}'
+  [ "$PEON_EXIT" -eq 0 ]
+  afplay_was_called
+  sound=$(afplay_sound)
+  [[ "$sound" == *"/packs/sc_kerrigan/sounds/"* ]]
+
+  # Second event with same session_id should still use rotation list (not cache)
+  run_peon '{"hook_event_name":"Stop","cwd":"/tmp/myproject","session_id":"shuf1","permission_mode":"default"}'
+  [ "$PEON_EXIT" -eq 0 ]
+  afplay_was_called
+  sound2=$(afplay_sound)
+  [[ "$sound2" == *"/packs/sc_kerrigan/sounds/"* ]]
+}
+
+@test "shuffle mode does not cache pack in session_packs" {
+  cat > "$TEST_DIR/config.json" <<'JSON'
+{
+  "default_pack": "peon", "volume": 0.5, "enabled": true,
+  "categories": {},
+  "pack_rotation": ["sc_kerrigan"],
+  "pack_rotation_mode": "shuffle"
+}
+JSON
+  run_peon '{"hook_event_name":"SessionStart","cwd":"/tmp/myproject","session_id":"shuf2","permission_mode":"default"}'
+  [ "$PEON_EXIT" -eq 0 ]
+
+  # Verify session_packs does NOT contain the shuffle session
+  /usr/bin/python3 <<PYTHON
+import json, os
+state = json.load(open(os.environ['TEST_DIR'] + '/.state.json'))
+sp = state.get('session_packs', {})
+assert 'shuf2' not in sp, f"shuffle should not cache in session_packs, got: {sp}"
+PYTHON
+}
+
 @test "empty pack_rotation falls back to default_pack" {
   cat > "$TEST_DIR/config.json" <<'JSON'
 {


### PR DESCRIPTION
## Summary

Adds a new `shuffle` rotation mode that picks a random pack from `pack_rotation` on **every sound event**, instead of locking to one pack per session.

Usage: `peon rotation shuffle`

Closes #443

## Changes

- Add `shuffle` to accepted rotation modes in CLI validation and pack selection logic
- When `rotation_mode == 'shuffle'`, skip the `session_packs` cache and call `random.choice(pack_rotation)` on every event
- Path rules still take priority over shuffle, consistent with the existing override hierarchy
- Update help text and shell completions (bash, zsh, fish)
- Add tests for shuffle mode

## Tests

Two new bats tests added:

- **`shuffle mode picks from pack_rotation on every event`** — verifies sounds come from the rotation list across multiple events in the same session
- **`shuffle mode does not cache pack in session_packs`** — verifies the session_packs state is not populated, ensuring no session locking

Full suite passes (348/348).

## Test plan

- [x] `peon rotation shuffle` sets the mode and confirms with `peon rotation`
- [x] Sounds play from the rotation list on every event
- [x] No session_packs entry is created for shuffle sessions
- [x] Path rules still override shuffle when matched
- [x] Switching back to `random` restores per-session locking behavior
- [x] Shell completions show `shuffle` as an option
- [x] All existing tests pass (no regressions)