### PR TITLE
fix: bound stdin read to prevent hang on Windows git-bash

### DIFF
--- a/peon.sh
+++ b/peon.sh
@@ -3236,7 +3236,18 @@ if [ -t 0 ]; then
   exit 0
 fi
 
-INPUT=$(cat)
+# Bounded stdin read — on Windows git-bash, Claude Code's hook stdin pipe
+# sometimes never closes, causing plain `cat` to hang until the outer hook
+# timeout fires (surfacing as "SessionStart:* hook error" in the UI). Cap
+# the read at 2s; empty INPUT is handled gracefully by the Python block
+# below (json.load fails → PEON_EXIT=true → clean exit with rc 0).
+if command -v timeout >/dev/null 2>&1; then
+  INPUT=$(timeout 2 cat 2>/dev/null) || INPUT=""
+elif command -v gtimeout >/dev/null 2>&1; then
+  INPUT=$(gtimeout 2 cat 2>/dev/null) || INPUT=""
+else
+  INPUT=$(cat)
+fi
 
 # Debug log (uncomment to troubleshoot)
 # echo "$(date): peon hook — $INPUT" >> /tmp/peon-ping-debug.log


### PR DESCRIPTION
## Summary
- Replaces bare `INPUT=$(cat)` with a bounded 2-second read using `timeout`/`gtimeout`
- On Windows git-bash, Claude Code's hook stdin pipe sometimes never receives EOF, causing `cat` to hang until the outer 10-second hook timeout fires
- Empty INPUT from timeout is handled gracefully by the existing Python block (json.load fails -> PEON_EXIT=true -> clean exit rc 0)

Closes #445

## Test plan
- [x] All 643 BATS tests pass
- [ ] Manual test on Windows git-bash with FIFO repro from issue
- [ ] Verify no regression on macOS/Linux (stdin closes normally, well under 2s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)