### PR TITLE
feat: add --lang flag to filter packs by language during install

### DIFF
--- a/completions.bash
+++ b/completions.bash
@@ -27,11 +27,15 @@ _peon_completions() {
             COMPREPLY=( $(compgen -W "$names" -- "$cur") )
           fi
         elif [ "$cword" -eq 3 ] && [ "$prev" = "install" ]; then
-          COMPREPLY=( $(compgen -W "--all" -- "$cur") )
+          COMPREPLY=( $(compgen -W "--all --lang" -- "$cur") )
+        elif [ "$cword" -eq 4 ] && [ "${words[2]}" = "install" ]; then
+          COMPREPLY=( $(compgen -W "--lang" -- "$cur") )
         elif [ "$cword" -eq 3 ] && [ "$prev" = "install-local" ]; then
           COMPREPLY=( $(compgen -d -- "$cur") )
         elif [ "$cword" -eq 3 ] && [ "$prev" = "list" ]; then
           COMPREPLY=( $(compgen -W "--registry" -- "$cur") )
+        elif [ "$cword" -eq 4 ] && [ "${words[2]}" = "list" ] && [ "$prev" = "--registry" ]; then
+          COMPREPLY=( $(compgen -W "--lang" -- "$cur") )
         elif [ "$cword" -eq 3 ] && { [ "$prev" = "use" ] || [ "$prev" = "remove" ] || [ "$prev" = "bind" ]; }; then
           packs_dir="${CLAUDE_PEON_DIR:-${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/peon-ping}/packs"
           [ ! -d "$packs_dir" ] && [ -d "$HOME/.openpeon/packs" ] && packs_dir="$HOME/.openpeon/packs"

--- a/completions.fish
+++ b/completions.fish
@@ -62,9 +62,11 @@ complete -c peon -n "__peon_packs_subcommand rotation" -a clear -d "Clear all pa
 
 # packs install options
 complete -c peon -n "__peon_packs_subcommand install" -a "--all" -d "Install all packs from registry"
+complete -c peon -n "__peon_packs_subcommand install" -a "--lang" -d "Filter packs by language (e.g. --lang=en,fr)"
 
 # packs list options
 complete -c peon -n "__peon_packs_subcommand list" -a "--registry" -d "List all available packs from registry"
+complete -c peon -n "__peon_packs_subcommand list" -a "--lang" -d "Filter by language (e.g. --lang=en)"
 
 # Pack name completions for 'packs use' and 'packs remove'
 complete -c peon -n "__peon_packs_subcommand use" -a "(

--- a/install.ps1
+++ b/install.ps1
@@ -6,7 +6,8 @@
 param(
     [Parameter()]
     $Packs = @(),
-    [switch]$All
+    [switch]$All,
+    [string]$Lang = ""
 )
 
 # When run via Invoke-Expression (one-liner install), $PSScriptRoot is empty.
@@ -109,6 +110,29 @@ if ($Packs -and $Packs.Count -gt 0) {
     $defaultPacks = @("peon", "peasant", "glados", "sc_kerrigan", "sc_battlecruiser", "ra2_kirov", "dota2_axe", "duke_nukem", "tf2_engineer", "hd2_helldiver")
     $packsToInstall = $registry.packs | Where-Object { $_.name -in $defaultPacks }
     Write-Host "  Installing $($packsToInstall.Count) packs (use -All for all $($registry.packs.Count))..." -ForegroundColor Cyan
+}
+
+# --- Language filter ---
+if ($Lang) {
+    $langCodes = $Lang -split ',' | ForEach-Object { $_.Trim() } | Where-Object { $_ }
+    $packsToInstall = @($packsToInstall | Where-Object {
+        $packLangs = ($_.language -split ',') | ForEach-Object { $_.Trim() }
+        $match = $false
+        foreach ($pl in $packLangs) {
+            foreach ($code in $langCodes) {
+                if ($pl -eq $code -or $pl.StartsWith("$code-")) {
+                    $match = $true; break
+                }
+            }
+            if ($match) { break }
+        }
+        $match
+    })
+    if ($packsToInstall.Count -eq 0) {
+        Write-Host "Warning: no packs match language(s): $Lang" -ForegroundColor Yellow
+    } else {
+        Write-Host "  Filtered to $($packsToInstall.Count) pack(s) matching language: $Lang" -ForegroundColor Cyan
+    }
 }
 
 # --- Create directories ---

--- a/install.sh
+++ b/install.sh
@@ -11,6 +11,7 @@ CUSTOM_PACKS=""
 OPENCLAW_MODE=false
 NO_RC=false
 ROVODEV_ONLY=false
+LANG_FILTER=""
 for arg in "$@"; do
   case "$arg" in
     --global) LOCAL_MODE=false ;;
@@ -21,6 +22,7 @@ for arg in "$@"; do
     --no-rc) NO_RC=true ;;
     --rovodev-only) ROVODEV_ONLY=true ;;
     --packs=*) CUSTOM_PACKS="${arg#--packs=}" ;;
+    --lang=*) LANG_FILTER="${arg#--lang=}" ;;
     --help|-h)
       cat <<'HELPEOF'
 Usage: install.sh [OPTIONS]
@@ -34,6 +36,7 @@ Options:
   --no-rc              Skip .bashrc/.zshrc/fish config modifications
   --rovodev-only       Only register Rovo Dev CLI hooks, then exit
   --packs=<a,b,c>      Install specific packs
+  --lang=<en,fr,...>   Install only packs matching language(s)
 HELPEOF
       exit 0
       ;;
@@ -654,12 +657,15 @@ fi
 PACK_DL="$INSTALL_DIR/scripts/pack-download.sh"
 chmod +x "$PACK_DL" 2>/dev/null || true
 
+LANG_ARG=""
+[ -n "$LANG_FILTER" ] && LANG_ARG="--lang=$LANG_FILTER"
+
 if [ -n "$CUSTOM_PACKS" ]; then
-  bash "$PACK_DL" --dir="$INSTALL_DIR" --packs="$CUSTOM_PACKS"
+  bash "$PACK_DL" --dir="$INSTALL_DIR" --packs="$CUSTOM_PACKS" $LANG_ARG
 elif [ "$INSTALL_ALL" = true ]; then
-  bash "$PACK_DL" --dir="$INSTALL_DIR" --all
+  bash "$PACK_DL" --dir="$INSTALL_DIR" --all $LANG_ARG
 else
-  bash "$PACK_DL" --dir="$INSTALL_DIR" --packs="$(echo "$DEFAULT_PACKS" | tr ' ' ',')"
+  bash "$PACK_DL" --dir="$INSTALL_DIR" --packs="$(echo "$DEFAULT_PACKS" | tr ' ' ',')" $LANG_ARG
 fi
 
 chmod +x "$INSTALL_DIR/peon.sh"

--- a/peon.sh
+++ b/peon.sh
@@ -1665,8 +1665,14 @@ print('peon-ping: rotation mode set to ' + mode)
     case "${2:-}" in
       list)
         if [ "${3:-}" = "--registry" ]; then
+          LIST_LANG=""
+          for _larg in "${@:4}"; do
+            case "$_larg" in
+              --lang=*) LIST_LANG="$_larg" ;;
+            esac
+          done
           PACK_DL="$(resolve_pack_download)" || exit 1
-          bash "$PACK_DL" --list-registry --dir="$PEON_DIR"
+          bash "$PACK_DL" --list-registry --dir="$PEON_DIR" $LIST_LANG
           exit 0
         fi
         python3 -c "
@@ -2110,15 +2116,23 @@ if rotation:
 "
         sync_adapter_configs; exit 0 ;;
       install)
-        INSTALL_ARG="${3:-}"
+        INSTALL_ARG=""
+        INSTALL_LANG=""
+        for _iarg in "${@:3}"; do
+          case "$_iarg" in
+            --lang=*) INSTALL_LANG="$_iarg" ;;
+            *) [ -z "$INSTALL_ARG" ] && INSTALL_ARG="$_iarg" ;;
+          esac
+        done
         PACK_DL="$(resolve_pack_download)" || exit 1
         if [ "$INSTALL_ARG" = "--all" ]; then
-          bash "$PACK_DL" --dir="$PEON_DIR" --all
+          bash "$PACK_DL" --dir="$PEON_DIR" --all $INSTALL_LANG
         elif [ -n "$INSTALL_ARG" ]; then
-          bash "$PACK_DL" --dir="$PEON_DIR" --packs="$INSTALL_ARG"
+          bash "$PACK_DL" --dir="$PEON_DIR" --packs="$INSTALL_ARG" $INSTALL_LANG
         else
           echo "Usage: peon packs install <pack1,pack2,...>" >&2
           echo "       peon packs install --all" >&2
+          echo "       peon packs install --all --lang=<en,fr,...>" >&2
           echo "" >&2
           echo "Run 'peon packs list --registry' to see available packs." >&2
           exit 1
@@ -2867,8 +2881,10 @@ Commands:
 Pack management:
   packs list              List installed sound packs
   packs list --registry   List all available packs from registry
+  packs list --registry --lang=<codes> Filter registry list by language
   packs install <p1,p2>   Download and install new packs
   packs install --all     Download all packs from registry
+  packs install --all --lang=<codes> Download packs matching language(s)
   packs install-local <path> Install a pack from a local directory
   packs use <name>        Switch to a specific pack
   packs use --install <n> Switch to pack, installing from registry if needed

--- a/scripts/pack-download.sh
+++ b/scripts/pack-download.sh
@@ -27,6 +27,7 @@ PEON_DIR=""
 PACKS_CSV=""
 INSTALL_ALL=false
 LIST_REGISTRY=false
+LANG_FILTER=""
 
 for arg in "$@"; do
   case "$arg" in
@@ -34,6 +35,7 @@ for arg in "$@"; do
     --packs=*) PACKS_CSV="${arg#--packs=}" ;;
     --all) INSTALL_ALL=true ;;
     --list-registry) LIST_REGISTRY=true ;;
+    --lang=*) LANG_FILTER="${arg#--lang=}" ;;
   esac
 done
 
@@ -159,10 +161,60 @@ for p in data.get('packs', []):
   fi
 }
 
+# --- Language filter ---
+# When --lang is specified, filter ALL_PACKS and REGISTRY_JSON to only include
+# packs whose language field prefix-matches any requested code.
+# Multi-language packs (e.g. "en,ru") match if any token matches.
+apply_lang_filter() {
+  if [ -z "$LANG_FILTER" ]; then
+    return
+  fi
+  if [ -z "$REGISTRY_JSON" ]; then
+    echo "Warning: --lang filtering unavailable without registry" >&2
+    return
+  fi
+  local filtered
+  filtered=$(LANG_FILTER="$LANG_FILTER" python3 -c "
+import json, sys, os
+
+registry = json.loads(sys.stdin.read())
+codes = [c.strip() for c in os.environ['LANG_FILTER'].split(',') if c.strip()]
+
+def matches(pack):
+    lang = pack.get('language', '')
+    if not lang:
+        return False
+    pack_langs = [l.strip() for l in lang.split(',')]
+    for pl in pack_langs:
+        for code in codes:
+            if pl == code or pl.startswith(code + '-'):
+                return True
+    return False
+
+filtered_packs = [p for p in registry.get('packs', []) if matches(p)]
+registry['packs'] = filtered_packs
+print(json.dumps(registry))
+" <<< "$REGISTRY_JSON")
+  REGISTRY_JSON="$filtered"
+  ALL_PACKS=$(python3 -c "
+import json, sys
+data = json.loads(sys.stdin.read())
+for p in data.get('packs', []):
+    print(p['name'])
+" <<< "$REGISTRY_JSON")
+  if [ -z "$ALL_PACKS" ]; then
+    echo "Warning: no packs match language(s): $LANG_FILTER. Use 'peon packs list --registry --lang' to see available languages." >&2
+  fi
+}
+
 # --- List registry mode ---
 
 if [ "$LIST_REGISTRY" = true ]; then
   fetch_registry
+  apply_lang_filter
+  if [ -n "$LANG_FILTER" ] && [ -z "$ALL_PACKS" ]; then
+    exit 0
+  fi
   if [ -n "$REGISTRY_JSON" ]; then
     PEON_DIR="$(py_path "$PEON_DIR")" python3 -c "
 import json, sys, os
@@ -208,6 +260,12 @@ fi
 # --- Fetch registry and select packs ---
 
 fetch_registry
+apply_lang_filter
+
+# Exit gracefully if language filter yielded zero packs
+if [ -n "$LANG_FILTER" ] && [ -z "$ALL_PACKS" ]; then
+  exit 0
+fi
 
 if [ "$INSTALL_ALL" = true ]; then
   PACKS="$ALL_PACKS"

--- a/tests/install.bats
+++ b/tests/install.bats
@@ -36,7 +36,8 @@ setup() {
   MOCK_BIN="$(mktemp -d)"
 
   # Mock registry index.json — include all 10 default packs so install doesn't fail
-  MOCK_REGISTRY_JSON='{"packs":[{"name":"peon","display_name":"Orc Peon","source_repo":"PeonPing/og-packs","source_ref":"v1.0.0","source_path":"peon"},{"name":"peasant","display_name":"Human Peasant","source_repo":"PeonPing/og-packs","source_ref":"v1.0.0","source_path":"peasant"},{"name":"glados","display_name":"GLaDOS","source_repo":"PeonPing/og-packs","source_ref":"v1.0.0","source_path":"glados"},{"name":"sc_kerrigan","display_name":"Sarah Kerrigan","source_repo":"PeonPing/og-packs","source_ref":"v1.0.0","source_path":"sc_kerrigan"},{"name":"sc_battlecruiser","display_name":"Battlecruiser","source_repo":"PeonPing/og-packs","source_ref":"v1.0.0","source_path":"sc_battlecruiser"},{"name":"ra2_kirov","display_name":"Kirov Airship","source_repo":"PeonPing/og-packs","source_ref":"v1.0.0","source_path":"ra2_kirov"},{"name":"dota2_axe","display_name":"Axe","source_repo":"PeonPing/og-packs","source_ref":"v1.0.0","source_path":"dota2_axe"},{"name":"duke_nukem","display_name":"Duke Nukem","source_repo":"PeonPing/og-packs","source_ref":"v1.0.0","source_path":"duke_nukem"},{"name":"tf2_engineer","display_name":"Engineer","source_repo":"PeonPing/og-packs","source_ref":"v1.0.0","source_path":"tf2_engineer"},{"name":"hd2_helldiver","display_name":"Helldiver","source_repo":"PeonPing/og-packs","source_ref":"v1.0.0","source_path":"hd2_helldiver"},{"name":"extra_pack","display_name":"Extra Pack","source_repo":"PeonPing/og-packs","source_ref":"v1.0.0","source_path":"extra_pack"}]}'
+  # language fields: most are "en", peon_fr is "fr", extra_pack is "fr" (for --lang filter tests)
+  MOCK_REGISTRY_JSON='{"packs":[{"name":"peon","display_name":"Orc Peon","language":"en","source_repo":"PeonPing/og-packs","source_ref":"v1.0.0","source_path":"peon"},{"name":"peasant","display_name":"Human Peasant","language":"en","source_repo":"PeonPing/og-packs","source_ref":"v1.0.0","source_path":"peasant"},{"name":"glados","display_name":"GLaDOS","language":"en","source_repo":"PeonPing/og-packs","source_ref":"v1.0.0","source_path":"glados"},{"name":"sc_kerrigan","display_name":"Sarah Kerrigan","language":"en","source_repo":"PeonPing/og-packs","source_ref":"v1.0.0","source_path":"sc_kerrigan"},{"name":"sc_battlecruiser","display_name":"Battlecruiser","language":"en","source_repo":"PeonPing/og-packs","source_ref":"v1.0.0","source_path":"sc_battlecruiser"},{"name":"ra2_kirov","display_name":"Kirov Airship","language":"en","source_repo":"PeonPing/og-packs","source_ref":"v1.0.0","source_path":"ra2_kirov"},{"name":"dota2_axe","display_name":"Axe","language":"en","source_repo":"PeonPing/og-packs","source_ref":"v1.0.0","source_path":"dota2_axe"},{"name":"duke_nukem","display_name":"Duke Nukem","language":"en","source_repo":"PeonPing/og-packs","source_ref":"v1.0.0","source_path":"duke_nukem"},{"name":"tf2_engineer","display_name":"Engineer","language":"en","source_repo":"PeonPing/og-packs","source_ref":"v1.0.0","source_path":"tf2_engineer"},{"name":"hd2_helldiver","display_name":"Helldiver","language":"en","source_repo":"PeonPing/og-packs","source_ref":"v1.0.0","source_path":"hd2_helldiver"},{"name":"extra_pack","display_name":"Extra Pack","language":"fr","source_repo":"PeonPing/og-packs","source_ref":"v1.0.0","source_path":"extra_pack"}]}'
 
   # Generic manifest template (used for any openpeon.json request)
   MOCK_MANIFEST='{"cesp_version":"1.0","name":"mock","display_name":"Mock Pack","categories":{"session.start":{"sounds":[{"file":"sounds/Hello1.wav","label":"Hello"}]},"task.complete":{"sounds":[{"file":"sounds/Done1.wav","label":"Done"}]}}}'
@@ -599,4 +600,29 @@ EOF
   run bash "$CLONE_DIR/install.sh" --help
   [ "$status" -eq 0 ]
   [[ "$output" == *"--rovodev-only"* ]]
+}
+
+# ============================================================
+# --lang (language filtering)
+# ============================================================
+
+@test "--all --lang=fr installs only French packs" {
+  bash "$CLONE_DIR/install.sh" --all --lang=fr
+  # extra_pack is the only French pack in our mock registry
+  [ -d "$INSTALL_DIR/packs/extra_pack" ]
+  # English packs should NOT be installed
+  [ ! -d "$INSTALL_DIR/packs/peon" ]
+  [ ! -d "$INSTALL_DIR/packs/glados" ]
+}
+
+@test "--lang=xx shows zero-match warning" {
+  run bash "$CLONE_DIR/install.sh" --all --lang=xx
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"no packs match language"* ]]
+}
+
+@test "--lang appears in --help output" {
+  run bash "$CLONE_DIR/install.sh" --help
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"--lang"* ]]
 }

--- a/tests/pack-download.bats
+++ b/tests/pack-download.bats
@@ -195,3 +195,76 @@ JSON
   result=$(urlencode_filename "Hello.wav")
   [ "$result" = "Hello.wav" ]
 }
+
+# ============================================================
+# --lang (language filtering)
+# ============================================================
+
+@test "--lang=en with --all installs English packs (prefix match + multi-lang)" {
+  run bash "$PACK_DL_SH" --dir="$TEST_DIR" --all --lang=en
+  [ "$status" -eq 0 ]
+  # test_pack_a (en), test_pack_c (en-GB), test_pack_d (en,ru) should match
+  [ -d "$TEST_DIR/packs/test_pack_a" ]
+  [ -d "$TEST_DIR/packs/test_pack_c" ]
+  [ -d "$TEST_DIR/packs/test_pack_d" ]
+  # test_pack_b (fr) should NOT match
+  [ ! -d "$TEST_DIR/packs/test_pack_b" ]
+}
+
+@test "--lang=fr with --all installs only French packs" {
+  run bash "$PACK_DL_SH" --dir="$TEST_DIR" --all --lang=fr
+  [ "$status" -eq 0 ]
+  [ -d "$TEST_DIR/packs/test_pack_b" ]
+  [ ! -d "$TEST_DIR/packs/test_pack_a" ]
+  [ ! -d "$TEST_DIR/packs/test_pack_c" ]
+  [ ! -d "$TEST_DIR/packs/test_pack_d" ]
+}
+
+@test "--lang=en-GB with --all installs only exact en-GB pack" {
+  run bash "$PACK_DL_SH" --dir="$TEST_DIR" --all --lang=en-GB
+  [ "$status" -eq 0 ]
+  [ -d "$TEST_DIR/packs/test_pack_c" ]
+  [ ! -d "$TEST_DIR/packs/test_pack_a" ]
+  [ ! -d "$TEST_DIR/packs/test_pack_b" ]
+  [ ! -d "$TEST_DIR/packs/test_pack_d" ]
+}
+
+@test "--lang=ru with --all installs multi-lang pack" {
+  run bash "$PACK_DL_SH" --dir="$TEST_DIR" --all --lang=ru
+  [ "$status" -eq 0 ]
+  [ -d "$TEST_DIR/packs/test_pack_d" ]
+  [ ! -d "$TEST_DIR/packs/test_pack_a" ]
+  [ ! -d "$TEST_DIR/packs/test_pack_b" ]
+  [ ! -d "$TEST_DIR/packs/test_pack_c" ]
+}
+
+@test "--lang=xx with --all prints zero-match warning" {
+  run bash "$PACK_DL_SH" --dir="$TEST_DIR" --all --lang=xx
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"no packs match language"* ]]
+}
+
+@test "--list-registry --lang=en shows only English packs" {
+  run bash "$PACK_DL_SH" --list-registry --dir="$TEST_DIR" --lang=en
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"test_pack_a"* ]]
+  [[ "$output" == *"test_pack_c"* ]]
+  [[ "$output" == *"test_pack_d"* ]]
+  [[ "$output" != *"test_pack_b"* ]]
+}
+
+@test "--list-registry --lang=fr shows only French packs" {
+  run bash "$PACK_DL_SH" --list-registry --dir="$TEST_DIR" --lang=fr
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"test_pack_b"* ]]
+  [[ "$output" != *"test_pack_a"* ]]
+}
+
+@test "no --lang downloads all packs unchanged" {
+  run bash "$PACK_DL_SH" --dir="$TEST_DIR" --all
+  [ "$status" -eq 0 ]
+  [ -d "$TEST_DIR/packs/test_pack_a" ]
+  [ -d "$TEST_DIR/packs/test_pack_b" ]
+  [ -d "$TEST_DIR/packs/test_pack_c" ]
+  [ -d "$TEST_DIR/packs/test_pack_d" ]
+}

--- a/tests/setup.bash
+++ b/tests/setup.bash
@@ -476,9 +476,9 @@ teardown_test_env() {
 
 # Set up mock fixtures for pack-download.sh tests
 setup_pack_download_env() {
-  # Mock registry JSON
+  # Mock registry JSON (includes language field for --lang filter tests)
   cat > "$TEST_DIR/.mock_registry_json" <<'JSON'
-{"packs":[{"name":"test_pack_a","display_name":"Test Pack A","source_repo":"PeonPing/og-packs","source_ref":"v1.0.0","source_path":"test_pack_a"},{"name":"test_pack_b","display_name":"Test Pack B","source_repo":"PeonPing/og-packs","source_ref":"v1.0.0","source_path":"test_pack_b"}]}
+{"packs":[{"name":"test_pack_a","display_name":"Test Pack A","language":"en","source_repo":"PeonPing/og-packs","source_ref":"v1.0.0","source_path":"test_pack_a"},{"name":"test_pack_b","display_name":"Test Pack B","language":"fr","source_repo":"PeonPing/og-packs","source_ref":"v1.0.0","source_path":"test_pack_b"},{"name":"test_pack_c","display_name":"Test Pack C","language":"en-GB","source_repo":"PeonPing/og-packs","source_ref":"v1.0.0","source_path":"test_pack_c"},{"name":"test_pack_d","display_name":"Test Pack D","language":"en,ru","source_repo":"PeonPing/og-packs","source_ref":"v1.0.0","source_path":"test_pack_d"}]}
 JSON
 
   # Mock manifest (used for any openpeon.json download)


### PR DESCRIPTION
## Summary

- Adds `--lang` flag to `install.sh`, `install.ps1`, `peon packs install`, and `peon packs list --registry` so users can filter sound packs by language during installation
- Implements prefix matching (`--lang en` matches `en`, `en-GB`) and multi-language pack support (`language: "en,ru"` matches `--lang en` or `--lang ru`)
- Prints a zero-match warning and exits gracefully when no packs match the requested language(s)

Closes #395

## Changes

| File | Change |
|------|--------|
| `scripts/pack-download.sh` | `--lang=` arg parsing, `apply_lang_filter()` with Python prefix matching |
| `install.sh` | `--lang=` arg parsing, help text, passthrough to pack-download.sh |
| `install.ps1` | `-Lang` parameter with PowerShell filtering logic |
| `peon.sh` | `--lang` in `packs install`, `packs list --registry`, help text |
| `completions.bash` | `--lang` completion for `packs install` and `packs list --registry` |
| `completions.fish` | `--lang` completion for `packs install` and `packs list` |
| `tests/setup.bash` | Mock registry with `language` fields (en, fr, en-GB, en,ru) |
| `tests/pack-download.bats` | 8 new tests for language filtering |
| `tests/install.bats` | Language fields on mock registry + 3 new tests |

## Usage

```bash
# Install only English packs
bash install.sh --all --lang=en

# Install French and Spanish packs
bash install.sh --all --lang=fr,es

# Filter default packs to English only
bash install.sh --lang=en

# List Korean packs from registry
peon packs list --registry --lang=ko

# Install all Japanese packs
peon packs install --all --lang=ja

# Windows: install English packs only
powershell -File install.ps1 -All -Lang en
```

## Test plan

- [ ] CI: BATS tests pass on macOS (8 new pack-download tests + 3 new install tests)
- [ ] CI: Pester tests pass on Windows (401 tests, validated locally)
- [ ] `--lang en` prefix-matches `en`, `en-GB`, and multi-lang `en,ru` packs
- [ ] `--lang xx` with no matches prints warning and exits 0
- [ ] No `--lang` flag → behavior identical to before (no regressions)