### PR TITLE
fix: pack sync — skip installed packs, silence failures, show progress summary

### DIFF
--- a/scripts/pack-download.sh
+++ b/scripts/pack-download.sh
@@ -3,6 +3,9 @@
 # Used by install.sh and `peon packs install`
 set -euo pipefail
 
+# Restore cursor on exit (in case we hid it for progress bars)
+trap '[ -t 1 ] && printf "\033[?25h"' EXIT
+
 REGISTRY_URL="https://peonping.github.io/registry/index.json"
 
 # MSYS2/MinGW: Windows Python can't read /c/... paths — convert to C:/... via cygpath
@@ -93,7 +96,7 @@ is_cached_valid() {
   [ -s "$filepath" ] || return 1
   [ -f "$checksums_file" ] || return 1
   local stored_hash current_hash
-  stored_hash=$(grep -F "$filename " "$checksums_file" 2>/dev/null | head -1 | cut -d' ' -f2)
+  stored_hash=$(grep -F "$filename " "$checksums_file" 2>/dev/null | head -1 | rev | cut -d' ' -f1 | rev)
   [ -n "$stored_hash" ] || return 1
   current_hash=$(file_sha256 "$filepath")
   [ "$stored_hash" = "$current_hash" ]
@@ -109,6 +112,7 @@ store_checksum() {
   echo "$filename $hash" >> "$checksums_file.tmp"
   mv "$checksums_file.tmp" "$checksums_file"
 }
+
 
 # --- Progress bar ---
 
@@ -134,7 +138,7 @@ draw_progress() {
     size_str="$bytes B"
   fi
 
-  printf "\r  [%${idx_width}d/%d] %-20s [%s] %d/%d (%s)%-10s" \
+  printf "\r  [%${idx_width}d/%d] %-20s [%s] %d/%d (%s)%-16s" \
     "$pidx" "$ptotal" "$pname" "$bar" "$cur" "$total" "$size_str" ""
 }
 
@@ -288,18 +292,60 @@ IS_TTY=false
 TOTAL_DOWNLOAD_FILES=0
 TOTAL_DOWNLOAD_BYTES=0
 TOTAL_DOWNLOAD_PACKS=0
+TOTAL_SKIPPED_PACKS=0
+TOTAL_FAILED_PACKS=0
+FAILED_PACK_NAMES=()
+PARTIAL_PACK_NAMES=()
+TOTAL_PARTIAL_PACKS=0
 
 echo ""
-echo "Downloading packs..."
+echo "Syncing packs..."
 for pack in $PACKS; do
   if ! is_safe_pack_name "$pack"; then
-    echo "  Warning: skipping invalid pack name: $pack" >&2
     continue
   fi
 
   PACK_INDEX=$((PACK_INDEX + 1))
+  idx_width=${#TOTAL_PACKS}
 
-  mkdir -p "$PEON_DIR/packs/$pack/sounds"
+  # Skip packs where every manifest sound has a valid checksum
+  if [ -s "$PEON_DIR/packs/$pack/openpeon.json" ] && [ -f "$PEON_DIR/packs/$pack/.checksums" ]; then
+    manifest_check="$(py_path "$PEON_DIR/packs/$pack/openpeon.json")"
+    checksums_check="$PEON_DIR/packs/$pack/.checksums"
+    pack_complete=$(CHECKSUMS="$checksums_check" PACKS_DIR="$(py_path "$PEON_DIR/packs/$pack")" python3 -c "
+import json, os, posixpath, hashlib
+m = json.load(open('$manifest_check'))
+checksums = {}
+cf = os.environ['CHECKSUMS']
+packs_dir = os.environ['PACKS_DIR']
+if os.path.isfile(cf):
+    for line in open(cf):
+        parts = line.strip().rsplit(' ', 1)
+        if len(parts) == 2:
+            checksums[parts[0]] = parts[1]
+seen = set()
+for cat in m.get('categories', {}).values():
+    for s in cat.get('sounds', []):
+        f = s['file']
+        rel = f[len('sounds/'):] if f.startswith('sounds/') else posixpath.basename(f)
+        seen.add(rel)
+def is_valid(rel):
+    stored = checksums.get(rel)
+    if not stored:
+        return False
+    fp = os.path.join(packs_dir, 'sounds', rel)
+    if not os.path.isfile(fp):
+        return False
+    actual = hashlib.sha256(open(fp, 'rb').read()).hexdigest()
+    return actual == stored
+print('yes' if seen and all(is_valid(r) for r in seen) else 'no')
+" 2>/dev/null || echo "no")
+    if [ "$pack_complete" = "yes" ]; then
+      TOTAL_SKIPPED_PACKS=$((TOTAL_SKIPPED_PACKS + 1))
+      printf "  [%${idx_width}d/%d] %s ✓\n" "$PACK_INDEX" "$TOTAL_PACKS" "$pack"
+      continue
+    fi
+  fi
 
   # Get source info from registry (or use fallback)
   SOURCE_REPO=""
@@ -344,9 +390,21 @@ for p in data.get('packs', []):
     PACK_BASE="https://raw.githubusercontent.com/$SOURCE_REPO/$SOURCE_REF"
   fi
 
+  # Verify manifest exists before creating any local directories
+  if ! curl -fsSL --head "$PACK_BASE/openpeon.json" >/dev/null 2>&1; then
+    TOTAL_FAILED_PACKS=$((TOTAL_FAILED_PACKS + 1))
+    FAILED_PACK_NAMES+=("$pack")
+    printf "  [%${idx_width}d/%d] %s ❌\n" "$PACK_INDEX" "$TOTAL_PACKS" "$pack"
+    continue
+  fi
+
+  mkdir -p "$PEON_DIR/packs/$pack/sounds"
+
   # Download manifest
   if ! curl -fsSL "$PACK_BASE/openpeon.json" -o "$PEON_DIR/packs/$pack/openpeon.json" 2>/dev/null; then
-    echo "  Warning: failed to download manifest for $pack" >&2
+    TOTAL_FAILED_PACKS=$((TOTAL_FAILED_PACKS + 1))
+    FAILED_PACK_NAMES+=("$pack")
+    printf "  [%${idx_width}d/%d] %s ❌\n" "$PACK_INDEX" "$TOTAL_PACKS" "$pack"
     continue
   fi
 
@@ -393,15 +451,10 @@ print(len(seen))
     while read -r ifile; do
       ifile="${ifile%$'\r'}"  # strip Windows CRLF trailing CR (Python on Windows outputs \r\n)
       [ -z "$ifile" ] && continue
-      if ! is_safe_filename "$ifile"; then
-        echo "  Warning: skipped unsafe icon path in $pack: $ifile" >&2
-        continue
-      fi
+      is_safe_filename "$ifile" || continue
       mkdir -p "$PEON_DIR/packs/$pack/$(dirname "$ifile")"
-      if ! curl -fsSL "$PACK_BASE/$(urlencode_filename "$ifile")" \
-           -o "$PEON_DIR/packs/$pack/$ifile" </dev/null 2>/dev/null; then
-        echo "  Warning: failed to download $pack/$ifile" >&2
-      fi
+      curl -fsSL "$PACK_BASE/$(urlencode_filename "$ifile")" \
+           -o "$PEON_DIR/packs/$pack/$ifile" </dev/null 2>/dev/null || true
     done <<< "$ICON_LIST"
   fi
 
@@ -409,14 +462,12 @@ print(len(seen))
     local_file_count=0
     local_byte_count=0
 
+    printf '\033[?25l'  # hide cursor during progress
     draw_progress "$PACK_INDEX" "$TOTAL_PACKS" "$pack" 0 "$SOUND_COUNT" 0
 
     while read -r sfile; do
       sfile="${sfile%$'\r'}"  # strip Windows CRLF trailing CR (Python on Windows outputs \r\n)
-      if ! is_safe_filename "$sfile"; then
-        echo "  Warning: skipped unsafe filename in $pack: $sfile" >&2
-        continue
-      fi
+      is_safe_filename "$sfile" || continue
       mkdir -p "$PEON_DIR/packs/$pack/sounds/$(dirname "$sfile")"
       if is_cached_valid "$PEON_DIR/packs/$pack/sounds/$sfile" "$CHECKSUMS_FILE" "$sfile"; then
         local_file_count=$((local_file_count + 1))
@@ -429,7 +480,7 @@ print(len(seen))
         fsize=$(wc -c < "$PEON_DIR/packs/$pack/sounds/$sfile" | tr -d ' ')
         local_byte_count=$((local_byte_count + fsize))
       else
-        echo "  Warning: failed to download $pack/sounds/$sfile" >&2
+        break
       fi
       draw_progress "$PACK_INDEX" "$TOTAL_PACKS" "$pack" \
         "$local_file_count" "$SOUND_COUNT" "$local_byte_count"
@@ -449,17 +500,39 @@ for cat in m.get('categories', {}).values():
             print(rel)
 ")
 
-    draw_progress "$PACK_INDEX" "$TOTAL_PACKS" "$pack" \
-      "$local_file_count" "$SOUND_COUNT" "$local_byte_count"
-    printf "\n"
+    # Clear the progress bar line and print final status on a clean line
+    printf '\033[?25h'  # restore cursor
+    printf "\r%80s\r" ""
+    if [ "$local_file_count" -eq "$SOUND_COUNT" ]; then
+      printf "  [%${idx_width}d/%d] %s ✅\n" "$PACK_INDEX" "$TOTAL_PACKS" "$pack"
+      TOTAL_DOWNLOAD_PACKS=$((TOTAL_DOWNLOAD_PACKS + 1))
+    else
+      printf "  [%${idx_width}d/%d] %s (%d/%d) ⚠️\n" "$PACK_INDEX" "$TOTAL_PACKS" "$pack" "$local_file_count" "$SOUND_COUNT"
+      TOTAL_PARTIAL_PACKS=$((TOTAL_PARTIAL_PACKS + 1))
+      PARTIAL_PACK_NAMES+=("$pack")
+    fi
 
     TOTAL_DOWNLOAD_FILES=$((TOTAL_DOWNLOAD_FILES + local_file_count))
     TOTAL_DOWNLOAD_BYTES=$((TOTAL_DOWNLOAD_BYTES + local_byte_count))
-    TOTAL_DOWNLOAD_PACKS=$((TOTAL_DOWNLOAD_PACKS + 1))
   else
-    printf "  [%d/%d] %s " "$PACK_INDEX" "$TOTAL_PACKS" "$pack"
+    printf "  [%${idx_width}d/%d] %s " "$PACK_INDEX" "$TOTAL_PACKS" "$pack"
+    local_file_count=0
 
-    python3 -c "
+    while read -r sfile; do
+      sfile="${sfile%$'\r'}"  # strip Windows CRLF trailing CR (Python on Windows outputs \r\n)
+      is_safe_filename "$sfile" || continue
+      mkdir -p "$PEON_DIR/packs/$pack/sounds/$(dirname "$sfile")"
+      if is_cached_valid "$PEON_DIR/packs/$pack/sounds/$sfile" "$CHECKSUMS_FILE" "$sfile"; then
+        printf "."
+        local_file_count=$((local_file_count + 1))
+      elif curl -fsSL "$PACK_BASE/sounds/$(urlencode_filename "$sfile")" -o "$PEON_DIR/packs/$pack/sounds/$sfile" </dev/null 2>/dev/null; then
+        store_checksum "$CHECKSUMS_FILE" "$sfile" "$PEON_DIR/packs/$pack/sounds/$sfile"
+        printf "."
+        local_file_count=$((local_file_count + 1))
+      else
+        break
+      fi
+    done < <(python3 -c "
 import json, posixpath
 m = json.load(open('$manifest_py'))
 seen = set()
@@ -473,37 +546,70 @@ for cat in m.get('categories', {}).values():
         if rel not in seen:
             seen.add(rel)
             print(rel)
-" | while read -r sfile; do
-      sfile="${sfile%$'\r'}"  # strip Windows CRLF trailing CR (Python on Windows outputs \r\n)
-      if ! is_safe_filename "$sfile"; then
-        echo "  Warning: skipped unsafe filename in $pack: $sfile" >&2
-        continue
-      fi
-      mkdir -p "$PEON_DIR/packs/$pack/sounds/$(dirname "$sfile")"
-      if is_cached_valid "$PEON_DIR/packs/$pack/sounds/$sfile" "$CHECKSUMS_FILE" "$sfile"; then
-        printf "."
-      elif curl -fsSL "$PACK_BASE/sounds/$(urlencode_filename "$sfile")" -o "$PEON_DIR/packs/$pack/sounds/$sfile" </dev/null 2>/dev/null; then
-        store_checksum "$CHECKSUMS_FILE" "$sfile" "$PEON_DIR/packs/$pack/sounds/$sfile"
-        printf "."
-      else
-        printf "x"
-        echo "  Warning: failed to download $pack/sounds/$sfile" >&2
-      fi
-    done
+")
 
-    printf " %s sounds\n" "$SOUND_COUNT"
-    TOTAL_DOWNLOAD_PACKS=$((TOTAL_DOWNLOAD_PACKS + 1))
+    if [ "$SOUND_COUNT" != "?" ] && [ "$local_file_count" -eq "$SOUND_COUNT" ]; then
+      printf " ✅ %s sounds\n" "$SOUND_COUNT"
+      TOTAL_DOWNLOAD_PACKS=$((TOTAL_DOWNLOAD_PACKS + 1))
+    else
+      printf " ⚠️%s/%s sounds\n" "$local_file_count" "$SOUND_COUNT"
+      TOTAL_PARTIAL_PACKS=$((TOTAL_PARTIAL_PACKS + 1))
+      PARTIAL_PACK_NAMES+=("$pack")
+    fi
   fi
 done
 
-if [ "$IS_TTY" = true ] && [ "$TOTAL_DOWNLOAD_PACKS" -gt 0 ]; then
-  if [ "$TOTAL_DOWNLOAD_BYTES" -ge 1048576 ]; then
-    SUMMARY_SIZE="$(( TOTAL_DOWNLOAD_BYTES / 1048576 )).$(( (TOTAL_DOWNLOAD_BYTES % 1048576) * 10 / 1048576 )) MB"
-  elif [ "$TOTAL_DOWNLOAD_BYTES" -ge 1024 ]; then
-    SUMMARY_SIZE="$(( TOTAL_DOWNLOAD_BYTES / 1024 )) KB"
+# --- Summary ---
+echo ""
+SUMMARY_PARTS=()
+if [ "$TOTAL_DOWNLOAD_PACKS" -gt 0 ]; then
+  if [ "$IS_TTY" = true ] && [ "$TOTAL_DOWNLOAD_BYTES" -gt 0 ]; then
+    if [ "$TOTAL_DOWNLOAD_BYTES" -ge 1048576 ]; then
+      SUMMARY_SIZE="$(( TOTAL_DOWNLOAD_BYTES / 1048576 )).$(( (TOTAL_DOWNLOAD_BYTES % 1048576) * 10 / 1048576 )) MB"
+    elif [ "$TOTAL_DOWNLOAD_BYTES" -ge 1024 ]; then
+      SUMMARY_SIZE="$(( TOTAL_DOWNLOAD_BYTES / 1024 )) KB"
+    else
+      SUMMARY_SIZE="$TOTAL_DOWNLOAD_BYTES B"
+    fi
+    SUMMARY_PARTS+=("✅ $TOTAL_DOWNLOAD_PACKS downloaded ($TOTAL_DOWNLOAD_FILES files, $SUMMARY_SIZE)")
   else
-    SUMMARY_SIZE="$TOTAL_DOWNLOAD_BYTES B"
+    SUMMARY_PARTS+=("✅ $TOTAL_DOWNLOAD_PACKS downloaded")
   fi
+fi
+if [ "$TOTAL_SKIPPED_PACKS" -gt 0 ]; then
+  SUMMARY_PARTS+=("✓ $TOTAL_SKIPPED_PACKS already installed")
+fi
+if [ "$TOTAL_PARTIAL_PACKS" -gt 0 ]; then
+  SUMMARY_PARTS+=("⚠️ $TOTAL_PARTIAL_PACKS partial")
+fi
+if [ "$TOTAL_FAILED_PACKS" -gt 0 ]; then
+  SUMMARY_PARTS+=("❌ $TOTAL_FAILED_PACKS unavailable")
+fi
+if [ "${#SUMMARY_PARTS[@]}" -gt 0 ]; then
+  IFS="  " ; echo "${SUMMARY_PARTS[*]}" ; unset IFS
+fi
+if [ "${#PARTIAL_PACK_NAMES[@]}" -gt 0 ]; then
   echo ""
-  echo "Downloaded $TOTAL_DOWNLOAD_PACKS packs ($TOTAL_DOWNLOAD_FILES files, $SUMMARY_SIZE)"
+  echo "Partial downloads (some sounds unavailable):"
+  for p in "${PARTIAL_PACK_NAMES[@]}"; do echo "  - $p"; done
+fi
+if [ "${#FAILED_PACK_NAMES[@]}" -gt 0 ]; then
+  echo ""
+  echo "Failed downloads (manifest unavailable):"
+  for p in "${FAILED_PACK_NAMES[@]}"; do echo "  - $p"; done
+fi
+
+# Report total disk usage for all packs
+PACKS_PATH="$PEON_DIR/packs"
+# Resolve symlink to show actual storage location
+PACKS_REAL="$(cd "$PACKS_PATH" 2>/dev/null && pwd -P)"
+DISK_BYTES=$(du -sk "$PACKS_REAL" 2>/dev/null | cut -f1)
+if [ -n "$DISK_BYTES" ] && [ "$DISK_BYTES" -gt 0 ]; then
+  DISK_MB=$(( DISK_BYTES / 1024 ))
+  echo ""
+  if [ "$PACKS_REAL" != "$PACKS_PATH" ]; then
+    echo "Disk usage: ${DISK_MB} MB ($PACKS_REAL)"
+  else
+    echo "Disk usage: ${DISK_MB} MB"
+  fi
 fi

--- a/tests/pack-download.bats
+++ b/tests/pack-download.bats
@@ -109,7 +109,8 @@ JSON
 @test "invalid pack name is skipped" {
   run bash "$PACK_DL_SH" --dir="$TEST_DIR" --packs="../etc/passwd"
   [ "$status" -eq 0 ]
-  [[ "$output" == *"skipping invalid"* ]] || [[ "$(cat "$TEST_DIR/stderr.log" 2>/dev/null)" == *"skipping invalid"* ]]
+  # Invalid pack name should be silently skipped — no directory created
+  [ ! -d "$TEST_DIR/packs/../etc/passwd" ]
 }
 
 @test "missing --dir shows error" {


### PR DESCRIPTION
## Summary

- Skip already-installed packs (verified via on-disk checksums) instead of re-downloading every time
- Probe manifest URL before creating local directories — no cleanup needed on failure
- Stop downloading remaining sounds on first failure (partial packs retry next run)
- Replace noisy warnings with per-pack status: ✓ (installed), ✅ (downloaded), ⚠️ (partial), ❌ (unavailable)
- Hide cursor during progress bars to prevent terminal rendering artifacts
- Print summary with counts and itemized partial/failed packs
- Show total disk usage at the end
- Fix pre-existing bug: checksum lookup for filenames with spaces (e.g. `incoming (1).mp3`) used `split(' ', 1)` which broke on the first space, causing packs like tf2_spy to re-download every run

## Test plan

- [x] `bats tests/pack-download.bats` — all pass (updated `invalid pack name` test for silent skip)
- [x] `bats tests/install.bats` — `corrupted file is re-downloaded` passes (skip check now verifies on-disk hashes)
- [ ] Run `bash scripts/pack-download.sh --dir=<packs_dir> --all` on fresh install — all packs download with ✅ or ❌
- [ ] Run again — all packs show ✓, no re-downloads
- [ ] Ctrl-c mid-download, run again — completed packs skip, interrupted pack resumes
- [ ] Verify disk usage line shows at the end with correct path

🤖 Generated with [Claude Code](https://claude.com/claude-code)