### PR TITLE
feat: notification stacking, type text fix, close button & setup wizard

### DIFF
--- a/peon.sh
+++ b/peon.sh
@@ -755,6 +755,9 @@ send_notification() {
       fi
       export PEON_MSG_SUBTITLE="${MSG_SUBTITLE:-}"
       export PEON_NOTIFY_TYPE="${NOTIFY_TYPE:-}"
+      export PEON_SESSION_ID="${SESSION_ID:-}"
+      export PEON_NOTIF_STACKING="${NOTIF_STACKING:-true}"
+      export PEON_NOTIF_CLOSE_BUTTON="${NOTIF_CLOSE_BUTTON:-true}"
       bash "$notify_script" "$msg" "$title" "$color" "$icon_path"
       ;;
     devcontainer|ssh)
@@ -2839,6 +2842,165 @@ if changed:
       curl -fsSL https://raw.githubusercontent.com/PeonPing/peon-ping/main/install.sh | bash
     fi
     exit $? ;;
+  setup)
+    echo ""
+    echo "  ╔══════════════════════════════════════╗"
+    echo "  ║       peon-ping  setup wizard        ║"
+    echo "  ╚══════════════════════════════════════╝"
+    echo ""
+    python3 -c "
+import json, sys, os
+
+config_path = os.environ.get('PEON_ENV_CONFIG', '')
+try:
+    cfg = json.load(open(config_path))
+except Exception:
+    cfg = {}
+
+def ask(prompt, options, current):
+    for i, (key, label) in enumerate(options):
+        marker = ' \u2190' if key == current else ''
+        print(f'    {i+1}) {label}{marker}')
+    while True:
+        try:
+            choice = input(f'  > {prompt} [{current}]: ').strip()
+        except (EOFError, KeyboardInterrupt):
+            print(); sys.exit(0)
+        if not choice:
+            return current
+        try:
+            idx = int(choice) - 1
+            if 0 <= idx < len(options):
+                return options[idx][0]
+        except ValueError:
+            for key, label in options:
+                if choice.lower() in (key, label.lower()):
+                    return key
+        print('    Invalid choice, try again.')
+
+def ask_bool(prompt, current):
+    label = 'on' if current else 'off'
+    while True:
+        try:
+            choice = input(f'  > {prompt} [on/off] ({label}): ').strip().lower()
+        except (EOFError, KeyboardInterrupt):
+            print(); sys.exit(0)
+        if not choice:
+            return current
+        if choice in ('on', 'true', 'yes', 'y', '1', 'oui'):
+            return True
+        if choice in ('off', 'false', 'no', 'n', '0', 'non'):
+            return False
+        print('    on or off?')
+
+def ask_number(prompt, current, min_val=0, max_val=100):
+    while True:
+        try:
+            choice = input(f'  > {prompt} ({current}): ').strip()
+        except (EOFError, KeyboardInterrupt):
+            print(); sys.exit(0)
+        if not choice:
+            return current
+        try:
+            val = float(choice)
+            if min_val <= val <= max_val:
+                return val if val != int(val) else int(val)
+            print(f'    Must be between {min_val} and {max_val}.')
+        except ValueError:
+            print('    Enter a number.')
+
+# == Volume ==
+print('  \u2500\u2500 Volume \u2500\u2500')
+cfg['volume'] = ask_number('Volume (0.0 - 1.0)', cfg.get('volume', 0.5), 0, 1)
+print()
+
+# == Categories ==
+print('  \u2500\u2500 Sound categories \u2500\u2500')
+cats = cfg.get('categories', {})
+cat_list = [
+    ('session.start', 'Session start'),
+    ('task.acknowledge', 'Task acknowledge'),
+    ('task.complete', 'Task complete'),
+    ('task.error', 'Task error'),
+    ('input.required', 'Input required (permissions, questions)'),
+    ('resource.limit', 'Resource limit (context compaction)'),
+    ('user.spam', 'User spam (rapid prompts)'),
+]
+defaults_off = {'task.acknowledge'}
+for key, label in cat_list:
+    default = False if key in defaults_off else True
+    current = cats.get(key, default)
+    cats[key] = ask_bool(f'  {label}', current)
+cfg['categories'] = cats
+print()
+
+# == Notifications ==
+print('  \u2500\u2500 Notifications \u2500\u2500')
+cfg['desktop_notifications'] = ask_bool('Desktop notifications', cfg.get('desktop_notifications', True))
+
+if cfg['desktop_notifications']:
+    themes = [
+        ('neon', 'Neon (cyberpunk)'),
+        ('glass', 'Glass (translucent)'),
+        ('sakura', 'Sakura (cherry blossom)'),
+        ('jarvis', 'Jarvis (iron man)'),
+    ]
+    print()
+    print('  Overlay theme:')
+    cfg['overlay_theme'] = ask('Theme', themes, cfg.get('overlay_theme', 'neon'))
+
+    positions = [
+        ('top-center', 'Top center'),
+        ('top-right', 'Top right'),
+        ('top-left', 'Top left'),
+        ('bottom-center', 'Bottom center'),
+        ('bottom-right', 'Bottom right'),
+        ('bottom-left', 'Bottom left'),
+    ]
+    print()
+    print('  Notification position:')
+    cfg['notification_position'] = ask('Position', positions, cfg.get('notification_position', 'top-center'))
+
+    print()
+    dismiss_opts = [
+        (0, 'Persistent (click to dismiss)'),
+        (3, '3 seconds'),
+        (4, '4 seconds'),
+        (5, '5 seconds'),
+        (8, '8 seconds'),
+    ]
+    print('  Auto-dismiss:')
+    cfg['notification_dismiss_seconds'] = ask('Dismiss time', dismiss_opts, cfg.get('notification_dismiss_seconds', 4))
+
+    print()
+    cfg['notification_stacking'] = ask_bool('Stack notifications from same session (with count badge)', cfg.get('notification_stacking', True))
+
+    print()
+    cfg['notification_close_button'] = ask_bool('Show X close button on notifications', cfg.get('notification_close_button', True))
+
+print()
+
+# == Save ==
+json.dump(cfg, open(config_path, 'w'), indent=2)
+print('  \u2713 Configuration saved!')
+print()
+
+print('  \u2500\u2500 Summary \u2500\u2500')
+print(f'    Volume:        {cfg[\"volume\"]}')
+dn = 'on' if cfg.get('desktop_notifications', True) else 'off'
+print(f'    Notifications: {dn}')
+if cfg.get('desktop_notifications', True):
+    print(f'    Theme:         {cfg.get(\"overlay_theme\", \"neon\")}')
+    print(f'    Position:      {cfg.get(\"notification_position\", \"top-center\")}')
+    d = cfg.get('notification_dismiss_seconds', 4)
+    print(f'    Dismiss:       {\"persistent\" if d == 0 else str(d) + \"s\"}')
+    print(f'    Stacking:      {\"on\" if cfg.get(\"notification_stacking\", True) else \"off\"}')
+    print(f'    Close button:  {\"on\" if cfg.get(\"notification_close_button\", True) else \"off\"}')
+cats_on = [k for k, v in cfg.get('categories', {}).items() if v]
+print(f'    Categories:    {\", \".join(cats_on)}')
+print()
+"
+    sync_adapter_configs; exit 0 ;;
   help|--help|-h)
     cat <<'HELPEOF'
 Usage: peon <command>
@@ -2876,6 +3038,7 @@ Commands:
   logs --session ID    Filter today's log by session ID
   logs --session ID --all  Search across all log files for session ID
   logs --clear         Delete all log files (with confirmation)
+  setup                Interactive setup wizard
   update               Update peon-ping and refresh all sound packs
   help                 Show this help
 
@@ -4002,6 +4165,8 @@ elif category:
 if category and not cat_enabled.get(category, True):
     log('route', category=category, suppressed=True, reason='category_disabled')
     category = ''
+    notify = ''
+    notify_color = ''
 
 # --- Log route decision ---
 if category:
@@ -4281,6 +4446,9 @@ print('DESKTOP_NOTIF=' + ('true' if desktop_notif else 'false'))
 print('NOTIF_STYLE=' + q(cfg.get('notification_style', 'overlay')))
 print('NOTIF_POSITION=' + q(cfg.get('notification_position', 'top-center')))
 print('NOTIF_DISMISS=' + q(str(cfg.get('notification_dismiss_seconds', 4))))
+print('NOTIF_STACKING=' + ('true' if cfg.get('notification_stacking', True) else 'false'))
+print('NOTIF_CLOSE_BUTTON=' + ('true' if cfg.get('notification_close_button', True) else 'false'))
+print('SESSION_ID=' + q(session_id))
 print('NOTIF_ALL_SCREENS=' + ('true' if cfg.get('notification_all_screens', True) else 'false'))
 print('USE_SOUND_EFFECTS_DEVICE=' + q(str(use_sound_effects_device).lower()))
 print('LINUX_AUDIO_PLAYER=' + q(linux_audio_player))

--- a/scripts/mac-overlay-glass.js
+++ b/scripts/mac-overlay-glass.js
@@ -20,6 +20,7 @@ function run(argv) {
   var notifType   = argv[10] || ''; // Semantic type: complete|permission|limit|idle|question
   var allScreens  = argv[11] === 'true';
   var screenIdx   = (argv[12] !== undefined && argv[12] !== '') ? parseInt(argv[12], 10) : -1;
+  var showCloseButton = (argv[13] || 'true') === 'true';
 
   // ── Type text ──
   var typeText;
@@ -32,7 +33,8 @@ function run(argv) {
     default:
       // Fallback for relay.sh and other callers that don't set notifType
       if (color === 'blue')   typeText = 'TASK COMPLETE';
-      else if (color === 'red' || color === 'yellow') typeText = 'LIMIT REACHED';
+      else if (color === 'red')    typeText = 'APPROVAL NEEDED';
+      else if (color === 'yellow') typeText = 'STANDING BY';
       else                    typeText = 'INPUT REQUIRED';
   }
 
@@ -101,9 +103,10 @@ function run(argv) {
   }
 
   // ── Window ──
-  var win = $.NSWindow.alloc.initWithContentRectStyleMaskBackingDefer(
+  var nonActivating = 1 << 7; // NSWindowStyleMaskNonactivatingPanel
+  var win = $.NSPanel.alloc.initWithContentRectStyleMaskBackingDefer(
     $.NSMakeRect(x, y, winW, winH),
-    $.NSWindowStyleMaskBorderless, $.NSBackingStoreBuffered, false
+    $.NSWindowStyleMaskBorderless | nonActivating, $.NSBackingStoreBuffered, false
   );
   win.setBackgroundColor($.NSColor.clearColor);
   win.setOpaque(false); win.setHasShadow(false); win.setAlphaValue(0.0);
@@ -268,45 +271,12 @@ function run(argv) {
   ObjC.registerSubclass({
     name: 'GlassDismissHandler', superclass: 'NSObject',
     methods: { 'handleDismiss': { types: ['void', []], implementation: function() {
-      // Focus the terminal/IDE
-      if (bundleId || idePid > 0) {
-        var activated = false;
-        if (bundleId) {
-          var ws=$.NSWorkspace.sharedWorkspace, apps=ws.runningApplications;
-          for (var i=0;i<apps.count;i++) {
-            var app=apps.objectAtIndex(i), bid=app.bundleIdentifier;
-            if (!bid.isNil() && bid.js===bundleId) {
-              app.activateWithOptions($.NSApplicationActivateIgnoringOtherApps);
-              activated=true; break;
-            }
-          }
-        }
-        if (!activated && idePid > 0) {
-          var ideApp=$.NSRunningApplication.runningApplicationWithProcessIdentifier(idePid);
-          if (ideApp && !ideApp.isNil()) ideApp.activateWithOptions($.NSApplicationActivateIgnoringOtherApps);
-        }
-        // iTerm2: try tab/window-level focus after app activation (fire-and-forget)
-        if (sessionTty && bundleId === 'com.googlecode.iterm2') {
-          try {
-            var task = $.NSTask.alloc.init;
-            task.setLaunchPath($('/usr/bin/osascript'));
-            task.setArguments($(['-l', 'JavaScript', '-e',
-              'var iTerm=Application("iTerm2");var ws=iTerm.windows();var f=0;' +
-              'for(var w=0;w<ws.length&&!f;w++){var ts=ws[w].tabs();' +
-              'for(var t=0;t<ts.length&&!f;t++){var ss=ts[t].sessions();' +
-              'for(var s=0;s<ss.length&&!f;s++){try{if(ss[s].tty()==="' + sessionTty + '")' +
-              '{ts[t].select();ss[s].select();ws[w].index=1;f=1}}catch(e){}}}}'
-            ]));
-            task.launch;
-          } catch(e) {}
-        }
+      // Hide windows first to prevent focus shift from iTerm overlay
+      var allWindows = $.NSApp.windows;
+      for (var w = 0; w < allWindows.count; w++) {
+        allWindows.objectAtIndex(w).orderOut(null);
       }
-      // Signal ALL sibling overlays to dismiss (event-driven, no polling!)
-      $.NSDistributedNotificationCenter.defaultCenter.postNotificationNameObject($(dismissNotificationName), $.NSString.string);
-      // Small delay to ensure notification is delivered before we terminate
-      $.NSTimer.scheduledTimerWithTimeIntervalTargetSelectorUserInfoRepeats(
-        0.05, $.NSApp, 'terminate:', null, false
-      );
+      $.NSApp.stop(null);
     }}}
   });
   var dh = $.GlassDismissHandler.alloc.init;
@@ -314,6 +284,29 @@ function run(argv) {
   btn.setTitle($('')); btn.setBordered(false); btn.setTransparent(true);
   btn.setTarget(dh); btn.setAction('handleDismiss');
   win.contentView.addSubview(btn);
+
+  // Visible X close button (configurable)
+  if (showCloseButton) {
+    var xSize = 22;
+    var xPosX = padX + contentW - xSize + 6;
+    var xPosY = padY + contentH - xSize + 6;
+    var xLabel = $.NSTextField.alloc.initWithFrame($.NSMakeRect(xPosX, xPosY, xSize, xSize));
+    xLabel.setStringValue($('\u00D7'));
+    xLabel.setBezeled(false);
+    xLabel.setDrawsBackground(false);
+    xLabel.setEditable(false);
+    xLabel.setSelectable(false);
+    xLabel.setTextColor($.NSColor.colorWithSRGBRedGreenBlueAlpha(accentR, accentG, accentB, 0.6));
+    xLabel.setAlignment($.NSTextAlignmentCenter);
+    xLabel.setFont($.NSFont.boldSystemFontOfSize(16));
+    win.contentView.addSubview(xLabel);
+    var xBtn = $.NSButton.alloc.initWithFrame($.NSMakeRect(xPosX - 4, xPosY - 4, xSize + 8, xSize + 8));
+    xBtn.setTitle($(''));
+    xBtn.setBordered(false);
+    xBtn.setTransparent(true);
+    xBtn.setTarget(dh); xBtn.setAction('handleDismiss');
+    win.contentView.addSubview(xBtn);
+  }
 
   // ══════════════════════════════════════════════
   // ANIMATION

--- a/scripts/mac-overlay-jarvis.js
+++ b/scripts/mac-overlay-jarvis.js
@@ -20,6 +20,7 @@ function run(argv) {
   var notifType   = argv[10] || ''; // Semantic type: complete|permission|limit|idle|question
   var allScreens  = argv[11] === 'true';
   var screenIdx   = (argv[12] !== undefined && argv[12] !== '') ? parseInt(argv[12], 10) : -1;
+  var showCloseButton = (argv[13] || 'true') === 'true';
 
   var accentR = 0.0, accentG = 0.75, accentB = 1.0;
   switch (color) {
@@ -37,9 +38,9 @@ function run(argv) {
     case 'idle':       typeText = 'STANDING BY';     break;
     case 'question':   typeText = 'INPUT REQUIRED';  break;
     default:
-      // Fallback for relay.sh and other callers that don't set notifType
       if (color === 'blue')   typeText = 'TASK COMPLETE';
-      else if (color === 'red' || color === 'yellow') typeText = 'LIMIT REACHED';
+      else if (color === 'red')    typeText = 'APPROVAL NEEDED';
+      else if (color === 'yellow') typeText = 'STANDING BY';
       else                    typeText = 'INPUT REQUIRED';
   }
 
@@ -107,9 +108,10 @@ function run(argv) {
       y = vf.origin.y + vf.size.height - winSize - ySlotOffset;
   }
 
-  var win = $.NSWindow.alloc.initWithContentRectStyleMaskBackingDefer(
+  var nonActivating = 1 << 7; // NSWindowStyleMaskNonactivatingPanel
+  var win = $.NSPanel.alloc.initWithContentRectStyleMaskBackingDefer(
     $.NSMakeRect(x, y, winSize, winSize),
-    $.NSWindowStyleMaskBorderless, $.NSBackingStoreBuffered, false
+    $.NSWindowStyleMaskBorderless | nonActivating, $.NSBackingStoreBuffered, false
   );
   win.setBackgroundColor($.NSColor.clearColor);
   win.setOpaque(false); win.setHasShadow(false); win.setAlphaValue(0.0);
@@ -512,45 +514,12 @@ function run(argv) {
   ObjC.registerSubclass({
     name: 'JarvisDismissHandler', superclass: 'NSObject',
     methods: { 'handleDismiss': { types: ['void', []], implementation: function() {
-      // Focus the terminal/IDE
-      if (bundleId || idePid > 0) {
-        var activated = false;
-        if (bundleId) {
-          var ws=$.NSWorkspace.sharedWorkspace, apps=ws.runningApplications;
-          for (var i=0;i<apps.count;i++) {
-            var app=apps.objectAtIndex(i), bid=app.bundleIdentifier;
-            if (!bid.isNil() && bid.js===bundleId) {
-              app.activateWithOptions($.NSApplicationActivateIgnoringOtherApps);
-              activated=true; break;
-            }
-          }
-        }
-        if (!activated && idePid > 0) {
-          var ideApp=$.NSRunningApplication.runningApplicationWithProcessIdentifier(idePid);
-          if (ideApp && !ideApp.isNil()) ideApp.activateWithOptions($.NSApplicationActivateIgnoringOtherApps);
-        }
-        // iTerm2: try tab/window-level focus after app activation (fire-and-forget)
-        if (sessionTty && bundleId === 'com.googlecode.iterm2') {
-          try {
-            var task = $.NSTask.alloc.init;
-            task.setLaunchPath($('/usr/bin/osascript'));
-            task.setArguments($(['-l', 'JavaScript', '-e',
-              'var iTerm=Application("iTerm2");var ws=iTerm.windows();var f=0;' +
-              'for(var w=0;w<ws.length&&!f;w++){var ts=ws[w].tabs();' +
-              'for(var t=0;t<ts.length&&!f;t++){var ss=ts[t].sessions();' +
-              'for(var s=0;s<ss.length&&!f;s++){try{if(ss[s].tty()==="' + sessionTty + '")' +
-              '{ts[t].select();ss[s].select();ws[w].index=1;f=1}}catch(e){}}}}'
-            ]));
-            task.launch;
-          } catch(e) {}
-        }
+      // Hide windows first to prevent focus shift from iTerm overlay
+      var allWindows = $.NSApp.windows;
+      for (var w = 0; w < allWindows.count; w++) {
+        allWindows.objectAtIndex(w).orderOut(null);
       }
-      // Signal ALL sibling overlays to dismiss (event-driven, no polling!)
-      $.NSDistributedNotificationCenter.defaultCenter.postNotificationNameObject($(dismissNotificationName), $.NSString.string);
-      // Small delay to ensure notification is delivered before we terminate
-      $.NSTimer.scheduledTimerWithTimeIntervalTargetSelectorUserInfoRepeats(
-        0.05, $.NSApp, 'terminate:', null, false
-      );
+      $.NSApp.stop(null);
     }}}
   });
   var dh=$.JarvisDismissHandler.alloc.init;
@@ -558,6 +527,29 @@ function run(argv) {
   btn.setTitle($('')); btn.setBordered(false); btn.setTransparent(true);
   btn.setTarget(dh); btn.setAction('handleDismiss');
   win.contentView.addSubview(btn);
+
+  // Visible X close button (configurable)
+  if (showCloseButton) {
+    var xSize = 22;
+    var xPosX = padding + circleSize - xSize - 2;
+    var xPosY = padding + circleSize - xSize - 2;
+    var xLabel = $.NSTextField.alloc.initWithFrame($.NSMakeRect(xPosX, xPosY, xSize, xSize));
+    xLabel.setStringValue($('\u00D7'));
+    xLabel.setBezeled(false);
+    xLabel.setDrawsBackground(false);
+    xLabel.setEditable(false);
+    xLabel.setSelectable(false);
+    xLabel.setTextColor($.NSColor.colorWithSRGBRedGreenBlueAlpha(accentR, accentG, accentB, 0.6));
+    xLabel.setAlignment($.NSTextAlignmentCenter);
+    xLabel.setFont($.NSFont.boldSystemFontOfSize(16));
+    win.contentView.addSubview(xLabel);
+    var xBtn = $.NSButton.alloc.initWithFrame($.NSMakeRect(xPosX - 4, xPosY - 4, xSize + 8, xSize + 8));
+    xBtn.setTitle($(''));
+    xBtn.setBordered(false);
+    xBtn.setTransparent(true);
+    xBtn.setTarget(dh); xBtn.setAction('handleDismiss');
+    win.contentView.addSubview(xBtn);
+  }
 
   // ══════════════════════════════════════════════
   // ANIMATION

--- a/scripts/mac-overlay-sakura.js
+++ b/scripts/mac-overlay-sakura.js
@@ -20,6 +20,7 @@ function run(argv) {
   var notifType   = argv[10] || ''; // Semantic type: complete|permission|limit|idle|question
   var allScreens  = argv[11] === 'true';
   var screenIdx   = (argv[12] !== undefined && argv[12] !== '') ? parseInt(argv[12], 10) : -1;
+  var showCloseButton = (argv[13] || 'true') === 'true';
 
   var PI = Math.PI, TAU = 2 * PI;
 
@@ -32,9 +33,9 @@ function run(argv) {
     case 'idle':       typeText = 'STANDING BY';     break;
     case 'question':   typeText = 'INPUT REQUIRED';  break;
     default:
-      // Fallback for relay.sh and other callers that don't set notifType
       if (color === 'blue')   typeText = 'TASK COMPLETE';
-      else if (color === 'red' || color === 'yellow') typeText = 'LIMIT REACHED';
+      else if (color === 'red')    typeText = 'APPROVAL NEEDED';
+      else if (color === 'yellow') typeText = 'STANDING BY';
       else                    typeText = 'INPUT REQUIRED';
   }
 
@@ -103,9 +104,10 @@ function run(argv) {
   }
 
   // ── Window ──
-  var win = $.NSWindow.alloc.initWithContentRectStyleMaskBackingDefer(
+  var nonActivating = 1 << 7; // NSWindowStyleMaskNonactivatingPanel
+  var win = $.NSPanel.alloc.initWithContentRectStyleMaskBackingDefer(
     $.NSMakeRect(x, y, winW, winH),
-    $.NSWindowStyleMaskBorderless, $.NSBackingStoreBuffered, false
+    $.NSWindowStyleMaskBorderless | nonActivating, $.NSBackingStoreBuffered, false
   );
   win.setBackgroundColor($.NSColor.clearColor);
   win.setOpaque(false); win.setHasShadow(false); win.setAlphaValue(0.0);
@@ -453,45 +455,12 @@ function run(argv) {
   ObjC.registerSubclass({
     name: 'SakuraDismissHandler', superclass: 'NSObject',
     methods: { 'handleDismiss': { types: ['void', []], implementation: function() {
-      // Focus the terminal/IDE
-      if (bundleId || idePid > 0) {
-        var activated = false;
-        if (bundleId) {
-          var ws=$.NSWorkspace.sharedWorkspace, apps=ws.runningApplications;
-          for (var i=0;i<apps.count;i++) {
-            var app=apps.objectAtIndex(i), bid=app.bundleIdentifier;
-            if (!bid.isNil() && bid.js===bundleId) {
-              app.activateWithOptions($.NSApplicationActivateIgnoringOtherApps);
-              activated=true; break;
-            }
-          }
-        }
-        if (!activated && idePid > 0) {
-          var ideApp=$.NSRunningApplication.runningApplicationWithProcessIdentifier(idePid);
-          if (ideApp && !ideApp.isNil()) ideApp.activateWithOptions($.NSApplicationActivateIgnoringOtherApps);
-        }
-        // iTerm2: try tab/window-level focus after app activation (fire-and-forget)
-        if (sessionTty && bundleId === 'com.googlecode.iterm2') {
-          try {
-            var task = $.NSTask.alloc.init;
-            task.setLaunchPath($('/usr/bin/osascript'));
-            task.setArguments($(['-l', 'JavaScript', '-e',
-              'var iTerm=Application("iTerm2");var ws=iTerm.windows();var f=0;' +
-              'for(var w=0;w<ws.length&&!f;w++){var ts=ws[w].tabs();' +
-              'for(var t=0;t<ts.length&&!f;t++){var ss=ts[t].sessions();' +
-              'for(var s=0;s<ss.length&&!f;s++){try{if(ss[s].tty()==="' + sessionTty + '")' +
-              '{ts[t].select();ss[s].select();ws[w].index=1;f=1}}catch(e){}}}}'
-            ]));
-            task.launch;
-          } catch(e) {}
-        }
+      // Hide windows first to prevent focus shift from iTerm overlay
+      var allWindows = $.NSApp.windows;
+      for (var w = 0; w < allWindows.count; w++) {
+        allWindows.objectAtIndex(w).orderOut(null);
       }
-      // Signal ALL sibling overlays to dismiss (event-driven, no polling!)
-      $.NSDistributedNotificationCenter.defaultCenter.postNotificationNameObject($(dismissNotificationName), $.NSString.string);
-      // Small delay to ensure notification is delivered before we terminate
-      $.NSTimer.scheduledTimerWithTimeIntervalTargetSelectorUserInfoRepeats(
-        0.05, $.NSApp, 'terminate:', null, false
-      );
+      $.NSApp.stop(null);
     }}}
   });
   var dh = $.SakuraDismissHandler.alloc.init;
@@ -499,6 +468,29 @@ function run(argv) {
   btn.setTitle($('')); btn.setBordered(false); btn.setTransparent(true);
   btn.setTarget(dh); btn.setAction('handleDismiss');
   win.contentView.addSubview(btn);
+
+  // Visible X close button (configurable)
+  if (showCloseButton) {
+    var xSize = 22;
+    var xPosX = padX + contentW - xSize + 6;
+    var xPosY = padY + contentH - xSize + 6;
+    var xLabel = $.NSTextField.alloc.initWithFrame($.NSMakeRect(xPosX, xPosY, xSize, xSize));
+    xLabel.setStringValue($('\u00D7'));
+    xLabel.setBezeled(false);
+    xLabel.setDrawsBackground(false);
+    xLabel.setEditable(false);
+    xLabel.setSelectable(false);
+    xLabel.setTextColor($.NSColor.colorWithSRGBRedGreenBlueAlpha(accentR, accentG, accentB, 0.6));
+    xLabel.setAlignment($.NSTextAlignmentCenter);
+    xLabel.setFont($.NSFont.boldSystemFontOfSize(16));
+    win.contentView.addSubview(xLabel);
+    var xBtn = $.NSButton.alloc.initWithFrame($.NSMakeRect(xPosX - 4, xPosY - 4, xSize + 8, xSize + 8));
+    xBtn.setTitle($(''));
+    xBtn.setBordered(false);
+    xBtn.setTransparent(true);
+    xBtn.setTarget(dh); xBtn.setAction('handleDismiss');
+    win.contentView.addSubview(xBtn);
+  }
 
   // ══════════════════════════════════════════════
   // ANIMATION

--- a/scripts/notify.sh
+++ b/scripts/notify.sh
@@ -198,32 +198,82 @@ case "$PEON_PLATFORM" in
           fi
         fi
         slot_dir="/tmp/peon-ping-popups"; mkdir -p "$slot_dir"
-        slot=0
-        while [ "$slot" -lt 5 ] && ! mkdir "$slot_dir/slot-$slot" 2>/dev/null; do
-          slot=$((slot + 1))
-        done
-        if [ "$slot" -ge 5 ]; then
-          find "$slot_dir" -maxdepth 1 -name 'slot-*' -mmin +1 -exec rm -rf {} + 2>/dev/null
-          slot=0; mkdir -p "$slot_dir/slot-0"
+        local session_id="${PEON_SESSION_ID:-}"
+        local session_file=""
+        local count=1
+        local reuse_slot=-1
+
+        # --- Session stacking: group notifications from the same Claude session ---
+        local stacking_enabled="${PEON_NOTIF_STACKING:-true}"
+        if [ "$stacking_enabled" = "true" ] && [ -n "$session_id" ]; then
+          session_file="$slot_dir/.session-${session_id}"
+          if [ -f "$session_file" ]; then
+            local old_slot old_pid old_count
+            IFS='|' read -r old_slot old_pid old_count < "$session_file" 2>/dev/null || true
+            old_count="${old_count:-1}"
+            count=$((old_count + 1))
+            # Kill the previous overlay(s) for this session
+            if [ -n "$old_pid" ]; then
+              for _kp in $old_pid; do
+                kill "$_kp" 2>/dev/null || true
+              done
+              # Wait briefly for slot cleanup
+              local _w=0
+              while [ "$_w" -lt 10 ] && [ -d "$slot_dir/slot-${old_slot}" ]; do
+                sleep 0.05; _w=$((_w + 1))
+              done
+            fi
+            # Try to reuse the same slot position
+            if mkdir "$slot_dir/slot-${old_slot}" 2>/dev/null; then
+              reuse_slot=$old_slot
+            fi
+          fi
         fi
+
+        # Allocate a new slot if we couldn't reuse
+        if [ "$reuse_slot" -ge 0 ]; then
+          slot=$reuse_slot
+        else
+          slot=0
+          while [ "$slot" -lt 5 ] && ! mkdir "$slot_dir/slot-$slot" 2>/dev/null; do
+            slot=$((slot + 1))
+          done
+          if [ "$slot" -ge 5 ]; then
+            find "$slot_dir" -maxdepth 1 -name 'slot-*' -mmin +1 -exec rm -rf {} + 2>/dev/null
+            slot=0; mkdir -p "$slot_dir/slot-0"
+          fi
+        fi
+
         local session_tty="${PEON_SESSION_TTY:-}"
         local subtitle="${PEON_MSG_SUBTITLE:-}"
         local dismiss_secs="${PEON_NOTIF_DISMISS:-4}"
         local notif_position="${PEON_NOTIF_POSITION:-top-center}"
         local notify_type="${PEON_NOTIFY_TYPE:-}"
         local all_screens="${PEON_NOTIF_ALL_SCREENS:-true}"
-        # argv[5]=bundle_id, argv[6]=ide_pid, argv[7]=session_tty, argv[8]=subtitle, argv[9]=position, argv[10]=notify_type, argv[11]=all_screens, argv[12]=screen_index
+        local close_button="${PEON_NOTIF_CLOSE_BUTTON:-true}"
+
+        # Prepend count badge if stacked
+        if [ "$count" -gt 1 ]; then
+          msg="($count) $msg"
+        fi
+
+        # argv[5]=bundle_id, argv[6]=ide_pid, argv[7]=session_tty, argv[8]=subtitle, argv[9]=position, argv[10]=notify_type, argv[11]=all_screens, argv[12]=screen_index, argv[13]=close_button
         local _overlay_pids=""
         if [ "$all_screens" = "true" ]; then
           local screen_count
           screen_count=$(osascript -l JavaScript -e 'ObjC.import("Cocoa"); $.NSScreen.screens.count' 2>/dev/null || echo 1)
           for _si in $(seq 0 $((screen_count - 1))); do
-            osascript -l JavaScript "$overlay_script" "$msg" "$color" "$local_icon_arg" "$slot" "$dismiss_secs" "$bundle_id" "$ide_pid" "$session_tty" "$subtitle" "$notif_position" "$notify_type" "$all_screens" "$_si" >/dev/null 2>&1 &
+            osascript -l JavaScript "$overlay_script" "$msg" "$color" "$local_icon_arg" "$slot" "$dismiss_secs" "$bundle_id" "$ide_pid" "$session_tty" "$subtitle" "$notif_position" "$notify_type" "$all_screens" "$_si" "$close_button" >/dev/null 2>&1 &
             _overlay_pids="$_overlay_pids $!"
           done
         else
-          osascript -l JavaScript "$overlay_script" "$msg" "$color" "$local_icon_arg" "$slot" "$dismiss_secs" "$bundle_id" "$ide_pid" "$session_tty" "$subtitle" "$notif_position" "$notify_type" "$all_screens" >/dev/null 2>&1 &
+          osascript -l JavaScript "$overlay_script" "$msg" "$color" "$local_icon_arg" "$slot" "$dismiss_secs" "$bundle_id" "$ide_pid" "$session_tty" "$subtitle" "$notif_position" "$notify_type" "$all_screens" "" "$close_button" >/dev/null 2>&1 &
           _overlay_pids="$!"
+        fi
+
+        # Save session state for stacking
+        if [ -n "$session_file" ]; then
+          echo "${slot}|${_overlay_pids## }|${count}" > "$session_file"
         fi
         # Shell-level watchdog: kill if JXA terminate timer doesn't fire (macOS regression)
         # When dismiss_secs=0 (persistent), skip the watchdog — overlay stays until clicked.
@@ -245,6 +295,8 @@ case "$PEON_PLATFORM" in
           wait "$_last_wd" 2>/dev/null || true
         done
         rm -rf "$slot_dir/slot-$slot"
+        # Clean up session file when overlay is dismissed
+        [ -n "$session_file" ] && rm -f "$session_file"
       )
       if [ "$use_bg" = true ]; then _run_overlay & else _run_overlay; fi
     else


### PR DESCRIPTION
## Summary

- **Fix: type text fallback** — overlay themes mapped all red notifications to "LIMIT REACHED", including permission requests. Now the fallback correctly shows "APPROVAL NEEDED" for red and "STANDING BY" for yellow. The `notifType` switch already had the right labels; only the color-based fallback was wrong.
- **Fix: suppress notification when category disabled** — when a category like `resource.limit` is disabled in config, both sound AND notification are now suppressed (previously only the sound was suppressed but the overlay still appeared).
- **Fix: NSPanel non-activating** — overlay windows now use `NSPanel` with `NSWindowStyleMaskNonactivatingPanel` instead of `NSWindow`, preventing iTerm2 hotkey/overlay windows from closing when clicking a notification.
- **Feat: session-based notification stacking** — multiple notifications from the same Claude session consolidate into one overlay at the same slot position, with a count badge prefix like `(3) project — needs approval`. Configurable via `notification_stacking` (default: `true`).
- **Feat: visible X close button** — a `×` button in the top-right corner of themed overlays allows dismissing without any focus side-effects. Configurable via `notification_close_button` (default: `true`).
- **Feat: simplified dismiss handlers** — click-to-dismiss no longer activates the terminal app, just hides the overlay windows and stops the process cleanly.
- **Feat: `peon setup` wizard** — interactive CLI wizard that walks through volume, sound categories, notification theme, position, dismiss behavior, stacking, and close button settings.

## New config keys

| Key | Type | Default | Description |
|-----|------|---------|-------------|
| `notification_stacking` | bool | `true` | Group notifications from same session with count badge |
| `notification_close_button` | bool | `true` | Show visible × dismiss button on overlays |

## Files changed

- `peon.sh` — category suppression fix, new config exports, `peon setup` command
- `scripts/notify.sh` — session stacking logic, close_button passthrough
- `scripts/mac-overlay-glass.js` — NSPanel, fallback fix, X button, simplified dismiss
- `scripts/mac-overlay-sakura.js` — same
- `scripts/mac-overlay-jarvis.js` — same

## Test plan

- [ ] Run `peon setup` and verify all prompts work, config is saved correctly
- [ ] Disable `resource.limit` category → verify no notification on PreCompact events
- [ ] Trigger PermissionRequest → verify overlay shows "APPROVAL NEEDED" not "LIMIT REACHED"
- [ ] Trigger multiple notifications from same session → verify stacking with count badge
- [ ] Click notification body → verify it dismisses without closing iTerm overlay/hotkey window
- [ ] Click X button → verify it dismisses the notification
- [ ] Set `notification_close_button: false` → verify X button is hidden
- [ ] Set `notification_stacking: false` → verify each notification gets its own slot

🤖 Generated with [Claude Code](https://claude.com/claude-code)