### PR TITLE
fix: type text fallback and category suppression

### DIFF
--- a/peon.sh
+++ b/peon.sh
@@ -4002,6 +4002,8 @@ elif category:
 if category and not cat_enabled.get(category, True):
     log('route', category=category, suppressed=True, reason='category_disabled')
     category = ''
+    notify = ''
+    notify_color = ''
 
 # --- Log route decision ---
 if category:

--- a/scripts/mac-overlay-glass.js
+++ b/scripts/mac-overlay-glass.js
@@ -32,7 +32,8 @@ function run(argv) {
     default:
       // Fallback for relay.sh and other callers that don't set notifType
       if (color === 'blue')   typeText = 'TASK COMPLETE';
-      else if (color === 'red' || color === 'yellow') typeText = 'LIMIT REACHED';
+      else if (color === 'red')    typeText = 'APPROVAL NEEDED';
+      else if (color === 'yellow') typeText = 'STANDING BY';
       else                    typeText = 'INPUT REQUIRED';
   }
 

--- a/scripts/mac-overlay-jarvis.js
+++ b/scripts/mac-overlay-jarvis.js
@@ -39,7 +39,8 @@ function run(argv) {
     default:
       // Fallback for relay.sh and other callers that don't set notifType
       if (color === 'blue')   typeText = 'TASK COMPLETE';
-      else if (color === 'red' || color === 'yellow') typeText = 'LIMIT REACHED';
+      else if (color === 'red')    typeText = 'APPROVAL NEEDED';
+      else if (color === 'yellow') typeText = 'STANDING BY';
       else                    typeText = 'INPUT REQUIRED';
   }
 

--- a/scripts/mac-overlay-sakura.js
+++ b/scripts/mac-overlay-sakura.js
@@ -34,7 +34,8 @@ function run(argv) {
     default:
       // Fallback for relay.sh and other callers that don't set notifType
       if (color === 'blue')   typeText = 'TASK COMPLETE';
-      else if (color === 'red' || color === 'yellow') typeText = 'LIMIT REACHED';
+      else if (color === 'red')    typeText = 'APPROVAL NEEDED';
+      else if (color === 'yellow') typeText = 'STANDING BY';
       else                    typeText = 'INPUT REQUIRED';
   }
 


### PR DESCRIPTION
## Summary
- Overlay color-based fallback now maps red → "APPROVAL NEEDED" and yellow → "STANDING BY" instead of "LIMIT REACHED" for both. Permission requests were incorrectly labeled when `notifType` was not set.
- When a category is disabled in config, both sound AND notification are now suppressed (previously only sound was suppressed).

## Test plan
- [ ] Disable `resource.limit` → verify no overlay on PreCompact
- [ ] Trigger PermissionRequest via relay without notifType → verify "APPROVAL NEEDED"

🤖 Generated with [Claude Code](https://claude.com/claude-code)