### PR TITLE
feat: session-based notification stacking with auto-dismiss

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -2830,7 +2830,7 @@ $peonEntry = [PSCustomObject]@{
     hooks = @($peonHook)
 }
 
-$events = @("SessionStart", "SessionEnd", "SubagentStart", "Stop", "Notification", "PermissionRequest", "PostToolUseFailure", "PreCompact")
+$events = @("SessionStart", "SessionEnd", "SubagentStart", "Stop", "Notification", "PermissionRequest", "PreToolUse", "PostToolUseFailure", "PreCompact")
 
 foreach ($evt in $events) {
     $eventHooks = @()

--- a/install.sh
+++ b/install.sh
@@ -1022,7 +1022,7 @@ peon_hook_async = {
 # SessionStart runs sync so stderr messages (update notice, pause status,
 # relay guidance) appear immediately. All other events run async.
 sync_events = ('SessionStart',)
-events = ['SessionStart', 'SessionEnd', 'SubagentStart', 'SubagentStop', 'UserPromptSubmit', 'Stop', 'Notification', 'PermissionRequest', 'PostToolUseFailure', 'PreCompact']
+events = ['SessionStart', 'SessionEnd', 'SubagentStart', 'SubagentStop', 'UserPromptSubmit', 'Stop', 'Notification', 'PermissionRequest', 'PreToolUse', 'PostToolUseFailure', 'PreCompact']
 
 # PostToolUseFailure only triggers on Bash failures — use matcher to limit scope
 bash_only_events = ('PostToolUseFailure',)

--- a/peon.sh
+++ b/peon.sh
@@ -756,6 +756,8 @@ send_notification() {
       export PEON_MSG_SUBTITLE="${MSG_SUBTITLE:-}"
       export PEON_NOTIFY_TYPE="${NOTIFY_TYPE:-}"
       export PEON_NOTIF_CLOSE_BUTTON="${NOTIF_CLOSE_BUTTON:-true}"
+      export PEON_SESSION_ID="${SESSION_ID:-}"
+      export PEON_NOTIF_STACKING="${NOTIF_STACKING:-true}"
       bash "$notify_script" "$msg" "$title" "$color" "$icon_path"
       ;;
     devcontainer|ssh)
@@ -3812,6 +3814,26 @@ notify_color = ''
 msg = ''
 msg_subtitle = ''
 
+# --- Auto-dismiss: kill pending overlays when user resumes interaction ---
+# UserPromptSubmit = user typed/accepted, Stop = task finished,
+# PostToolUseFailure/Notification = tool ran (permission was granted) — dismiss stale notifications
+_dismiss_events = ('UserPromptSubmit', 'Stop', 'PreToolUse', 'PostToolUse', 'PostToolUseFailure', 'Notification')
+if event in _dismiss_events and session_id and cfg.get('notification_stacking', True):
+    _slot_dir = '/tmp/peon-ping-popups'
+    _sf = os.path.join(_slot_dir, '.session-' + session_id)
+    if os.path.isfile(_sf):
+        try:
+            _parts = open(_sf).read().strip().split('|')
+            if len(_parts) >= 2:
+                for _kpid in _parts[1].split():
+                    try:
+                        os.kill(int(_kpid), 15)
+                    except (OSError, ValueError):
+                        pass
+            os.unlink(_sf)
+        except Exception:
+            pass
+
 if event == 'SessionStart':
     source = event_data.get('source', '')
     if source == 'compact':
@@ -4332,6 +4354,8 @@ print('NOTIF_DISMISS=' + q(str(cfg.get('notification_dismiss_seconds', 4))))
 print('NOTIF_ALL_SCREENS=' + ('true' if cfg.get('notification_all_screens', True) else 'false'))
 print('NOTIF_MARKER=' + q(cfg.get('notification_title_marker', '●')))
 print('NOTIF_CLOSE_BUTTON=' + ('true' if cfg.get('notification_close_button', True) else 'false'))
+print('NOTIF_STACKING=' + ('true' if cfg.get('notification_stacking', True) else 'false'))
+print('SESSION_ID=' + q(session_id))
 print('USE_SOUND_EFFECTS_DEVICE=' + q(str(use_sound_effects_device).lower()))
 print('LINUX_AUDIO_PLAYER=' + q(linux_audio_player))
 print('PEON_SSH_AUDIO_MODE=' + q(str(cfg.get('ssh_audio_mode', 'relay'))))

--- a/scripts/notify.sh
+++ b/scripts/notify.sh
@@ -198,14 +198,48 @@ case "$PEON_PLATFORM" in
           fi
         fi
         slot_dir="/tmp/peon-ping-popups"; mkdir -p "$slot_dir"
-        slot=0
-        while [ "$slot" -lt 5 ] && ! mkdir "$slot_dir/slot-$slot" 2>/dev/null; do
-          slot=$((slot + 1))
-        done
-        if [ "$slot" -ge 5 ]; then
-          find "$slot_dir" -maxdepth 1 -name 'slot-*' -mmin +1 -exec rm -rf {} + 2>/dev/null
-          slot=0; mkdir -p "$slot_dir/slot-0"
+        local session_id="${PEON_SESSION_ID:-}"
+        local session_file=""
+        local count=1
+        local reuse_slot=-1
+
+        # --- Session stacking: group notifications from the same Claude session ---
+        local stacking_enabled="${PEON_NOTIF_STACKING:-true}"
+        if [ "$stacking_enabled" = "true" ] && [ -n "$session_id" ]; then
+          session_file="$slot_dir/.session-${session_id}"
+          if [ -f "$session_file" ]; then
+            local old_slot old_pid old_count
+            IFS='|' read -r old_slot old_pid old_count < "$session_file" 2>/dev/null || true
+            old_count="${old_count:-1}"
+            count=$((old_count + 1))
+            if [ -n "$old_pid" ]; then
+              for _kp in $old_pid; do
+                kill "$_kp" 2>/dev/null || true
+              done
+              local _w=0
+              while [ "$_w" -lt 10 ] && [ -d "$slot_dir/slot-${old_slot}" ]; do
+                sleep 0.05; _w=$((_w + 1))
+              done
+            fi
+            if mkdir "$slot_dir/slot-${old_slot}" 2>/dev/null; then
+              reuse_slot=$old_slot
+            fi
+          fi
         fi
+
+        if [ "$reuse_slot" -ge 0 ]; then
+          slot=$reuse_slot
+        else
+          slot=0
+          while [ "$slot" -lt 5 ] && ! mkdir "$slot_dir/slot-$slot" 2>/dev/null; do
+            slot=$((slot + 1))
+          done
+          if [ "$slot" -ge 5 ]; then
+            find "$slot_dir" -maxdepth 1 -name 'slot-*' -mmin +1 -exec rm -rf {} + 2>/dev/null
+            slot=0; mkdir -p "$slot_dir/slot-0"
+          fi
+        fi
+
         local session_tty="${PEON_SESSION_TTY:-}"
         local subtitle="${PEON_MSG_SUBTITLE:-}"
         local dismiss_secs="${PEON_NOTIF_DISMISS:-4}"
@@ -213,6 +247,12 @@ case "$PEON_PLATFORM" in
         local notify_type="${PEON_NOTIFY_TYPE:-}"
         local all_screens="${PEON_NOTIF_ALL_SCREENS:-true}"
         local close_button="${PEON_NOTIF_CLOSE_BUTTON:-true}"
+
+        # Prepend count badge if stacked
+        if [ "$count" -gt 1 ]; then
+          msg="($count) $msg"
+        fi
+
         # argv[5]=bundle_id, argv[6]=ide_pid, argv[7]=session_tty, argv[8]=subtitle, argv[9]=position, argv[10]=notify_type, argv[11]=all_screens, argv[12]=screen_index, argv[13]=close_button
         local _overlay_pids=""
         if [ "$all_screens" = "true" ]; then
@@ -226,6 +266,11 @@ case "$PEON_PLATFORM" in
           osascript -l JavaScript "$overlay_script" "$msg" "$color" "$local_icon_arg" "$slot" "$dismiss_secs" "$bundle_id" "$ide_pid" "$session_tty" "$subtitle" "$notif_position" "$notify_type" "$all_screens" "" "$close_button" >/dev/null 2>&1 &
           _overlay_pids="$!"
         fi
+        # Save session state for stacking
+        if [ -n "$session_file" ]; then
+          echo "${slot}|${_overlay_pids## }|${count}" > "$session_file"
+        fi
+
         # Shell-level watchdog: kill if JXA terminate timer doesn't fire (macOS regression)
         # When dismiss_secs=0 (persistent), skip the watchdog — overlay stays until clicked.
         local _max_wait
@@ -246,6 +291,7 @@ case "$PEON_PLATFORM" in
           wait "$_last_wd" 2>/dev/null || true
         done
         rm -rf "$slot_dir/slot-$slot"
+        [ -n "$session_file" ] && rm -f "$session_file"
       )
       if [ "$use_bg" = true ]; then _run_overlay & else _run_overlay; fi
     else


### PR DESCRIPTION
## Summary
Group notifications from the same Claude session into a single overlay with a count badge. When the user resumes interaction (accepts a permission, submits a prompt, etc.), pending overlays are automatically dismissed.

## Behavior
- 3 notifications from the same session → single overlay showing \`(3) project — needs approval\`
- The 2nd+ notification kills the previous overlay and reuses its slot position
- Session state stored in \`/tmp/peon-ping-popups/.session-<session_id>\`
- Auto-dismiss on events that mean \"user resumed\": UserPromptSubmit, Stop, PreToolUse, PostToolUse, PostToolUseFailure, Notification

## New config
- \`notification_stacking\` (bool, default \`true\`)

## Test plan
- [ ] Trigger 3 notifications from same session rapidly → verify single overlay with \`(3)\` prefix
- [ ] Accept a permission dialog → verify overlay dismisses automatically
- [ ] Set \`notification_stacking: false\` → verify each notification gets its own slot

🤖 Generated with [Claude Code](https://claude.com/claude-code)