### PR TITLE
feat: visible X close button on overlay notifications

### DIFF
--- a/peon.sh
+++ b/peon.sh
@@ -755,6 +755,7 @@ send_notification() {
       fi
       export PEON_MSG_SUBTITLE="${MSG_SUBTITLE:-}"
       export PEON_NOTIFY_TYPE="${NOTIFY_TYPE:-}"
+      export PEON_NOTIF_CLOSE_BUTTON="${NOTIF_CLOSE_BUTTON:-true}"
       bash "$notify_script" "$msg" "$title" "$color" "$icon_path"
       ;;
     devcontainer|ssh)
@@ -4330,6 +4331,7 @@ print('NOTIF_POSITION=' + q(cfg.get('notification_position', 'top-center')))
 print('NOTIF_DISMISS=' + q(str(cfg.get('notification_dismiss_seconds', 4))))
 print('NOTIF_ALL_SCREENS=' + ('true' if cfg.get('notification_all_screens', True) else 'false'))
 print('NOTIF_MARKER=' + q(cfg.get('notification_title_marker', '●')))
+print('NOTIF_CLOSE_BUTTON=' + ('true' if cfg.get('notification_close_button', True) else 'false'))
 print('USE_SOUND_EFFECTS_DEVICE=' + q(str(use_sound_effects_device).lower()))
 print('LINUX_AUDIO_PLAYER=' + q(linux_audio_player))
 print('PEON_SSH_AUDIO_MODE=' + q(str(cfg.get('ssh_audio_mode', 'relay'))))

--- a/scripts/mac-overlay-glass.js
+++ b/scripts/mac-overlay-glass.js
@@ -20,6 +20,7 @@ function run(argv) {
   var notifType   = argv[10] || ''; // Semantic type: complete|permission|limit|idle|question
   var allScreens  = argv[11] === 'true';
   var screenIdx   = (argv[12] !== undefined && argv[12] !== '') ? parseInt(argv[12], 10) : -1;
+  var showCloseButton = (argv[13] || 'true') === 'true';
 
   // ── Type text ──
   var typeText;
@@ -287,6 +288,29 @@ function run(argv) {
   btn.setTitle($('')); btn.setBordered(false); btn.setTransparent(true);
   btn.setTarget(dh); btn.setAction('handleDismiss');
   win.contentView.addSubview(btn);
+
+  // Visible X close button — top-right corner (configurable)
+  if (showCloseButton) {
+    var xSize = 22;
+    var xPosX = padX + contentW - xSize - 2;
+    var xPosY = padY + contentH - xSize - 2;
+    var xLabel = $.NSTextField.alloc.initWithFrame($.NSMakeRect(xPosX, xPosY, xSize, xSize));
+    xLabel.setStringValue($('\u00D7'));
+    xLabel.setBezeled(false);
+    xLabel.setDrawsBackground(false);
+    xLabel.setEditable(false);
+    xLabel.setSelectable(false);
+    xLabel.setTextColor($.NSColor.colorWithSRGBRedGreenBlueAlpha(accentR, accentG, accentB, 0.7));
+    xLabel.setAlignment($.NSTextAlignmentCenter);
+    xLabel.setFont($.NSFont.boldSystemFontOfSize(16));
+    win.contentView.addSubview(xLabel);
+    var xBtn = $.NSButton.alloc.initWithFrame($.NSMakeRect(xPosX - 4, xPosY - 4, xSize + 8, xSize + 8));
+    xBtn.setTitle($(''));
+    xBtn.setBordered(false);
+    xBtn.setTransparent(true);
+    xBtn.setTarget(dh); xBtn.setAction('handleDismiss');
+    win.contentView.addSubview(xBtn);
+  }
 
   // ══════════════════════════════════════════════
   // ANIMATION

--- a/scripts/mac-overlay-jarvis.js
+++ b/scripts/mac-overlay-jarvis.js
@@ -20,6 +20,7 @@ function run(argv) {
   var notifType   = argv[10] || ''; // Semantic type: complete|permission|limit|idle|question
   var allScreens  = argv[11] === 'true';
   var screenIdx   = (argv[12] !== undefined && argv[12] !== '') ? parseInt(argv[12], 10) : -1;
+  var showCloseButton = (argv[13] || 'true') === 'true';
 
   var accentR = 0.0, accentG = 0.75, accentB = 1.0;
   switch (color) {
@@ -531,6 +532,29 @@ function run(argv) {
   btn.setTitle($('')); btn.setBordered(false); btn.setTransparent(true);
   btn.setTarget(dh); btn.setAction('handleDismiss');
   win.contentView.addSubview(btn);
+
+  // Visible X close button — top-right corner of the window (configurable)
+  if (showCloseButton) {
+    var xSize = 22;
+    var xPosX = winSize - xSize - padding / 2;
+    var xPosY = winSize - xSize - padding / 2;
+    var xLabel = $.NSTextField.alloc.initWithFrame($.NSMakeRect(xPosX, xPosY, xSize, xSize));
+    xLabel.setStringValue($('\u00D7'));
+    xLabel.setBezeled(false);
+    xLabel.setDrawsBackground(false);
+    xLabel.setEditable(false);
+    xLabel.setSelectable(false);
+    xLabel.setTextColor($.NSColor.colorWithSRGBRedGreenBlueAlpha(accentR, accentG, accentB, 0.7));
+    xLabel.setAlignment($.NSTextAlignmentCenter);
+    xLabel.setFont($.NSFont.boldSystemFontOfSize(16));
+    win.contentView.addSubview(xLabel);
+    var xBtn = $.NSButton.alloc.initWithFrame($.NSMakeRect(xPosX - 4, xPosY - 4, xSize + 8, xSize + 8));
+    xBtn.setTitle($(''));
+    xBtn.setBordered(false);
+    xBtn.setTransparent(true);
+    xBtn.setTarget(dh); xBtn.setAction('handleDismiss');
+    win.contentView.addSubview(xBtn);
+  }
 
   // ══════════════════════════════════════════════
   // ANIMATION

--- a/scripts/mac-overlay-sakura.js
+++ b/scripts/mac-overlay-sakura.js
@@ -20,6 +20,7 @@ function run(argv) {
   var notifType   = argv[10] || ''; // Semantic type: complete|permission|limit|idle|question
   var allScreens  = argv[11] === 'true';
   var screenIdx   = (argv[12] !== undefined && argv[12] !== '') ? parseInt(argv[12], 10) : -1;
+  var showCloseButton = (argv[13] || 'true') === 'true';
 
   var PI = Math.PI, TAU = 2 * PI;
 
@@ -472,6 +473,29 @@ function run(argv) {
   btn.setTitle($('')); btn.setBordered(false); btn.setTransparent(true);
   btn.setTarget(dh); btn.setAction('handleDismiss');
   win.contentView.addSubview(btn);
+
+  // Visible X close button — top-right corner (configurable)
+  if (showCloseButton) {
+    var xSize = 22;
+    var xPosX = padX + contentW - xSize - 2;
+    var xPosY = padY + contentH - xSize - 2;
+    var xLabel = $.NSTextField.alloc.initWithFrame($.NSMakeRect(xPosX, xPosY, xSize, xSize));
+    xLabel.setStringValue($('\u00D7'));
+    xLabel.setBezeled(false);
+    xLabel.setDrawsBackground(false);
+    xLabel.setEditable(false);
+    xLabel.setSelectable(false);
+    xLabel.setTextColor($.NSColor.colorWithSRGBRedGreenBlueAlpha(accentR, accentG, accentB, 0.7));
+    xLabel.setAlignment($.NSTextAlignmentCenter);
+    xLabel.setFont($.NSFont.boldSystemFontOfSize(16));
+    win.contentView.addSubview(xLabel);
+    var xBtn = $.NSButton.alloc.initWithFrame($.NSMakeRect(xPosX - 4, xPosY - 4, xSize + 8, xSize + 8));
+    xBtn.setTitle($(''));
+    xBtn.setBordered(false);
+    xBtn.setTransparent(true);
+    xBtn.setTarget(dh); xBtn.setAction('handleDismiss');
+    win.contentView.addSubview(xBtn);
+  }
 
   // ══════════════════════════════════════════════
   // ANIMATION

--- a/scripts/notify.sh
+++ b/scripts/notify.sh
@@ -212,17 +212,18 @@ case "$PEON_PLATFORM" in
         local notif_position="${PEON_NOTIF_POSITION:-top-center}"
         local notify_type="${PEON_NOTIFY_TYPE:-}"
         local all_screens="${PEON_NOTIF_ALL_SCREENS:-true}"
-        # argv[5]=bundle_id, argv[6]=ide_pid, argv[7]=session_tty, argv[8]=subtitle, argv[9]=position, argv[10]=notify_type, argv[11]=all_screens, argv[12]=screen_index
+        local close_button="${PEON_NOTIF_CLOSE_BUTTON:-true}"
+        # argv[5]=bundle_id, argv[6]=ide_pid, argv[7]=session_tty, argv[8]=subtitle, argv[9]=position, argv[10]=notify_type, argv[11]=all_screens, argv[12]=screen_index, argv[13]=close_button
         local _overlay_pids=""
         if [ "$all_screens" = "true" ]; then
           local screen_count
           screen_count=$(osascript -l JavaScript -e 'ObjC.import("Cocoa"); $.NSScreen.screens.count' 2>/dev/null || echo 1)
           for _si in $(seq 0 $((screen_count - 1))); do
-            osascript -l JavaScript "$overlay_script" "$msg" "$color" "$local_icon_arg" "$slot" "$dismiss_secs" "$bundle_id" "$ide_pid" "$session_tty" "$subtitle" "$notif_position" "$notify_type" "$all_screens" "$_si" >/dev/null 2>&1 &
+            osascript -l JavaScript "$overlay_script" "$msg" "$color" "$local_icon_arg" "$slot" "$dismiss_secs" "$bundle_id" "$ide_pid" "$session_tty" "$subtitle" "$notif_position" "$notify_type" "$all_screens" "$_si" "$close_button" >/dev/null 2>&1 &
             _overlay_pids="$_overlay_pids $!"
           done
         else
-          osascript -l JavaScript "$overlay_script" "$msg" "$color" "$local_icon_arg" "$slot" "$dismiss_secs" "$bundle_id" "$ide_pid" "$session_tty" "$subtitle" "$notif_position" "$notify_type" "$all_screens" >/dev/null 2>&1 &
+          osascript -l JavaScript "$overlay_script" "$msg" "$color" "$local_icon_arg" "$slot" "$dismiss_secs" "$bundle_id" "$ide_pid" "$session_tty" "$subtitle" "$notif_position" "$notify_type" "$all_screens" "" "$close_button" >/dev/null 2>&1 &
           _overlay_pids="$!"
         fi
         # Shell-level watchdog: kill if JXA terminate timer doesn't fire (macOS regression)


### PR DESCRIPTION
## Summary
Adds a discoverable \`×\` button in the top-right corner of overlay notifications (glass, sakura, jarvis themes). Helps users who don't realize the whole overlay is clickable to dismiss.

## New config
- \`notification_close_button\` (bool, default \`true\`)

## Test plan
- [ ] Verify X appears on each theme
- [ ] Click X → verify dismiss
- [ ] Set \`notification_close_button: false\` → verify X is hidden but overlay still dismissible via body click

🤖 Generated with [Claude Code](https://claude.com/claude-code)