### PR TITLE
feat: add `peon setup` interactive wizard

### DIFF
--- a/peon.sh
+++ b/peon.sh
@@ -2839,6 +2839,151 @@ if changed:
       curl -fsSL https://raw.githubusercontent.com/PeonPing/peon-ping/main/install.sh | bash
     fi
     exit $? ;;
+  setup)
+    echo ""
+    echo "  ╔══════════════════════════════════════╗"
+    echo "  ║       peon-ping  setup wizard        ║"
+    echo "  ╚══════════════════════════════════════╝"
+    echo ""
+    python3 -c "
+import json, sys, os
+
+config_path = os.environ.get('PEON_ENV_CONFIG', '')
+try:
+    cfg = json.load(open(config_path))
+except Exception:
+    cfg = {}
+
+def ask(prompt, options, current):
+    for i, (key, label) in enumerate(options):
+        marker = ' \u2190' if key == current else ''
+        print(f'    {i+1}) {label}{marker}')
+    while True:
+        try:
+            choice = input(f'  > {prompt} [{current}]: ').strip()
+        except (EOFError, KeyboardInterrupt):
+            print(); sys.exit(0)
+        if not choice:
+            return current
+        try:
+            idx = int(choice) - 1
+            if 0 <= idx < len(options):
+                return options[idx][0]
+        except ValueError:
+            for key, label in options:
+                if choice.lower() in (key, label.lower()):
+                    return key
+        print('    Invalid choice, try again.')
+
+def ask_bool(prompt, current):
+    label = 'on' if current else 'off'
+    while True:
+        try:
+            choice = input(f'  > {prompt} [on/off] ({label}): ').strip().lower()
+        except (EOFError, KeyboardInterrupt):
+            print(); sys.exit(0)
+        if not choice:
+            return current
+        if choice in ('on', 'true', 'yes', 'y', '1'):
+            return True
+        if choice in ('off', 'false', 'no', 'n', '0'):
+            return False
+        print('    on or off?')
+
+def ask_number(prompt, current, min_val=0, max_val=100):
+    while True:
+        try:
+            choice = input(f'  > {prompt} ({current}): ').strip()
+        except (EOFError, KeyboardInterrupt):
+            print(); sys.exit(0)
+        if not choice:
+            return current
+        try:
+            val = float(choice)
+            if min_val <= val <= max_val:
+                return val if val != int(val) else int(val)
+            print(f'    Must be between {min_val} and {max_val}.')
+        except ValueError:
+            print('    Enter a number.')
+
+print('  \u2500\u2500 Volume \u2500\u2500')
+cfg['volume'] = ask_number('Volume (0.0 - 1.0)', cfg.get('volume', 0.5), 0, 1)
+print()
+
+print('  \u2500\u2500 Sound categories \u2500\u2500')
+cats = cfg.get('categories', {})
+cat_list = [
+    ('session.start', 'Session start'),
+    ('task.acknowledge', 'Task acknowledge'),
+    ('task.complete', 'Task complete'),
+    ('task.error', 'Task error'),
+    ('input.required', 'Input required (permissions, questions)'),
+    ('resource.limit', 'Resource limit (context compaction)'),
+    ('user.spam', 'User spam (rapid prompts)'),
+]
+defaults_off = {'task.acknowledge'}
+for key, label in cat_list:
+    default = False if key in defaults_off else True
+    current = cats.get(key, default)
+    cats[key] = ask_bool(f'  {label}', current)
+cfg['categories'] = cats
+print()
+
+print('  \u2500\u2500 Notifications \u2500\u2500')
+cfg['desktop_notifications'] = ask_bool('Desktop notifications', cfg.get('desktop_notifications', True))
+
+if cfg['desktop_notifications']:
+    themes = [
+        ('neon', 'Neon (cyberpunk)'),
+        ('glass', 'Glass (translucent)'),
+        ('sakura', 'Sakura (cherry blossom)'),
+        ('jarvis', 'Jarvis (iron man)'),
+    ]
+    print()
+    print('  Overlay theme:')
+    cfg['overlay_theme'] = ask('Theme', themes, cfg.get('overlay_theme', 'neon'))
+
+    positions = [
+        ('top-center', 'Top center'),
+        ('top-right', 'Top right'),
+        ('top-left', 'Top left'),
+        ('bottom-center', 'Bottom center'),
+        ('bottom-right', 'Bottom right'),
+        ('bottom-left', 'Bottom left'),
+    ]
+    print()
+    print('  Notification position:')
+    cfg['notification_position'] = ask('Position', positions, cfg.get('notification_position', 'top-center'))
+
+    print()
+    dismiss_opts = [
+        (0, 'Persistent (click to dismiss)'),
+        (3, '3 seconds'),
+        (4, '4 seconds'),
+        (5, '5 seconds'),
+        (8, '8 seconds'),
+    ]
+    print('  Auto-dismiss:')
+    cfg['notification_dismiss_seconds'] = ask('Dismiss time', dismiss_opts, cfg.get('notification_dismiss_seconds', 4))
+
+print()
+json.dump(cfg, open(config_path, 'w'), indent=2)
+print('  \u2713 Configuration saved!')
+print()
+print('  \u2500\u2500 Summary \u2500\u2500')
+print(f'    Volume:        {cfg[\"volume\"]}')
+dn = 'on' if cfg.get('desktop_notifications', True) else 'off'
+print(f'    Notifications: {dn}')
+if cfg.get('desktop_notifications', True):
+    print(f'    Theme:         {cfg.get(\"overlay_theme\", \"neon\")}')
+    print(f'    Position:      {cfg.get(\"notification_position\", \"top-center\")}')
+    d = cfg.get('notification_dismiss_seconds', 4)
+    print(f'    Dismiss:       {\"persistent\" if d == 0 else str(d) + \"s\"}')
+cats_on = [k for k, v in cfg.get('categories', {}).items() if v]
+print(f'    Categories:    {\", \".join(cats_on)}')
+print()
+"
+    sync_adapter_configs; exit 0 ;;
   help|--help|-h)
     cat <<'HELPEOF'
 Usage: peon <command>
@@ -2876,6 +3021,7 @@ Commands:
   logs --session ID    Filter today's log by session ID
   logs --session ID --all  Search across all log files for session ID
   logs --clear         Delete all log files (with confirmation)
+  setup                Interactive setup wizard
   update               Update peon-ping and refresh all sound packs
   help                 Show this help
 


### PR DESCRIPTION
## Summary
New \`peon setup\` command that walks users through the most common configuration options interactively: volume, sound categories, desktop notifications, overlay theme, position, and auto-dismiss behavior.

## Why
First-time setup currently requires reading docs to discover config keys. This wizard lowers the barrier and surfaces the most-used options in one place.

## Demo
\`\`\`
  ╔══════════════════════════════════════╗
  ║       peon-ping  setup wizard        ║
  ╚══════════════════════════════════════╝

  ── Volume ──
  > Volume (0.0 - 1.0) (0.5):

  ── Sound categories ──
  >   Session start [on/off] (on):
  ...
\`\`\`

## Test plan
- [ ] Run \`peon setup\` → verify all prompts work
- [ ] Press Enter at each prompt → verify defaults are preserved
- [ ] Verify config.json is updated correctly
- [ ] Verify summary at the end reflects the saved values

🤖 Generated with [Claude Code](https://claude.com/claude-code)