### PR TITLE
feat: add --install flag to packs rotation add

### DIFF
--- a/completions.bash
+++ b/completions.bash
@@ -26,6 +26,8 @@ _peon_completions() {
             names=$(find "$packs_dir" -maxdepth 2 \( -name manifest.json -o -name openpeon.json \) -exec dirname {} \; 2>/dev/null | xargs -I{} basename {} | sort)
             COMPREPLY=( $(compgen -W "$names" -- "$cur") )
           fi
+        elif [ "$cword" -eq 5 ] && [ "${words[2]}" = "rotation" ] && [ "${words[3]}" = "add" ]; then
+          COMPREPLY=( $(compgen -W "--install" -- "$cur") )
         elif [ "$cword" -eq 3 ] && [ "$prev" = "install" ]; then
           COMPREPLY=( $(compgen -W "--all --lang" -- "$cur") )
         elif [ "$cword" -eq 4 ] && [ "${words[2]}" = "install" ]; then

--- a/completions.fish
+++ b/completions.fish
@@ -60,6 +60,13 @@ complete -c peon -n "__peon_packs_subcommand rotation" -a add -d "Add pack(s) to
 complete -c peon -n "__peon_packs_subcommand rotation" -a remove -d "Remove pack(s) from rotation"
 complete -c peon -n "__peon_packs_subcommand rotation" -a clear -d "Clear all packs from rotation"
 
+# packs rotation add --install flag
+function __peon_rotation_add
+  set -l cmd (commandline -opc)
+  test (count $cmd) -ge 4; and test $cmd[2] = packs; and test $cmd[3] = rotation; and test $cmd[4] = add
+end
+complete -c peon -n __peon_rotation_add -a "--install" -d "Install from registry if needed"
+
 # packs install options
 complete -c peon -n "__peon_packs_subcommand install" -a "--all" -d "Install all packs from registry"
 complete -c peon -n "__peon_packs_subcommand install" -a "--lang" -d "Filter packs by language (e.g. --lang=en,fr)"

--- a/peon.sh
+++ b/peon.sh
@@ -2427,11 +2427,24 @@ print(f'Use peon packs use {pack_name} to activate it')
         sync_adapter_configs; exit 0 ;;
       rotation)
         ROT_SUB="${3:-}"
-        ROT_ARG="${4:-}"
+        ROT_INSTALL=0
+        ROT_ARG=""
+        for arg in "${4:-}" "${5:-}"; do
+          case "$arg" in
+            --install) ROT_INSTALL=1 ;;
+            "") ;;
+            *) ROT_ARG="$arg" ;;
+          esac
+        done
         case "$ROT_SUB" in
           add)
             if [ -z "$ROT_ARG" ]; then
-              echo "Usage: peon packs rotation add <pack1,pack2,...>" >&2; exit 1
+              echo "Usage: peon packs rotation add <pack1,pack2,...> [--install]" >&2; exit 1
+            fi
+            # Download requested packs if --install
+            if [ "$ROT_INSTALL" -eq 1 ]; then
+              PACK_DL="$(resolve_pack_download)" || exit 1
+              bash "$PACK_DL" --dir="$PEON_DIR" --packs="$ROT_ARG" || exit 1
             fi
             ROT_ARG="$ROT_ARG" python3 -c "
 import json, os, sys
@@ -3276,6 +3289,7 @@ Pack management:
   packs remove --all      Remove all packs except the active one
   packs rotation list     Show current rotation list and mode
   packs rotation add <p>  Add pack(s) to rotation (comma-separated)
+  packs rotation add --install <p>  Add to rotation, installing from registry if needed
   packs rotation remove <p> Remove pack(s) from rotation
   packs rotation clear    Clear all packs from rotation
 

--- a/tests/peon.bats
+++ b/tests/peon.bats
@@ -1827,6 +1827,49 @@ JSON
   [[ "$output" == *"Usage"* ]]
 }
 
+# ============================================================
+# packs rotation add --install
+# ============================================================
+
+@test "packs rotation add --install downloads and adds absent pack" {
+  setup_pack_download_env
+  run bash "$PEON_SH" packs rotation add --install test_pack_a
+  [ "$status" -eq 0 ]
+  [ -d "$TEST_DIR/packs/test_pack_a" ]
+  [ -f "$TEST_DIR/packs/test_pack_a/openpeon.json" ]
+  [[ "$output" == *"Added test_pack_a to rotation"* ]]
+  rotation=$(/usr/bin/python3 -c "import json; print(json.load(open('$TEST_DIR/config.json')).get('pack_rotation', []))")
+  [[ "$rotation" == *"test_pack_a"* ]]
+}
+
+@test "packs rotation add <name> --install works (flag after name)" {
+  setup_pack_download_env
+  run bash "$PEON_SH" packs rotation add test_pack_a --install
+  [ "$status" -eq 0 ]
+  [ -d "$TEST_DIR/packs/test_pack_a" ]
+  [[ "$output" == *"Added test_pack_a to rotation"* ]]
+}
+
+@test "packs rotation add --install errors when pack-download.sh missing" {
+  # Don't call setup_pack_download_env — no scripts/ dir
+  run bash "$PEON_SH" packs rotation add --install test_pack_a
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"pack-download.sh not found"* ]]
+}
+
+@test "packs rotation add --install with comma-separated packs" {
+  setup_pack_download_env
+  run bash "$PEON_SH" packs rotation add --install test_pack_a,test_pack_b
+  [ "$status" -eq 0 ]
+  [ -d "$TEST_DIR/packs/test_pack_a" ]
+  [ -d "$TEST_DIR/packs/test_pack_b" ]
+  [[ "$output" == *"Added test_pack_a to rotation"* ]]
+  [[ "$output" == *"Added test_pack_b to rotation"* ]]
+  rotation=$(/usr/bin/python3 -c "import json; print(json.load(open('$TEST_DIR/config.json')).get('pack_rotation', []))")
+  [[ "$rotation" == *"test_pack_a"* ]]
+  [[ "$rotation" == *"test_pack_b"* ]]
+}
+
 @test "help shows packs rotation commands" {
   run bash "$PEON_SH" help
   [ "$status" -eq 0 ]


### PR DESCRIPTION
## Summary
- Adds `--install` flag to `peon packs rotation add` that downloads missing packs from the registry before adding them to rotation
- Mirrors the existing `peon packs use --install` behavior — same arg parsing pattern, same `resolve_pack_download` call
- Updates bash and fish completions to offer `--install` after pack name

## Test plan
- [x] All 4 new `rotation add --install` tests pass
- [x] Full suite (372 tests) — no regressions

Generated with [Claude Code](https://claude.com/claude-code)