### PR TITLE
Fix macOS notification regressions and land TTS architecture docs (relands #470)

### DIFF
--- a/docs/adr/ADR-001-tts-backend-architecture.md
+++ b/docs/adr/ADR-001-tts-backend-architecture.md
@@ -1,0 +1,265 @@
+# ADR-001: TTS Backend Architecture — Independent Scripts over Plugin Registry
+
+> **Status**: Accepted | **Date**: 2026-03-28 | **Deciders**: cameron
+
+## Context
+
+peon-ping is adding text-to-speech (TTS) as a new output modality alongside pre-recorded sound files (v2/m5, PRD-003). The hook pipeline currently plays audio through a single `play_sound()` function that uses a platform `case` switch — one monolithic function handling macOS (`afplay`), WSL2 (PowerShell `SoundPlayer`), Linux (six-backend priority chain), SSH/devcontainer (relay HTTP), and MSYS2 (player chain + PowerShell fallback). This pattern grew organically and works, but it concentrates all platform logic in ~110 lines of shell with no separation between "what to play" and "how to play it."
+
+TTS introduces a second axis of variation. Sound playback varies by **platform** (macOS vs. Windows vs. Linux). TTS varies by both **platform** (native engines differ per OS) and **engine** (native, ElevenLabs API, Piper local neural, future others). The roadmap explicitly plans three backend categories shipping at different times:
+
+- **Platform-native** (Phase 1): macOS `say`, Windows SAPI5, Linux `espeak-ng`/`piper`
+- **ElevenLabs** (future): Cloud API with audio caching, API key management, cost controls
+- **Piper** (future): Local neural TTS with model management, BYO binary
+
+These backends have fundamentally different operational characteristics. Native backends are synchronous CLI commands that speak directly to the audio device. ElevenLabs is an HTTP API that returns audio files requiring caching and playback. Piper is a local binary that writes WAV to stdout or file. A single abstraction that handles all three elegantly would need to bridge direct-to-device speech, cached file playback, and piped audio — three different I/O models.
+
+Meanwhile, the existing `win-play.ps1` establishes a precedent: platform-specific audio logic extracted into a standalone script, invoked via `Start-Process` as a fire-and-forget background process. The Windows adapter ecosystem (`.ps1` counterparts for every `.sh` adapter) shows the codebase already handles dual-platform scripts as a known pattern.
+
+The forces in tension:
+
+1. **Extensibility**: New TTS engines must be addable without modifying the core hook pipeline. The roadmap plans at least three backends, and community contributions could add more.
+2. **Simplicity**: peon-ping is a shell script, not a framework. Each layer of abstraction adds cognitive overhead for contributors and debugging surface area for users.
+3. **Operational diversity**: Backends differ in I/O model (direct speech vs. file output vs. HTTP), lifecycle (stateless vs. cached), and configuration (none vs. API keys vs. model paths).
+4. **Platform parity**: Both `peon.sh` (Unix) and `peon.ps1` (Windows) must implement the same TTS behavior, doubling the surface area of any abstraction layer.
+
+## Decision
+
+We will implement TTS backends as **independent, self-contained scripts** — one per backend per platform — invoked by the hook pipeline through a minimal calling convention rather than a formal plugin interface.
+
+Each backend is a script that accepts speech parameters as command-line arguments and handles its own audio output asynchronously. The hook pipeline's only responsibility is: resolve the speech text, select the backend based on config, and invoke the corresponding script as a background process. There is no backend registry, no discovery mechanism, no shared backend library, and no abstract interface definition.
+
+**Calling convention** (the entire "contract"):
+
+```
+# Unix (bash scripts) — text on stdin, options as arguments
+echo "<text>" | scripts/tts-native.sh  "<voice>" "<rate>" "<volume>"
+
+# Windows (PowerShell scripts) — text on stdin, options as named params
+"<text>" | scripts/tts-native.ps1 -voice "<voice>" -rate <rate> -vol <volume>
+```
+
+Speech text is passed on **stdin**, not as a CLI argument. Dynamic text from template interpolation (`{project}`, `{summary}`) can contain shell metacharacters, quotes, newlines, and other content that is unsafe to pass as positional arguments without careful escaping. Stdin avoids this class of problems entirely — the backend reads one line from stdin and speaks it, with no shell interpretation of the content.
+
+Each script:
+- Reads speech text from stdin (one line)
+- Handles its own platform detection internally (for native: macOS `say` vs. Linux `espeak-ng`/`piper`)
+- Manages its own dependencies (ElevenLabs: HTTP + caching; Piper: binary + model detection)
+- Exits cleanly on failure (no error propagation to hook — TTS failure is never a hook failure)
+- Runs as a background process via the same `nohup ... &` / `Start-Process -WindowStyle Hidden` pattern as `play_sound()`
+
+**Speech text resolution** happens in the hook pipeline's Python block (Unix) / PowerShell block (Windows) — centralized, before any backend is invoked:
+
+1. If the selected sound entry has `speech_text` and TTS is enabled → interpolate template variables
+2. Else if a notification template exists for this category → use rendered template text
+3. Else → use default template `"{project} — {status}"`
+4. If resolved text is empty after interpolation → skip TTS entirely
+
+**Pipeline integration** in `_run_sound_and_notify` (or equivalent):
+
+```
+# Pseudocode — actual implementation adapts to mode config
+if mode == "sound-then-speak":
+    play_sound(file, volume)        # existing, backgrounded
+    speak(text, voice, rate, vol)   # new, backgrounded after sound
+elif mode == "speak-only":
+    speak(text, voice, rate, vol)   # replaces sound
+elif mode == "speak-then-sound":
+    speak(text, voice, rate, vol)   # new, backgrounded
+    play_sound(file, volume)        # existing, after TTS
+```
+
+TTS gets its own PID tracking (`.tts.pid`) separate from `.sound.pid`, enabling independent kill-previous behavior and the sequencing modes.
+
+**File organization:**
+
+```
+scripts/
+  tts-native.sh       # macOS say / Linux espeak-ng|piper
+  tts-native.ps1      # Windows SAPI5
+  tts-elevenlabs.sh   # (future) ElevenLabs API
+  tts-elevenlabs.ps1  # (future) ElevenLabs API
+  tts-piper.sh        # (future) Piper standalone
+  tts-piper.ps1       # (future) Piper standalone
+  win-play.ps1        # (existing) Windows audio playback
+```
+
+## Rationale
+
+The current sound playback system is a cautionary example of what happens when platform variation accumulates in a single function. `play_sound()` started as a simple `afplay` call and grew to 110 lines spanning six platform paths with nested conditionals for relay modes, WSL format conversion, and player priority chains. It works, but it's the single hardest function to modify confidently — every platform path must be mentally held in context for any change.
+
+TTS would compound this problem because it adds engine variation on top of platform variation. An inline approach would mean the hook script grows a second 100+ line function with `case` branches for `native × {mac, linux, wsl, windows}`, `elevenlabs × {all platforms}`, and `piper × {all platforms}`. Each new backend multiplies the branch count.
+
+Independent scripts avoid this by giving each backend its own file with its own concerns. `tts-native.sh` can have a platform `case` for `say` vs. `espeak-ng` without carrying ElevenLabs caching logic. `tts-elevenlabs.sh` can manage its HTTP client and cache directory without knowing anything about SAPI5. The complexity of each backend is **contained** rather than **composed**.
+
+### Key Factors
+
+1. **Operational isolation prevents cascade failures.** A bug in ElevenLabs caching logic cannot affect native TTS. A SAPI5 PowerShell quirk cannot break `espeak-ng`. This matters in practice — peon-ping runs in hook context where any failure delays the user's IDE. Independent scripts fail independently, and the hook pipeline's error handling is trivially simple: if the background process exits non-zero, nothing happens (fire-and-forget).
+
+2. **The calling convention is the contract, and it's deliberately minimal.** Four arguments in, audio out. No interface file, no type system, no registration. This is a shell tool — the filesystem *is* the registry (`scripts/tts-*.sh` is the set of backends). A contributor adding a new backend writes one script, adds one `case` branch in the backend selector, and they're done. The barrier to contribution is "can you write a shell script that speaks text?" — not "can you navigate a plugin framework?"
+
+3. **Backend diversity is real and resists unification.** Native TTS speaks directly to the audio device (no file output). ElevenLabs returns MP3 bytes over HTTP that need caching and playback through the existing audio pipeline. Piper writes WAV to stdout. A unified interface that abstracts these I/O models would either be so generic it provides no value (just "make audio happen") or so specific it forces backends into unnatural patterns (e.g., requiring file output from `say`, which natively speaks to device). The independent script model lets each backend use its natural I/O pattern.
+
+4. **`win-play.ps1` already proves the pattern.** Windows audio playback was extracted into a standalone script precisely because it needed platform-specific complexity (MediaPlayer WPF dispatcher pumping, CLI player priority chains) that didn't belong inline. It works well — invoked via `Start-Process`, fire-and-forget, self-contained. TTS backends follow the same proven model.
+
+## Consequences
+
+### Positive
+
+- **Each backend is independently testable.** `tts-native.sh` can be tested by invoking it directly with known arguments — no hook pipeline setup required. BATS tests call the script, Pester tests call the `.ps1`. This matches the existing test pattern for `win-play.ps1`.
+
+- **New backends don't touch existing code.** Adding ElevenLabs means creating `tts-elevenlabs.sh` and adding a `case` branch in the backend selector — two changes, both additive. Zero risk to native TTS behavior.
+
+- **Debugging is straightforward.** `peon debug on` can log the exact command invoked (`[tts] backend=native cmd="scripts/tts-native.sh 'hello' 'Alex' '1.0' '0.5'" pid=48291`). Users can run the same command manually to reproduce issues. The `[tts]` log phase slots naturally into the existing structured logging format.
+
+- **Contributors face a minimal learning curve.** "Write a script that takes text/voice/rate/volume and speaks" is a self-contained task. No framework concepts to learn, no interfaces to implement, no registration to configure.
+
+### Negative
+
+- **Duplicated platform detection across backends.** `tts-native.sh` and a hypothetical `tts-festival.sh` would both need to detect macOS vs. Linux. This is a small amount of duplication (a `uname` check) and acceptable — the alternative (a shared platform library) adds a dependency chain to every backend script, creating the coupling we're trying to avoid.
+
+- **Each backend requires parallel bash and PowerShell implementations.** Three planned backends means six script files with mirrored logic. This is the same dual-platform cost every peon-ping feature pays (every `.sh` adapter has a `.ps1` counterpart), but it multiplies with the backend count. Acceptable because each script is self-contained and small (~50-100 lines), and the alternative — a unified cross-platform layer — would introduce a new dependency or abstraction that doesn't exist in the codebase today.
+
+- **No compile-time contract enforcement.** If a backend script ignores the volume argument or takes arguments in the wrong order, the only feedback is wrong behavior at runtime. For a shell-based CLI tool with 3-5 backends, this is manageable — backends are tested individually, and the argument list is documented in the script headers. A formal interface would only help if we had dozens of backends.
+
+- **Backend selection is a hardcoded switch, not dynamic discovery.** The hook pipeline has a `case` block mapping config values to script paths. Adding a backend requires editing this block. Automatic discovery (scanning `scripts/tts-*.sh`) would eliminate this, but introduces ordering ambiguity and makes the "which backend runs?" question harder to answer from reading the code. Explicit is better than implicit for a system with <10 backends.
+
+### Neutral
+
+- **Speech text resolution stays centralized in the hook pipeline.** The Python block (Unix) and PowerShell block (Windows) handle template interpolation, manifest `speech_text` lookup, and variable resolution. Backends receive already-resolved plain text. This means the resolution logic exists in two places (Python and PowerShell), but this is the same pattern as every other hook feature — the Windows port mirrors the Python logic.
+
+- **TTS PID tracking (`.tts.pid`) is separate from sound PID (`.sound.pid`).** This enables the three modes (`sound-then-speak`, `speak-only`, `speak-then-sound`) but means two PID files to manage. The kill-previous logic needs to respect both PIDs and the active mode. This is a small complexity increase with clear benefits for sequencing control.
+
+## Alternatives Considered
+
+### Alternative 1: Inline Platform Branching (Extend play_sound Pattern)
+
+**Description**: Add TTS as another `case` block in the main hook script, mirroring how `play_sound()` handles platform variation. A single `speak()` function contains all backend logic — native platform detection, ElevenLabs HTTP calls, Piper invocation — as branches in a nested `case` structure (outer: backend, inner: platform).
+
+**Pros**:
+- All TTS logic visible in one place — no script-hopping to understand the full flow
+- No process overhead — avoids the ~200ms PowerShell startup cost of a separate `Start-Process` on Windows (though this cost is already budgeted for `win-play.ps1` and fires in background)
+- Consistent with how `play_sound()` currently works — contributors familiar with the codebase already know the pattern
+
+**Cons**:
+- Compounds the monolith problem. `play_sound()` at 110 lines is already the hardest function to modify; adding a `speak()` of similar size with backend × platform branching doubles the cognitive load. Each new backend adds branches to both Unix and Windows code paths
+- Cross-backend contamination risk. A change to ElevenLabs caching could introduce a bug in native TTS if they share control flow or variables — even with careful scoping, inline proximity encourages shared state
+- Testing requires the full hook pipeline. You can't invoke "just the native backend" without setting up mock config, event JSON, and platform detection — all the surrounding context that the inline function depends on
+
+**Why not chosen**: `play_sound()` demonstrates the long-term trajectory of this pattern — organic growth into a function that's correct but increasingly difficult to modify with confidence. TTS would follow the same path with the added dimension of backend variation. The operational diversity of backends (direct speech vs. HTTP + cache vs. local binary) makes inline branches increasingly awkward as each backend's unique concerns bleed into shared scope.
+
+### Alternative 2: Plugin Registry with Auto-Discovery
+
+**Description**: Create a formal backend plugin system. Backend scripts live in a `tts-backends/` directory and self-register by implementing a standard interface. The hook pipeline scans the directory, loads available backends, and dispatches to the selected one. Each backend exports metadata (name, platform support, capabilities) that the registry uses for `auto` resolution and the `peon tts voices` enumeration.
+
+A backend script would follow a defined structure:
+
+```bash
+# tts-backends/native.sh
+BACKEND_NAME="native"
+BACKEND_PLATFORMS="mac linux wsl"
+
+backend_available() { ... }  # returns 0 if this backend can run
+backend_voices() { ... }     # lists available voices
+backend_speak() { ... }      # speaks text with given parameters
+```
+
+**Pros**:
+- Maximum extensibility — community backends drop into a directory and "just work" without any core code changes
+- Formalized contract prevents argument-order mistakes and documents the expected interface
+- Auto-discovery enables features like `peon tts backends` listing all available engines with their capabilities
+
+**Cons**:
+- Overengineered for the expected scale. The roadmap plans 3-4 backends (native, ElevenLabs, Piper, maybe OpenAI). A discovery framework serves a plugin ecosystem of dozens — we're building for 3
+- Introduces framework concepts foreign to the codebase. peon-ping is a shell script that reads JSON and plays sounds. Plugin registries, self-registration, and capability metadata are patterns from application frameworks, not CLI tools. Contributors now need to understand the plugin model before adding a backend
+- Discovery ordering creates implicit behavior. If multiple backends claim to support a platform, which wins? Priority ordering, explicit preference configuration, and conflict resolution add complexity that explicit backend selection avoids entirely
+- Shell-based plugin systems are fragile. Sourcing arbitrary scripts (`source tts-backends/*.sh`) in the hook's execution context risks variable collisions, function name conflicts, and error propagation. Subprocess isolation (what the independent scripts approach uses naturally) must be explicitly engineered
+
+**Why not chosen**: The plugin registry solves a problem we don't have — managing a large, open-ended set of backends contributed by a distributed community. With 3-4 planned backends, each shipping as a deliberate feature with its own roadmap entry, the editorial overhead of "add a case branch" is negligible. The registry's value proposition — "zero-touch extensibility" — comes at the cost of framework complexity that makes the first three backends harder to build, debug, and maintain. If peon-ping ever reaches 10+ TTS backends (unlikely given the TTS market), a registry can be introduced then with the independent scripts as migration targets.
+
+### Alternative 3: Unified Audio Pipeline (TTS as a Sound Source)
+
+**Description**: Instead of TTS being a separate pipeline, treat synthesized speech as another sound source feeding into the existing `play_sound()` function. TTS backends produce audio files (WAV/MP3) written to a temp directory, and `play_sound()` plays them like any pack sound. This unifies PID tracking, volume control, kill-previous behavior, and platform playback under a single code path.
+
+**Pros**:
+- Maximal code reuse — every platform's audio playback is already solved in `play_sound()`. TTS backends only need to produce files, not handle audio output
+- Single PID tracking (`.sound.pid`) — no dual-PID complexity, modes reduce to "play this file, then play that file"
+- ElevenLabs and Piper naturally produce files (MP3/WAV), so this model fits them natively
+
+**Cons**:
+- Forces native TTS through an unnatural path. macOS `say` and `espeak-ng` speak directly to the audio device — requiring them to write files first adds latency (synthesis + write + read + play vs. just synthesis + speak) and temp file management (creation, cleanup, disk usage). A 2-second phrase would need to fully synthesize before any audio plays, rather than streaming word-by-word as `say` does natively
+- Eliminates streaming playback. `say` begins speaking immediately as it processes text; file-based playback requires full synthesis first. For longer phrases (trainer progress with multiple exercises), the difference is perceptible — 1-2 seconds of silence before speech begins
+- Conflates two concerns in `play_sound()`. Sound files are static assets selected from a manifest. TTS output is dynamically generated text. Adding "is this a real file or a temp file that needs cleanup?" logic to `play_sound()` spreads TTS concerns into the sound pipeline
+- The sequencing modes (`sound-then-speak`, `speak-then-sound`) become harder — they're now "play file A, then play file B" which requires chaining `play_sound()` calls with wait-for-completion logic, adding the same PID coordination complexity we were trying to avoid
+
+**Why not chosen**: The appeal of this approach — reusing `play_sound()` — breaks down precisely for the most important backend (platform-native). Native TTS's strength is low-latency direct-to-device speech, and forcing it through file intermediation sacrifices that advantage. The approach optimizes for API backends (ElevenLabs, which naturally produces files) at the cost of the baseline experience. Since native TTS is the first and default backend — the one every user encounters — penalizing it to benefit future backends is the wrong tradeoff ordering. API backends that produce files can simply call `play_sound()` internally if they want to reuse it, without forcing native backends into the same path.
+
+### Alternative 4: Python Cross-Platform TTS (Single Script per Backend)
+
+**Description**: Leverage the Python runtime already present in the hook pipeline (`peon.sh` embeds a Python block for config loading, event parsing, and sound selection). Each TTS backend becomes a single `.py` script that handles all platforms internally — `tts-native.py` would call `say` via subprocess on macOS, `espeak-ng` on Linux, and either `pyttsx3` or `win32com.client` for SAPI5 on Windows. This halves the file count by eliminating the `.sh` / `.ps1` duplication.
+
+**Pros**:
+- One script per backend instead of two — three backends means three files, not six
+- Eliminates the "duplicated platform detection across backends" negative consequence entirely
+- Python's `subprocess` module provides consistent cross-platform process invocation
+- The hook pipeline already depends on Python (Unix side), so no new runtime dependency there
+
+**Cons**:
+- `peon.ps1` (native Windows) deliberately avoids Python — it's a pure PowerShell implementation with no Python dependency. Introducing Python TTS scripts would break this architectural boundary, requiring Python on Windows or maintaining a PowerShell fallback path anyway
+- `pyttsx3` (the main cross-platform TTS library) is a pip dependency peon-ping has never required. The existing Python usage is stdlib-only. Adding pip dependencies changes the install story and creates a new failure mode
+- Without `pyttsx3`, the Python scripts would just be subprocess wrappers around `say`/`espeak-ng`/SAPI5 — the same platform branching as shell scripts but in a different language, adding Python startup overhead (~100ms) without reducing complexity
+- Python is not available in all environments where peon-ping runs (minimal containers, some CI images, MSYS2 without Python installed)
+
+**Why not chosen**: The value proposition — halving file count — only materializes if a cross-platform Python TTS library is used, which introduces peon-ping's first pip dependency. Without it, Python scripts are just shell scripts in a different language with worse startup performance. More fundamentally, `peon.ps1` exists specifically to avoid a Python dependency on Windows, and that boundary is load-bearing — Windows users install peon-ping via `install.ps1` with no Python requirement. Forcing Python into the Windows path to reduce file count trades a real user-facing simplicity (no Python needed) for a developer-facing convenience (fewer files).
+
+## Implementation Notes
+
+**Phase 1 ships one backend script (native) with the integration layer:**
+
+1. Add `tts` section to `config.json` defaults — `enabled: false`, `backend: "auto"`, `voice: "default"`, `rate: 1.0`, `volume: 0.5`, `mode: "sound-then-speak"`
+2. Create `scripts/tts-native.sh` — platform detection (`uname`), macOS `say`, Linux `espeak-ng`/`piper` priority chain, async via `nohup ... &`
+3. Create `scripts/tts-native.ps1` — Windows TTS via `System.Speech.Synthesis.SpeechSynthesizer` (SAPI5), async via the script being invoked through `Start-Process -WindowStyle Hidden` (same pattern as `win-play.ps1`). Note: Microsoft is steering toward `Windows.Media.SpeechSynthesis` (WinRT), which offers neural voices on Windows 11 with notably higher quality. Phase 1 uses SAPI5 for broader compatibility (Windows 10 support, simpler PowerShell integration), but the independent script architecture means `tts-native.ps1` can adopt WinRT internally without affecting any other backend or the hook pipeline
+4. Add speech text resolution to the Python block in `peon.sh` — template interpolation using existing `_tpl_vars` machinery, outputting `TTS_TEXT` variable
+5. Add TTS invocation to `_run_sound_and_notify` — mode-aware sequencing, `.tts.pid` tracking, safety timeout
+6. Add `peon tts` CLI subcommands — `on`/`off`/`status`/`test`/`voices`/`voice`/`backend`
+7. Port all of the above to `peon.ps1` (PowerShell)
+8. `peon update` backfills `tts` config section for existing installs
+
+**Future backends add files, not framework:**
+
+- `scripts/tts-elevenlabs.sh`: HTTP client (`curl`), text-hash caching to `$PEON_DIR/cache/tts/`, plays cached MP3 via `play_sound()` internally
+- `scripts/tts-piper.sh`: Detects `piper` binary and model, pipes text to `piper --output-raw | aplay` (or writes WAV + `play_sound()`)
+- Each backend adds one `case` branch to the backend selector in `peon.sh` and `peon.ps1`
+
+**The `auto` backend resolution** for Phase 1 is trivially `native` — it's the only backend. When ElevenLabs ships, `auto` can prefer it when an API key is configured, falling back to native. This logic lives in the hook pipeline's backend selector, not in any backend script.
+
+## Validation
+
+- **Backend isolation holds**: Each backend can be invoked directly from the command line (`echo "test" | bash scripts/tts-native.sh "Alex" "1.0" "0.5"`) and produces speech without any hook pipeline context. BATS/Pester tests validate this independently.
+- **Hook latency unchanged**: Before/after timing of hook return shows no measurable increase. The structured logging `[exit] duration_ms=N` metric (from v2/m4) provides automated measurement. Target: <50ms delta.
+- **Adding ElevenLabs backend requires no changes to tts-native scripts**: When `tts-elevenlabs.sh` ships, the diff touches zero lines in `tts-native.sh` or `tts-native.ps1`. Only the backend selector in `peon.sh`/`peon.ps1` and config schema gain additions.
+- **Failure isolation**: Kill `espeak-ng` mid-utterance, corrupt the ElevenLabs cache, remove Piper's model file — each failure is contained to its backend with no impact on sound playback or other backends. The hook exits 0 regardless.
+- **Contributor test**: The calling convention and one example script (`tts-native.sh`) are sufficient documentation for a new backend — implementing a backend requires no reading of `peon.sh` internals. If a contributor must understand the hook pipeline to write a backend, the contract has grown too complex.
+
+## Related Decisions
+
+- **Async Audio and Safe State on Windows**: The `Start-Process -WindowStyle Hidden` pattern, atomic state writes, and 8-second safety timeout established during the Windows native port. TTS backends inherit this pattern. (Implementation reference: `scripts/win-play.ps1` and `peon.ps1` async invocation.)
+- **Structured Hook Logging** (v2/m4): The `[phase] key=value` log format defined for hook observability. TTS adds a `[tts]` phase following this convention.
+
+## References
+
+- [PRD-003: TTS Spoken Feedback](../prds/PRD-003-tts-spoken-feedback.md) — product requirements driving this decision
+- v2/m5 "The peon speaks to you" — parent roadmap milestone defining feature sequencing and success criteria
+- [macOS `say` man page](x-man-page://say) — native macOS TTS capabilities
+- [System.Speech.Synthesis (SAPI5)](https://learn.microsoft.com/en-us/dotnet/api/system.speech.synthesis) — Windows native TTS API
+- [espeak-ng](https://github.com/espeak-ng/espeak-ng) — open-source speech synthesizer for Linux
+- [Piper](https://github.com/rhasspy/piper) — fast local neural TTS for Linux
+
+---
+
+## Revision History
+
+| Date | Status | Notes |
+|------|--------|-------|
+| 2026-03-28 | Proposed | Initial proposal |
+| 2026-03-28 | Accepted | Adversarial review: switched calling convention from CLI args to stdin for safe text transport; added platform parity cost as negative consequence; added Python cross-platform alternative (Alt 4); noted WinRT as SAPI5 successor; fixed dead design doc references |

--- a/docs/designs/tts-integration.md
+++ b/docs/designs/tts-integration.md
@@ -1,0 +1,769 @@
+# Design Doc: TTS Integration Layer and Backend Contract
+
+> **ADR**: [ADR-001](../adr/ADR-001-tts-backend-architecture.md) | **Date**: 2026-03-28 | **Author**: cameron
+
+## Overview
+
+This document designs the TTS integration layer for peon-ping — the foundation that every TTS
+feature builds on. ADR-001 decided that TTS backends ship as independent, self-contained scripts
+invoked through a minimal calling convention (text on stdin, voice/rate/volume as arguments). This
+design doc works out the specifics: where the hook pipeline gains TTS awareness, how speech text is
+resolved from multiple sources, how mode sequencing coordinates sound and speech, how backend
+resolution selects the right script, and how the config schema and state management extend to
+support TTS.
+
+The integration layer is deliberately inert on its own — it resolves text and invokes a backend
+script, but without a backend installed (tts-native ships separately), `peon tts on` detects no
+available engine and tells the user. This separation means the integration layer can be tested
+against mock backends without platform-specific TTS dependencies.
+
+## Requirements
+
+The implementation is complete when:
+
+1. The hook pipeline in `peon.sh` resolves speech text from the configured source chain and invokes
+   the selected TTS backend as an async background process after (or instead of, per mode) sound
+   playback — without increasing hook return latency.
+2. The hook pipeline in `install.ps1` (embedded `peon.ps1` engine) provides identical TTS behavior
+   to the Unix implementation — same config keys, same text resolution, same mode sequencing, same
+   async contract.
+3. A TTS backend script receives text on stdin with voice, rate, and volume as arguments — nothing
+   else. No hook context, no config access, no state file. The contract is the calling convention
+   and nothing more.
+4. `config.json` gains a `tts` section with `enabled`, `backend`, `voice`, `rate`, `volume`, and
+   `mode` fields, and `peon update` backfills this section for existing installs without overwriting
+   user-modified values.
+5. Backend resolution maps `config.tts.backend` to a script path via an explicit `case`/`switch`
+   block. `"auto"` resolves to the best available backend by probing for installed scripts in
+   priority order. When no backend is available, TTS is silently skipped during hooks and explicitly
+   reported during `peon tts on`.
+6. Speech text resolution follows a defined chain: manifest `speech_text` field (when present) →
+   notification template for the active category → default template `"{project} — {status}"`. Empty
+   resolved text skips TTS entirely.
+7. TTS PID tracking (`.tts.pid`) is independent from sound PID (`.sound.pid`), enabling the three
+   sequencing modes and independent kill-previous behavior.
+8. All existing suppression rules (`headphones_only`, `meeting_detect`, `suppress_sound_when_tab_focused`,
+   pause/mute state) apply to TTS identically to how they apply to sound playback.
+
+## Current State
+
+### Hook pipeline (Unix — `peon.sh`)
+
+The embedded Python block (lines ~3329–3778) handles event routing, category mapping, sound
+selection, notification template resolution, and trainer reminder logic. It outputs shell variables
+via `print()` statements:
+
+```
+SOUND_FILE=/path/to/sound.mp3
+VOLUME=0.5
+NOTIFY=true
+MSG="api-server — Task complete"
+TRAINER_SOUND=/path/to/trainer.mp3
+TRAINER_MSG="Time for reps!"
+```
+
+Shell code `eval`s these variables, then `_run_sound_and_notify()` (line 3927) handles playback:
+
+1. Check suppression rules (headphones, meeting, tab focus)
+2. `play_sound "$SOUND_FILE" "$VOLUME"` — platform-dispatched, async via `nohup ... &`
+3. `send_notification` — desktop notification with template-rendered text
+4. `send_mobile_notification` — push notification if configured
+
+After `_run_sound_and_notify` returns (backgrounded via `& disown` in production), trainer reminder
+logic (line 3968) waits for the main sound PID to finish, pauses 0.5s, then plays the trainer
+sound and sends a trainer notification.
+
+### Hook pipeline (Windows — embedded in `install.ps1`)
+
+The `peon.ps1` engine (lines ~1400–1900 of `install.ps1`) mirrors the Python logic in pure
+PowerShell. Sound selection, anti-repeat, icon resolution, and notification template resolution
+all follow the same patterns. Audio delegates to `scripts/win-play.ps1` via
+`Start-Process -WindowStyle Hidden`. Trainer reminder logic follows the same wait-then-play
+pattern.
+
+### Sound PID tracking
+
+- `save_sound_pid()` writes PID to `$PEON_DIR/.sound.pid`
+- `kill_previous_sound()` reads and kills the previous PID before playing a new sound
+- Trainer reminder waits for `.sound.pid` to finish before playing its sound
+
+### Notification template resolution
+
+The Python block (lines 3715–3740) resolves templates using `_tpl_vars`:
+
+```python
+_tpl_vars = defaultdict(str, {
+    'project': project,
+    'summary': event_data.get('transcript_summary', '').strip()[:120],
+    'tool_name': event_data.get('tool_name', ''),
+    'status': status,
+    'event': event,
+})
+msg = _tpl.format_map(_tpl_vars)
+```
+
+Template key mapping: `task.complete` → `stop`, `task.error` → `error`,
+`PermissionRequest` → `permission`, idle/question from notification subtypes.
+
+### Config structure
+
+`config.json` has 44 keys. The `trainer` section (nested object) establishes the pattern for
+feature namespaces. No `tts` section exists today.
+
+### State management
+
+`.state.json` uses atomic writes (temp file + `os.replace()` on Unix, `Write-StateAtomic` on
+Windows). Stores `last_played`, `session_packs`, `prompt_timestamps`, `trainer`, etc. Read with
+retry logic (3 attempts with backoff).
+
+## Target State
+
+After this implementation, the hook pipeline gains a TTS phase between sound playback and
+notification dispatch. The flow becomes:
+
+```
+Event JSON → Python/PS routing → Category → Sound selection
+                                          → Speech text resolution (NEW)
+                                          ↓
+                              _run_sound_and_notify()
+                                  ├── play_sound()         [existing]
+                                  ├── speak()              [NEW]
+                                  ├── send_notification()  [existing]
+                                  └── send_mobile_notif()  [existing]
+                                          ↓
+                              Trainer reminder (if applicable)
+                                  ├── wait for .sound.pid  [existing]
+                                  ├── wait for .tts.pid    [NEW — avoids overlap]
+                                  ├── play trainer sound   [existing]
+                                  ├── speak trainer text   [NEW]
+                                  └── send trainer notif   [existing]
+```
+
+### Architecture
+
+```
+                          ┌──────────────────────┐
+                          │   Hook Pipeline       │
+                          │  (peon.sh / peon.ps1) │
+                          └──────┬───────────────┘
+                                 │
+                    ┌────────────┼────────────────┐
+                    │            │                 │
+            ┌───────▼──┐  ┌─────▼─────┐   ┌──────▼──────┐
+            │play_sound│  │  speak()  │   │send_notif() │
+            │ .sound.pid│  │ .tts.pid │   │             │
+            └──────────┘  └─────┬─────┘   └─────────────┘
+                                │
+                    ┌───────────┼───────────────┐
+                    │           │               │
+              ┌─────▼────┐ ┌───▼─────┐  ┌──────▼──────┐
+              │tts-native│ │tts-11lab│  │  tts-piper  │
+              │   .sh    │ │   .sh   │  │    .sh      │
+              │   .ps1   │ │   .ps1  │  │    .ps1     │
+              └──────────┘ └─────────┘  └─────────────┘
+```
+
+The `speak()` function is the integration layer's single responsibility: resolve the backend,
+construct the invocation, and fire it as a background process. Each backend script is a black box
+that reads text from stdin and produces audio.
+
+### Mode sequencing in `_run_sound_and_notify`
+
+```
+sound-then-speak (default):
+  play_sound() → speak()       → notifications
+
+speak-only:
+  [skip sound] → speak()       → notifications
+
+speak-then-sound:
+  speak()      → play_sound()  → notifications
+```
+
+In `sound-then-speak` and `speak-then-sound`, both sound and speech fire as independent background
+processes — no waiting. The perceptual ordering comes from invocation order and the ~200ms startup
+delta. `speak-only` skips `play_sound()` entirely.
+
+## Design
+
+### Key Design Decisions
+
+**1. Speech text resolution happens in the Python/PowerShell routing block, not in `speak()`.**
+
+The Python block already has access to the manifest (`pick` variable with the chosen sound entry),
+notification templates (`_tpl_vars`), and event context (`project`, `status`, `summary`). Resolving
+speech text here means `speak()` receives already-interpolated plain text — no template engine, no
+manifest access, no event context needed in the shell function or backend scripts.
+
+Alternative considered: having `speak()` accept template strings and variables, resolving text
+at invocation time. Rejected because it duplicates the template resolution already done for
+notifications and splits the "what text to produce" logic across two locations.
+
+**2. `_run_sound_and_notify()` handles mode sequencing; `speak()` is mode-unaware.**
+
+`_run_sound_and_notify()` is the only place that knows about both `play_sound()` and `speak()`, so
+it owns the ordering decision. A `case` on `TTS_MODE` determines whether sound fires first, speech
+fires first, or sound is skipped entirely. `speak()` itself is a thin wrapper — resolve backend,
+invoke script, track PID — with no knowledge of modes. This keeps each function to a single
+responsibility: the caller sequences, the speaker speaks.
+
+Alternative considered: having `speak()` handle mode logic internally, checking `TTS_MODE` and
+coordinating with `play_sound()`. Rejected because `speak()` would need to know about sound
+playback state and SOUND_FILE availability — concerns that belong to the caller.
+
+```bash
+_run_sound_and_notify() {
+  # ... suppression checks (applied to both sound and TTS) ...
+
+  if [ "$_skip_sound" = "false" ]; then
+    case "${TTS_MODE:-sound-then-speak}" in
+      sound-then-speak)
+        [ -n "$SOUND_FILE" ] && [ -f "$SOUND_FILE" ] && play_sound "$SOUND_FILE" "$VOLUME"
+        [ -n "$TTS_TEXT" ] && speak "$TTS_TEXT"
+        ;;
+      speak-only)
+        [ -n "$TTS_TEXT" ] && speak "$TTS_TEXT"
+        ;;
+      speak-then-sound)
+        [ -n "$TTS_TEXT" ] && speak "$TTS_TEXT"
+        [ -n "$SOUND_FILE" ] && [ -f "$SOUND_FILE" ] && play_sound "$SOUND_FILE" "$VOLUME"
+        ;;
+    esac
+  fi
+
+  # ... notifications (unchanged) ...
+}
+```
+
+Each branch guards both `SOUND_FILE` (may be empty if no sound for this category) and `TTS_TEXT`
+(may be empty if TTS disabled or text resolved empty). When `SOUND_FILE` is empty, only TTS fires
+regardless of mode. When `TTS_TEXT` is empty, only sound fires — existing behavior preserved
+exactly.
+
+**3. Backend resolution is a static `case` block, not filesystem scanning.**
+
+The ADR explicitly chose this: "Explicit is better than implicit for a system with <10 backends."
+The hook pipeline maps config values to script paths:
+
+```bash
+# Unix — always returns a script filename (e.g., "tts-native.sh"), never an absolute path.
+# The caller (speak()) resolves to absolute via find_bundled_script.
+_resolve_tts_backend() {
+  local backend="${1:-auto}"
+  case "$backend" in
+    native)     echo "tts-native.sh" ;;
+    elevenlabs) echo "tts-elevenlabs.sh" ;;
+    piper)      echo "tts-piper.sh" ;;
+    auto)
+      # Probe in priority order: prefer premium when installed.
+      # At Phase 1 launch, only native exists — probes are ~1ms each.
+      for b in elevenlabs piper native; do
+        local script_name
+        script_name="$(_resolve_tts_backend "$b")" || continue
+        find_bundled_script "$script_name" >/dev/null 2>&1 || continue
+        echo "$script_name" && return 0
+      done
+      return 1  # no backend available
+      ;;
+    *) return 1 ;;
+  esac
+}
+```
+
+```powershell
+# Windows — always returns a script filename (e.g., "tts-native.ps1"), never a full path.
+# The caller (Invoke-TtsSpeak) resolves to absolute via Join-Path $InstallDir "scripts\$name".
+function Resolve-TtsBackend {
+    param([string]$Backend = "auto")
+    switch ($Backend) {
+        "native"     { return "tts-native.ps1" }
+        "elevenlabs" { return "tts-elevenlabs.ps1" }
+        "piper"      { return "tts-piper.ps1" }
+        "auto" {
+            # Probe in priority order: prefer premium when installed.
+            # At Phase 1 launch, only native exists — probes are ~1ms each.
+            foreach ($b in @("elevenlabs", "piper", "native")) {
+                $scriptName = Resolve-TtsBackend -Backend $b
+                $full = Join-Path $InstallDir "scripts\$scriptName"
+                if (Test-Path $full) { return $scriptName }
+            }
+            return $null
+        }
+        default { return $null }
+    }
+}
+```
+
+The `auto` probe order prefers premium backends when installed (ElevenLabs > Piper > native). At
+Phase 1 launch, only `native` exists, so `auto` trivially resolves to `native`. This ordering
+means users who later install ElevenLabs get an automatic upgrade without config changes.
+
+**4. TTS PID tracking uses `.tts.pid` separate from `.sound.pid`.**
+
+The ADR specified this for mode independence. The `speak()` function manages `.tts.pid` with the
+same kill-previous pattern as `kill_previous_sound()`:
+
+```bash
+kill_previous_tts() {
+  local pidfile="$PEON_DIR/.tts.pid"
+  if [ -f "$pidfile" ]; then
+    local old_pid
+    old_pid=$(cat "$pidfile" 2>/dev/null)
+    if [ -n "$old_pid" ] && kill -0 "$old_pid" 2>/dev/null; then
+      kill "$old_pid" 2>/dev/null
+    fi
+    rm -f "$pidfile"
+  fi
+}
+
+save_tts_pid() {
+  echo "$1" > "$PEON_DIR/.tts.pid"
+}
+```
+
+The trainer subshell waits for *both* `.sound.pid` and `.tts.pid` to complete before playing
+trainer content. In `sound-then-speak` mode, main TTS starts after main sound — so `.sound.pid`
+can finish while `.tts.pid` is mid-utterance. Waiting for both PIDs prevents the trainer sound
+from overlapping with the main event's TTS phrase. The wait logic uses the same poll pattern as
+the existing `.sound.pid` wait (10s timeout, 100ms poll interval).
+
+**5. `PEON_TEST=1` makes TTS synchronous for test capture.**
+
+The existing test pattern: `PEON_TEST=1` causes `play_sound()` to run synchronously (no `nohup`,
+no `&`). TTS follows the same convention — `speak()` runs the backend in the foreground when
+`PEON_TEST=1`, allowing BATS tests to capture the invocation and verify arguments. In production,
+the backend runs via `nohup ... &` (Unix) or `Start-Process -WindowStyle Hidden` (Windows).
+
+### Interface Design
+
+#### `speak()` shell function (Unix)
+
+```bash
+speak() {
+  local text="$1"
+  [ -z "$text" ] && return 0
+
+  kill_previous_tts
+
+  # _resolve_tts_backend returns a script filename (e.g., "tts-native.sh").
+  # find_bundled_script resolves it to an absolute path.
+  local script_name
+  script_name="$(_resolve_tts_backend "${TTS_BACKEND:-auto}")" || return 0
+  local abs_script
+  abs_script="$(find_bundled_script "$script_name")" 2>/dev/null || return 0
+  [ -x "$abs_script" ] || return 0
+
+  local voice="${TTS_VOICE:-default}"
+  local rate="${TTS_RATE:-1.0}"
+  local vol="${TTS_VOLUME:-0.5}"
+
+  if [ "${PEON_TEST:-0}" = "1" ]; then
+    printf '%s\n' "$text" | "$abs_script" "$voice" "$rate" "$vol" >/dev/null 2>&1
+  else
+    # printf '%s\n' is used instead of echo to avoid flag interpretation
+    # (e.g., text starting with "-n" or "-e"). Text is passed as $0 to sh -c,
+    # avoiding shell interpolation of metacharacters in the text content.
+    nohup sh -c 'printf "%s\n" "$0" | "$1" "$2" "$3" "$4"' \
+      "$text" "$abs_script" "$voice" "$rate" "$vol" >/dev/null 2>&1 &
+    save_tts_pid $!
+  fi
+}
+```
+
+#### `Invoke-TtsSpeak` PowerShell function (Windows)
+
+```powershell
+function Invoke-TtsSpeak {
+    param(
+        [string]$Text,
+        [string]$Backend = "auto",
+        [string]$Voice = "default",
+        [double]$Rate = 1.0,
+        [double]$Volume = 0.5
+    )
+    if (-not $Text) { return }
+
+    # Kill previous TTS
+    $pidFile = Join-Path $InstallDir ".tts.pid"
+    if (Test-Path $pidFile) {
+        $oldPid = Get-Content $pidFile -ErrorAction SilentlyContinue
+        if ($oldPid) {
+            try { Stop-Process -Id $oldPid -Force -ErrorAction SilentlyContinue } catch {}
+        }
+        Remove-Item $pidFile -Force -ErrorAction SilentlyContinue
+    }
+
+    $scriptName = Resolve-TtsBackend -Backend $Backend
+    if (-not $scriptName) { return }
+    $scriptPath = Join-Path $InstallDir "scripts\$scriptName"
+    if (-not (Test-Path $scriptPath)) { return }
+
+    # Text is Base64-encoded to avoid shell metacharacter injection. Dynamic text
+    # from template variables ({summary}, {project}) can contain double quotes,
+    # dollar signs, backticks, and other PowerShell-interpreted characters that
+    # would corrupt or break a directly-interpolated -Command string. This matches
+    # the Unix side's safety guarantee (text passed as $0, never interpolated).
+    $b64 = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($Text))
+    $proc = Start-Process -FilePath "powershell.exe" `
+        -ArgumentList "-NoProfile", "-NonInteractive", "-Command",
+            "[Text.Encoding]::UTF8.GetString([Convert]::FromBase64String('$b64')) | & '$scriptPath' -voice '$Voice' -rate $Rate -vol $Volume" `
+        -WindowStyle Hidden -PassThru
+    $proc.Id | Set-Content $pidFile
+}
+```
+
+#### Python block output (new variables)
+
+The Python block gains these additional `print()` outputs:
+
+```python
+print('TTS_ENABLED=' + ('true' if tts_enabled else 'false'))
+print('TTS_TEXT=' + q(tts_text))
+print('TTS_BACKEND=' + q(tts_backend))
+print('TTS_VOICE=' + q(tts_voice))
+print('TTS_RATE=' + q(str(tts_rate)))
+print('TTS_VOLUME=' + q(str(tts_volume)))
+print('TTS_MODE=' + q(tts_mode))
+print('TRAINER_TTS_TEXT=' + q(trainer_tts_text))
+```
+
+#### Speech text resolution (Python block addition)
+
+```python
+# --- TTS speech text resolution ---
+tts_cfg = cfg.get('tts', {})
+tts_enabled = tts_cfg.get('enabled', False) and not paused
+tts_text = ''
+tts_backend = tts_cfg.get('backend', 'auto')
+tts_voice = tts_cfg.get('voice', 'default')
+tts_rate = tts_cfg.get('rate', 1.0)
+tts_volume = tts_cfg.get('volume', 0.5)
+tts_mode = tts_cfg.get('mode', 'sound-then-speak')
+
+if tts_enabled and category:
+    # Chain: manifest speech_text → notification template → default
+    if pick and pick.get('speech_text'):
+        _speech_tpl = pick['speech_text']
+    elif _tpl:
+        _speech_tpl = _tpl  # already resolved notification template
+    else:
+        _speech_tpl = '{project} \u2014 {status}'
+
+    try:
+        tts_text = _speech_tpl.format_map(_tpl_vars)
+    except Exception:
+        tts_text = ''
+
+    # Empty after interpolation → skip
+    tts_text = tts_text.strip()
+    if tts_text == '\u2014' or not tts_text:
+        tts_text = ''
+```
+
+The `pick` variable (the chosen manifest sound entry) is already in scope from sound selection
+(line 3571). The `_tpl_vars` dict is already populated from notification template resolution
+(line 3730). This placement — after both sound selection and template resolution — means all
+inputs are available.
+
+`TRAINER_TTS_TEXT` reuses the existing trainer progress string verbatim — the same string that
+currently renders into `TRAINER_MSG` for desktop notifications. No reformatting for speech in
+this phase (resolved question #1):
+
+```python
+# After trainer reminder logic (which already computes trainer_msg):
+trainer_tts_text = trainer_msg if (tts_enabled and trainer_msg) else ''
+```
+
+#### Speech text resolution (PowerShell addition)
+
+```powershell
+# --- TTS speech text resolution ---
+$ttsCfg = if ($config.tts) { $config.tts } else { @{} }
+$ttsEnabled = ($ttsCfg.enabled -eq $true) -and (-not $paused)
+$ttsText = ""
+$ttsBackend = if ($ttsCfg.backend) { $ttsCfg.backend } else { "auto" }
+$ttsVoice = if ($ttsCfg.voice) { $ttsCfg.voice } else { "default" }
+$ttsRate = if ($ttsCfg.rate) { $ttsCfg.rate } else { 1.0 }
+$ttsVolume = if ($ttsCfg.volume) { $ttsCfg.volume } else { 0.5 }
+$ttsMode = if ($ttsCfg.mode) { $ttsCfg.mode } else { "sound-then-speak" }
+
+if ($ttsEnabled -and $category) {
+    $speechTpl = ""
+    if ($chosen -and $chosen.speech_text) {
+        $speechTpl = $chosen.speech_text
+    } elseif ($resolvedTemplate) {
+        $speechTpl = $resolvedTemplate
+    } else {
+        $speechTpl = "{project} `u{2014} {status}"
+    }
+
+    # Interpolate template variables (same set as notification templates)
+    $ttsText = $speechTpl
+    foreach ($key in $tplVars.Keys) {
+        $ttsText = $ttsText.Replace("{$key}", $tplVars[$key])
+    }
+    $ttsText = $ttsText.Trim()
+    if ($ttsText -eq "`u{2014}" -or -not $ttsText) { $ttsText = "" }
+}
+```
+
+#### PowerShell mode sequencing (Windows)
+
+The PowerShell sound playback section gains the same mode-aware branching as Unix:
+
+```powershell
+if (-not $skipSound) {
+    switch ($ttsMode) {
+        "sound-then-speak" {
+            if ($soundFile -and (Test-Path $soundFile)) { Play-Sound $soundFile $volume }
+            if ($ttsText) { Invoke-TtsSpeak -Text $ttsText -Backend $ttsBackend -Voice $ttsVoice -Rate $ttsRate -Volume $ttsVolume }
+        }
+        "speak-only" {
+            if ($ttsText) { Invoke-TtsSpeak -Text $ttsText -Backend $ttsBackend -Voice $ttsVoice -Rate $ttsRate -Volume $ttsVolume }
+        }
+        "speak-then-sound" {
+            if ($ttsText) { Invoke-TtsSpeak -Text $ttsText -Backend $ttsBackend -Voice $ttsVoice -Rate $ttsRate -Volume $ttsVolume }
+            if ($soundFile -and (Test-Path $soundFile)) { Play-Sound $soundFile $volume }
+        }
+    }
+}
+```
+
+#### Config schema addition
+
+```json
+{
+  "tts": {
+    "enabled": false,
+    "backend": "auto",
+    "voice": "default",
+    "rate": 1.0,
+    "volume": 0.5,
+    "mode": "sound-then-speak"
+  }
+}
+```
+
+Added to `config.json` defaults. Runtime code uses `cfg.get('tts', {})` with per-field defaults,
+so missing keys in existing configs are safe.
+
+#### Debug logging
+
+TTS adds a `[tts]` log phase following the existing structured logging format:
+
+```
+[tts] enabled=true backend=native voice=Alex rate=1.0 volume=0.5 mode=sound-then-speak
+[tts] text="api-server — all tests passing" source=template
+[tts] cmd="scripts/tts-native.sh" pid=48291
+```
+
+Or when skipped:
+
+```
+[tts] enabled=true backend=auto resolved=none skip=no_backend
+[tts] enabled=true text="" skip=empty_text
+[tts] enabled=false skip=disabled
+```
+
+## Implementation Phases
+
+### Phase 1: Config schema and `peon update` backfill
+
+**Goal:** Existing installs gain the `tts` config section on next update, and new installs include
+it by default.
+
+**Deliverables:**
+- `config.json` updated with `tts` section (6 keys, all with safe defaults)
+- `peon update` config merge logic extended to backfill `tts` section without overwriting
+  user-modified values (same merge pattern as every prior config addition)
+- `install.ps1` Windows installer includes `tts` section in generated config
+
+**Test strategy:**
+- **Unit (BATS):** `peon update` on a config without `tts` section adds it with correct defaults.
+  `peon update` on a config with existing `tts` section preserves user values.
+- **Unit (Pester):** Same two cases for the Windows config generation path.
+
+**Infrastructure:** None.
+
+**Documentation:** None (config key docs ship with tts-docs feature).
+
+**Dependencies:** None.
+
+**Definition of done:**
+- [ ] `config.json` contains `tts` section with 6 keys
+- [ ] `peon update` backfills `tts` section on configs that lack it
+- [ ] `peon update` preserves existing `tts` values when section already present
+- [ ] Windows installer generates config with `tts` section
+- [ ] All existing BATS and Pester tests pass (no regressions)
+
+### Phase 2: Speech text resolution in Python block
+
+**Goal:** The Python routing block resolves TTS speech text from the manifest/template/default
+chain and outputs `TTS_*` shell variables.
+
+**Deliverables:**
+- Speech text resolution logic added to `peon.sh` Python block (after sound selection and template
+  resolution)
+- 8 new `print()` outputs: `TTS_ENABLED`, `TTS_TEXT`, `TTS_BACKEND`, `TTS_VOICE`, `TTS_RATE`,
+  `TTS_VOLUME`, `TTS_MODE`, `TRAINER_TTS_TEXT`
+- TTS config loading with safe defaults (`cfg.get('tts', {})`)
+
+**Test strategy:**
+- **Unit (BATS):** Mock events with TTS enabled verify correct `TTS_TEXT` output for each source
+  in the resolution chain: (a) manifest `speech_text` present → uses it, (b) notification template
+  configured → uses it, (c) neither → uses default `"{project} — {status}"`. (d) Empty text after
+  interpolation → `TTS_TEXT` is empty. (e) TTS disabled → `TTS_ENABLED=false`, no `TTS_TEXT`.
+
+**Infrastructure:** None.
+
+**Documentation:** None.
+
+**Dependencies:** Phase 1 (config schema).
+
+**Definition of done:**
+- [ ] Python block reads `tts` config section with safe defaults
+- [ ] `TTS_TEXT` resolves from manifest `speech_text` when present
+- [ ] `TTS_TEXT` falls back to notification template when no `speech_text`
+- [ ] `TTS_TEXT` falls back to default template `"{project} — {status}"` when no notification template
+- [ ] Empty resolved text produces empty `TTS_TEXT`
+- [ ] `TTS_ENABLED=false` when TTS disabled or hook is paused
+- [ ] `TRAINER_TTS_TEXT` populated with trainer progress string when trainer fires and TTS enabled
+- [ ] All 8 `TTS_*` variables printed in output block
+
+### Phase 3: `speak()` function, PID tracking, and mode sequencing (Unix)
+
+**Goal:** `peon.sh` gains the `speak()` shell function, TTS PID management, backend resolution,
+and mode-aware sequencing in `_run_sound_and_notify()`.
+
+**Deliverables:**
+- `speak()` function: backend resolution → script invocation → PID tracking
+- `_resolve_tts_backend()` function: config value → script path mapping with `auto` probing
+- `kill_previous_tts()` and `save_tts_pid()` functions
+- `_run_sound_and_notify()` updated with mode-aware sound/TTS ordering
+- Trainer reminder block updated to wait for both `.sound.pid` and `.tts.pid`, then speak
+  `TRAINER_TTS_TEXT` after trainer sound
+- All suppression rules (`headphones_only`, `meeting_detect`, `suppress_sound_when_tab_focused`,
+  pause) applied to TTS
+- `PEON_TEST=1` synchronous mode for test capture
+- `[tts]` debug log phase entries
+
+**Test strategy:**
+- **Unit (BATS):** Mock backend script (logs invocation args to a file instead of speaking).
+  Tests verify: (a) `speak()` invokes backend with correct args order, (b) text passed on stdin,
+  (c) mode sequencing — `sound-then-speak` plays sound then speaks, `speak-only` skips sound,
+  `speak-then-sound` speaks then plays sound, (d) empty `TTS_TEXT` skips TTS invocation entirely,
+  (e) `TTS_ENABLED=false` skips all TTS, (f) suppression rules suppress TTS same as sound,
+  (g) kill-previous kills old `.tts.pid` before new speak, (h) `auto` backend resolution probes
+  scripts in order, (i) missing backend script → graceful skip.
+- **Integration (BATS):** Full hook invocation with TTS enabled, mock backend, and mock `afplay`
+  — verify both sound and TTS fire in correct order for each mode.
+
+**Infrastructure:** None.
+
+**Documentation:** None.
+
+**Dependencies:** Phase 2 (speech text resolution).
+
+**Definition of done:**
+- [ ] `speak()` invokes resolved backend script with text on stdin
+- [ ] Backend receives voice, rate, volume as positional args
+- [ ] `.tts.pid` written after background TTS process starts
+- [ ] `kill_previous_tts()` kills old TTS before new invocation
+- [ ] `_run_sound_and_notify()` respects `TTS_MODE` for ordering
+- [ ] `speak-only` mode skips `play_sound()` entirely
+- [ ] All suppression rules apply to TTS
+- [ ] `PEON_TEST=1` runs TTS synchronously
+- [ ] `[tts]` debug log entries emitted when debug enabled
+- [ ] Trainer subshell waits for both `.sound.pid` and `.tts.pid` before playing trainer content
+- [ ] Trainer speaks `TRAINER_TTS_TEXT` after trainer sound when TTS enabled
+- [ ] Hook return latency unchanged (TTS is async)
+- [ ] Missing backend → silent skip, no error
+
+### Phase 4: PowerShell port (Windows)
+
+**Goal:** The Windows hook engine (`install.ps1` embedded `peon.ps1`) provides identical TTS
+behavior to the Unix implementation.
+
+**Deliverables:**
+- `Invoke-TtsSpeak` function: backend resolution → `Start-Process` invocation → PID tracking
+- `Resolve-TtsBackend` function: config value → script path mapping
+- TTS PID management (`.tts.pid` read/write/kill)
+- Mode-aware sequencing in the sound playback section
+- Speech text resolution in the PowerShell routing block (mirrors Python block output)
+- Trainer TTS integration
+- Suppression rules applied to TTS
+
+**Test strategy:**
+- **Unit (Pester):** (a) `Resolve-TtsBackend` returns correct paths for each named backend,
+  (b) `Resolve-TtsBackend -Backend auto` probes in priority order, (c) speech text resolution
+  chain produces correct output for manifest/template/default sources, (d) TTS disabled → no
+  `Start-Process` call, (e) mode sequencing logic branches correctly, (f) `.tts.pid` file
+  management (write on speak, read/kill on next speak).
+
+**Infrastructure:** None.
+
+**Documentation:** None.
+
+**Dependencies:** Phase 3 (Unix implementation validates the design; Windows mirrors it).
+
+**Definition of done:**
+- [ ] `Invoke-TtsSpeak` invokes resolved backend via `Start-Process -WindowStyle Hidden`
+- [ ] Backend receives text on stdin via PowerShell pipeline
+- [ ] `.tts.pid` managed (write/read/kill)
+- [ ] Mode sequencing matches Unix behavior
+- [ ] Speech text resolution chain matches Python block logic
+- [ ] All suppression rules apply
+- [ ] Trainer speaks progress when TTS enabled
+- [ ] All existing Pester tests pass (no regressions)
+
+## Migration & Rollback
+
+**Migration:** `peon update` backfills the `tts` section into existing configs. Runtime code
+defaults every `tts` field individually via `.get()` with fallbacks, so partially-populated
+configs are safe. `tts.enabled` defaults to `false`, meaning TTS has no effect until explicitly
+activated — zero behavior change for existing users.
+
+**Rollback:** Clean `git revert`. The `tts` section in config is inert when `enabled: false` (the
+default). Reverting the code leaves the config section harmless. No state migration — `.tts.pid`
+is only created when TTS runs and is cleaned up by `kill_previous_tts`.
+
+## Risks
+
+| Risk | Impact | Likelihood | Mitigation |
+|------|--------|------------|------------|
+| Speech text resolution adds latency to Python block | Hook return delayed for all users, not just TTS users | Low | Resolution is pure string operations (dict lookup + `format_map`). No I/O, no subprocess. Measured at <1ms in similar template resolution for notifications. |
+| Mode sequencing interacts badly with trainer wait logic | Trainer sound waits for wrong PID, causing silence or overlap | Medium | Trainer subshell waits for *both* `.sound.pid` and `.tts.pid` before playing trainer content. This prevents overlap in `sound-then-speak` mode where main TTS may still be speaking when `.sound.pid` finishes. Clear PID separation prevents cross-talk. Test all mode × trainer combinations. |
+| `nohup sh -c` text quoting breaks on edge cases | Speech text with quotes, newlines, or special chars corrupts backend input | Medium | Text passed via positional `$0` in `sh -c`, not interpolated into the command string. `printf '%s\n'` used instead of `echo` to avoid flag interpretation (text starting with `-n`, `-e`). BATS tests include adversarial text (quotes, backticks, newlines, Unicode, dash-prefixed strings). |
+| PowerShell `Start-Process` pipeline stdin not trivial | Windows backend doesn't receive text on stdin | Medium | Text is Base64-encoded before embedding in the `-Command` string, avoiding injection of shell metacharacters (double quotes, `$()`, backticks) from dynamic template content. The backend receives decoded text on stdin via PowerShell pipeline. |
+| `auto` backend resolution adds file probes to every hook | Minor latency from checking script existence | Low | `auto` probes 3 paths max (`-x` / `Test-Path` checks). ~1ms total. Cache result in state if needed (unlikely). |
+
+## Roadmap Connection
+
+This design implements the **tts-integration** feature under **v2/m5** ("The peon speaks to you").
+It's the P1 foundation that `tts-native`, `tts-cli`, and `tts-notifications` all depend on.
+
+The roadmap correctly sequences the dependency chain:
+`tts-integration` → `tts-native` → `tts-cli` → `tts-notifications` / `tts-docs` / `tts-elevenlabs` / `tts-piper`
+
+No roadmap changes needed — the existing feature breakdown and dependencies match this design.
+
+## Resolved Questions
+
+1. **Trainer TTS text format:** Use the existing trainer progress string as-is (e.g., "75 of 300
+   pushups. 50 of 300 squats. 21 percent."). Optimize for speech later if user feedback warrants it.
+
+2. **TTS volume in speak-only mode:** Always use `tts.volume`, independent from the top-level
+   `volume`. Users choosing `speak-only` set `tts.volume` to their preferred level.
+
+3. **Tab-focused suppression:** Suppress both sound and TTS uniformly when
+   `suppress_sound_when_tab_focused` is true. Granular per-modality suppression
+   (`suppress_tts_when_tab_focused`) is tracked as a separate roadmap feature under v2/m5.
+
+---
+
+## Revision History
+
+| Date | Author | Notes |
+|------|--------|-------|
+| 2026-03-28 | cameron | Initial design |
+| 2026-03-28 | cameron | Design review fixes: Windows text transport uses Base64 to match ADR stdin safety guarantee; backend resolution returns consistent filenames (not mixed relative/absolute paths); find_bundled_script called with correct script filenames including extension; printf replaces echo to avoid flag interpretation; trainer waits for both .sound.pid and .tts.pid before playing; KDD #2 prose aligned with code (caller handles mode sequencing); TRAINER_TTS_TEXT derivation specified; PowerShell mode sequencing code added; SOUND_FILE guards added to mode branches |

--- a/docs/prds/PRD-003-tts-spoken-feedback.md
+++ b/docs/prds/PRD-003-tts-spoken-feedback.md
@@ -1,0 +1,478 @@
+# PRD-003: The Peon Speaks to You — Text-to-Speech for peon-ping
+
+> **Status**: Draft | **Date**: 2026-03-28 | **Author**: cameron
+> **Roadmap**: v2/m5
+
+## Problem Statement
+
+Peon-ping communicates through pre-recorded audio files — a finite library of static sound clips mapped to event categories. This works well for reactive feedback ("work complete," "something need doing?") but breaks down when the content needs to be dynamic. A trainer reminder can play a nagging voice line, but it can't say "45 of 300 pushups done — you're behind pace." A notification can pop up a text template with `{project}` and `{summary}`, but the audio is always the same generic clip regardless of context. Users who rely on audio cues (eyes on code, not on notification popups) miss the richest information peon-ping has — the template-rendered text that only appears in silent desktop toasts.
+
+The gap widens as peon-ping grows more context-aware. Path rules, notification templates, and the trainer already generate dynamic text that's never spoken. Every new feature that produces meaningful text (and there will be more) hits the same wall: the audio layer is static, the text layer is dynamic, and they can't meet.
+
+## Background & Context
+
+### Why now
+
+Three factors converge:
+
+1. **The trainer shipped (v2/m3) with text it can't speak.** Trainer reminders generate progress strings like "45/300 pushups, 20/300 squats — 22% done" that appear in desktop notifications but never in audio. The entire value proposition of the trainer is nagging you to exercise — and nagging is dramatically more effective when it's spoken aloud rather than displayed in a toast you've already learned to ignore. The trainer is the killer app for TTS.
+
+2. **Notification templates shipped (v2/m2) with variables that beg to be read.** Templates like `"✅ {project} — {summary}"` render rich context into desktop notifications. Users who configured custom templates did so because they want *more information* from peon-ping's audio channel, not less. TTS closes the loop: the same template that renders a notification can be spoken.
+
+3. **Platform-native TTS is free and zero-dependency.** macOS ships `say`, Windows ships `System.Speech.Synthesis` (SAPI5), and Linux has `espeak-ng` (installed by default on most distros) plus the emerging `piper` for neural quality. The baseline implementation requires no API keys, no downloads, and no configuration — just the OS the user already has. This means TTS can be a toggle, not a project.
+
+### Prior art
+
+- **macOS `say` command**: Ships on every Mac. Supports 50+ voices across languages. Async via `&`. Quality ranges from robotic (older voices) to natural (Siri Neural voices on macOS 14+). Zero configuration.
+- **Windows SAPI5 (`System.Speech.Synthesis`)**: Ships on every Windows install. `Add-Type -AssemblyName System.Speech` in PowerShell. 2-3 built-in voices, more installable via Settings → Time & Language → Speech. Async via `SpeakAsync()` or `Start-Process`.
+- **Linux `espeak-ng`**: Available in every major distro's package manager. Robotic but functional. `piper` (C++ neural TTS from Rhasspy) offers dramatically better quality with ~50MB model downloads.
+- **Accessibility tools**: Screen readers (VoiceOver, NVDA, Narrator) prove that system TTS is reliable enough for continuous professional use. peon-ping's usage is far lighter — a few phrases per hour.
+- **Gaming**: Warcraft III itself used pre-recorded voice lines rather than TTS, but modern games increasingly use TTS for dynamic content (enemy callouts, quest updates). The peon-ping aesthetic is pre-recorded character voice lines *supplemented* by TTS for dynamic content — not replaced by it.
+- **CLI tools with TTS**: Rare. Most CLI tools are silent. `espanso` (text expander) has TTS for accessibility. `watson` (time tracker) has optional spoken summaries. peon-ping would be a first-mover for coding tool audio feedback with TTS.
+
+### Current audio pipeline
+
+The hook pipeline in `peon.sh` (and `peon.ps1` on Windows) follows this flow:
+
+1. JSON event arrives on stdin from IDE hook
+2. Python block (or PowerShell on Windows) maps event → CESP category → pack manifest → random sound file
+3. Shell plays sound async via platform backend (`afplay`, `pw-play`, `MediaPlayer`, etc.)
+4. Optionally, trainer reminder sound plays after main sound with delay
+5. Desktop/mobile notifications sent with template-rendered text
+
+TTS would insert after step 2: when TTS is enabled and the selected sound entry has a `speech_text` field (or a notification template is configured), generate and play spoken audio instead of or after the static sound file. The async playback pattern (step 3) already handles fire-and-forget audio — TTS just needs to produce a playable audio stream or invoke a system command that speaks directly to the audio device.
+
+### What exists today
+
+- **Zero TTS code.** No TTS references in `peon.sh`, `peon.ps1`, or any adapter.
+- **`label` field in manifests.** Every sound entry already has a `"label"` string (e.g., `"Ready to work?"`, `"Work, work."`). These are used for notification text and `peon preview` output. They're natural candidates for TTS text — but they're character-specific flavor text, not dynamic content.
+- **Notification templates.** Five template keys (`stop`, `error`, `permission`, `idle`, `question`) with variable interpolation (`{project}`, `{summary}`, `{tool_name}`, `{status}`, `{event}`). These already produce the dynamic text that TTS would speak.
+- **Trainer progress strings.** Generated during reminder logic: rep counts, percentages, pace status. Currently only rendered into notification messages.
+- **44 config keys** in `config.json`. No `tts` section exists. The `trainer` section (nested object) establishes the pattern for adding a new feature namespace.
+
+## User Segments
+
+### Trainer user who wants spoken progress
+- **Who**: Developer using the peon trainer for daily exercise goals (pushups, squats). Has trainer enabled, gets reminder sounds every 20 minutes during coding sessions.
+- **Current pain**: Trainer reminders play a generic nag sound. The actual progress ("45/300 pushups, behind pace") only appears in a desktop notification toast that auto-dismisses in 4 seconds. If they're in flow, they hear the sound but miss the numbers. They have to run `peon trainer status` to see where they stand.
+- **Desired outcome**: The peon *tells* them their progress: "45 of 300 pushups. You're slacking." They hear the information without looking away from code.
+- **Priority**: Primary
+
+### Power user who wants richer audio context
+- **Who**: Developer who already configured notification templates with `{project}` and `{summary}` variables because they want peon-ping to communicate *what happened*, not just *that something happened*. Likely uses multiple projects with path rules.
+- **Current pain**: The notification template renders useful text in a popup, but the audio is always the same pack sound regardless of project or event details. The audio channel carries no information beyond "task complete" vs "error" vs "needs input."
+- **Desired outcome**: After the character voice line plays, a brief spoken summary adds context: "myproject — all tests passing." Or the voice line is replaced entirely with a spoken template.
+- **Priority**: Primary
+
+### Pack creator who wants voiced characters
+- **Who**: Community pack author creating a character voice pack (e.g., GLaDOS, Kerrigan, a custom AI personality). Wants the character to "say" dynamic things that pre-recorded clips can't cover.
+- **Current pain**: Every line must be pre-recorded. If a pack wants to say the project name or a custom quip based on event data, there's no mechanism. The pack is limited to a fixed library of clips.
+- **Desired outcome**: Pack manifests can define `speech_text` templates per sound entry. When TTS is enabled, the character "speaks" dynamic content using the pack author's chosen voice/style configuration. The manifest becomes a script, not just a playlist.
+- **Priority**: Secondary
+
+### Accessibility-conscious user
+- **Who**: Developer who prefers or requires audio feedback over visual notifications. May have visual attention constraints, use a tiling window manager where notifications are hidden, or work in a terminal-only environment (SSH) where desktop notifications aren't available.
+- **Current pain**: peon-ping's audio is limited to categorical sounds — they know *something* happened but not *what*. Desktop notifications (the informational channel) require visual attention. Mobile push is too slow for real-time context.
+- **Desired outcome**: TTS provides the same information as desktop notifications, delivered through the audio channel. They can stay eyes-on-code and still know what happened.
+- **Priority**: Secondary
+
+## Goals & Non-Goals
+
+### Goals
+- Hook events can optionally trigger spoken output — in addition to, instead of, or after the normal sound file
+- Platform-native TTS works out of the box on macOS, Windows, and Linux with zero configuration beyond `peon tts on`
+- Dynamic content from notification templates and trainer progress can be spoken, not just displayed
+- Pack manifests can define per-entry spoken text with template variables, enabling character-voiced dynamic content
+- TTS backend is pluggable — the integration layer abstracts over native, cloud, and local AI engines
+- TTS playback is async and does not block hook return (same contract as sound playback)
+- CLI commands (`peon tts on/off/status/test/voices/backend`) provide full control without config file editing
+
+### Non-Goals
+- **Replacing pre-recorded voice packs with TTS.** TTS supplements pack audio — it doesn't replace the character voice lines that define each pack's personality. The peon's "work work" stays as a WAV file. TTS adds "myproject — all tests passing" after it.
+- **Real-time voice cloning or voice matching.** Making TTS output sound like the pack's character (e.g., making `say` sound like a Warcraft peon) is a fascinating future direction but requires custom voice models. Out of scope for this milestone.
+- **Streaming TTS during long events.** TTS speaks short phrases (1-2 sentences). Narrating full task output or streaming commentary during agent execution is a different product.
+- **SSML or advanced speech markup.** Platform-native TTS supports basic rate/pitch/volume. Rich SSML (pauses, emphasis, phoneme control) varies wildly across backends and adds complexity for marginal benefit at this stage.
+- **Automatic language detection.** TTS speaks in the language of the configured voice. Multilingual auto-detection is complex and error-prone. Users select their preferred voice, which implies a language.
+- **TTS for the relay/remote path.** SSH and devcontainer users route audio through `relay.sh`. TTS relay support is deferred to a future milestone to avoid overloading scope — but the architecture must not preclude it.
+
+## User Experience
+
+### Scenario 1: First-time TTS activation
+
+A user has been using peon-ping for weeks with the default peon pack. They hear "work work" on task completion and "something need doing?" on permission requests. They want to try TTS.
+
+```
+$ peon tts on
+✓ TTS enabled (backend: native, voice: default)
+  Speak a test phrase with: peon tts test
+
+$ peon tts test
+🔊 Speaking: "Ready to work? This is peon-ping text to speech."
+```
+
+The system voice speaks the test phrase through the same audio output as sound files. On macOS, this is `say`. On Windows, SAPI5. On Linux, whatever's available (`espeak-ng` or `piper`).
+
+From this point, hook events trigger both the normal pack sound AND a brief spoken phrase. The sound plays first (character identity), then TTS speaks dynamic content (information).
+
+```
+[hook fires: Stop event, project "api-server", summary "all 47 tests passing"]
+
+🔊 plays: peon/sounds/task_complete/work_work.mp3
+🔊 speaks: "api-server — all 47 tests passing"
+```
+
+The spoken text comes from the user's notification template for the `stop` category. If no template is configured, TTS speaks a sensible default: `"{project} — {status}"`.
+
+### Scenario 2: Trainer with spoken progress
+
+A user has the trainer enabled with 300 pushups and 300 squats daily. After a hook event, the trainer reminder fires:
+
+```
+[hook fires: Stop event]
+
+🔊 plays: peon/sounds/task_complete/okie_dokie.mp3     (main sound)
+   ... 0.5s gap ...
+🔊 plays: trainer/sounds/remind/do_pushups.mp3          (trainer nag)
+🔊 speaks: "75 of 300 pushups. 50 of 300 squats. You're at 21 percent."
+```
+
+The trainer's existing reminder sound plays first (character continuity), then TTS speaks the dynamic progress that previously only appeared in a notification toast. The spoken summary replaces the need to check `peon trainer status` or read a disappearing popup.
+
+When the user is slacking (past noon, below 25% progress):
+
+```
+🔊 plays: trainer/sounds/slacking/stop_touching.mp3
+🔊 speaks: "30 of 300 pushups. 10 percent. Pick it up."
+```
+
+### Scenario 3: Pack manifest with speech_text
+
+A pack author creating a "Mission Control" pack wants dynamic spoken content. They add `speech_text` to their manifest entries:
+
+```json
+{
+  "categories": {
+    "task.complete": {
+      "sounds": [
+        {
+          "file": "sounds/mission_complete.mp3",
+          "label": "Mission complete",
+          "speech_text": "Mission complete on {project}. {summary}"
+        }
+      ]
+    },
+    "task.error": {
+      "sounds": [
+        {
+          "file": "sounds/houston.mp3",
+          "label": "Houston, we have a problem",
+          "speech_text": "Alert. {project} encountered an error. {summary}"
+        }
+      ]
+    }
+  }
+}
+```
+
+When TTS is enabled, `speech_text` templates are interpolated with event variables and spoken after the sound file. When TTS is disabled, only the sound file plays (existing behavior, no regression).
+
+### Scenario 4: TTS-only mode (no sound files)
+
+A user wants spoken feedback without pack sounds — maybe they're in a meeting, want quieter output, or prefer TTS for accessibility:
+
+```
+$ peon tts on --mode speak-only
+✓ TTS enabled (mode: speak-only, backend: native, voice: default)
+```
+
+In `speak-only` mode, the pack sound file is skipped entirely. Only the TTS phrase plays. The volume, async behavior, and suppression rules (headphones-only, tab-focused muting) all apply to TTS the same way they apply to sound files.
+
+### Scenario 5: Choosing a voice
+
+```
+$ peon tts voices
+Available voices (backend: native):
+  Samantha (en_US)     ← current
+  Alex (en_US)
+  Daniel (en_GB)
+  Kyoko (ja_JP)
+  Thomas (fr_FR)
+  ... (23 more — run with --all to see full list)
+
+$ peon tts voice Daniel
+✓ TTS voice set to Daniel (en_GB)
+
+$ peon tts test
+🔊 Speaking: "Ready to work? This is peon-ping text to speech."
+   (in Daniel's British English voice)
+```
+
+Voice enumeration delegates to the platform: `say -v ?` on macOS, `Get-InstalledVoice` on Windows, `espeak-ng --voices` on Linux.
+
+### Error & Edge Cases
+
+**No TTS engine available (Linux minimal install):**
+```
+$ peon tts on
+⚠ No TTS engine found. Install espeak-ng: sudo apt install espeak-ng
+  TTS will remain disabled until a backend is available.
+```
+TTS fails gracefully — sound files continue playing normally. The user gets a clear action to fix it.
+
+**TTS takes too long:**
+TTS invocations inherit the same async pattern as sound playback — fire-and-forget via background process. If TTS takes 2 seconds to synthesize while the system `say` command buffers, it doesn't block the hook. A safety timeout (matching the existing 8-second audio timeout) kills runaway TTS processes.
+
+**Empty speech text:**
+If `speech_text` is empty or all template variables resolve to empty strings, TTS is silently skipped for that event. No empty audio plays.
+
+**TTS + relay (SSH/devcontainer):**
+TTS is not available over the relay in this milestone. The relay serves sound files only. Users in remote sessions hear pack sounds but not TTS. A future milestone can extend the relay protocol with a `/speak` endpoint. This is an explicit non-goal, documented so users aren't surprised.
+
+## Success Criteria
+
+| Criterion | Measurement | Target |
+|-----------|-------------|--------|
+| Zero-config activation | Steps from install to hearing TTS | `peon tts on` + `peon tts test` — two commands, no API keys, no downloads (macOS/Windows) |
+| Hook latency unchanged | Time from hook invocation to hook return | No measurable increase — TTS is async, fires after hook returns |
+| Trainer speaks progress | Trainer reminder includes spoken rep counts | 100% of trainer reminders with TTS enabled include spoken progress |
+| Template variables spoken | Notification template text rendered as speech | `{project}`, `{summary}`, `{tool_name}`, `{status}` all resolve in spoken output |
+| Platform coverage | TTS works on all supported platforms | macOS, Windows, Linux (with espeak-ng installed) |
+| Pack manifest speech | `speech_text` field in manifests triggers TTS | Verified with at least one official pack adding speech_text entries |
+| Graceful degradation | Behavior when TTS backend unavailable | Sound files play normally, warning on `peon tts on`, no errors during hooks |
+| Backend pluggability | Adding a new TTS backend | New backend requires implementing one function/scriptblock, no changes to hook pipeline |
+
+## Scope & Boundaries
+
+### In Scope
+- TTS integration layer in `peon.sh` (Python block) and `peon.ps1` (PowerShell) with pluggable backend contract
+- Platform-native TTS backend: macOS `say`, Windows `System.Speech.Synthesis`, Linux `espeak-ng`/`piper` priority chain
+- `tts` config section in `config.json` (enabled, backend, voice, rate, volume, mode)
+- TTS CLI commands: `peon tts on/off/status/test/voices/voice/backend`
+- Notification template text rendered as TTS speech after pack sound
+- Trainer progress strings spoken during trainer reminders
+- `speech_text` field in CESP manifest schema for pack-defined spoken content
+- Shell completions updates for new CLI commands
+- BATS tests (Unix) and Pester tests (Windows) for TTS pipeline
+- Documentation: README, README_zh, llms.txt, help text
+
+### Out of Scope
+- **ElevenLabs TTS backend** — deferred to its own feature (`v2/m5/tts-elevenlabs`). The pluggable architecture supports it, but API key management, audio caching, and cost controls are their own body of work. Each cloud/AI backend ships as an independent feature — no generic "cloud backends" layer.
+- **Piper TTS backend (local neural)** — deferred to its own feature (`v2/m5/tts-piper`). BYO binary and model. Piper as a Linux native fallback (detected in the espeak-ng priority chain) is in scope for Phase 1; Piper as a standalone managed backend with model downloads is not.
+- **Voice cloning / character voice matching** — making TTS output match pack character voices requires custom voice models. Fascinating but premature.
+- **TTS over relay (SSH/devcontainer)** — requires relay protocol extension. The architecture must not preclude it, but implementation is deferred.
+- **CESP spec changes** — `speech_text` is an optional extension field. The CESP v1.0 spec at openpeon doesn't need a version bump for additive optional fields, but should be documented in the spec's "extensions" section.
+- **Multilingual auto-detection** — users pick a voice (which implies a language). Auto-detecting the language of dynamic content and switching voices is complex and deferred.
+
+### Future Considerations
+- Each additional TTS backend (ElevenLabs, OpenAI, Piper, etc.) ships as its own feature implementing the `speak()` contract — no generic multi-provider abstraction layers. Only universal infrastructure (the contract itself, config schema, CLI framework) is shared.
+- TTS caching (text hash → cached audio file) ships with the first backend that needs it (ElevenLabs) — not pre-built speculatively in the integration layer
+- Voice profiles per pack (manifests declaring a preferred TTS voice/rate for their character) would let pack authors control the TTS experience; the config schema should not preclude this
+- The relay `/speak` endpoint should accept the same parameters as the local TTS contract
+
+## Delivery Phases
+
+### Phase 1: "peon tts on" — integration, native backends, and CLI
+
+**Value statement:** Users can run `peon tts on` and hear their peon speak dynamic content using their OS's built-in voice — on any platform, with zero setup.
+
+This phase ships the complete vertical slice: the backend contract (infrastructure), platform-native implementations (first backend), and CLI commands (user controls). These build on each other in sequence — the contract before the backends, the backends before the CLI — but they ship together because none delivers user value alone.
+
+**What ships:**
+
+*Integration layer (tts-integration):*
+- `tts` section in `config.json` with defaults (`enabled: false`, `backend: "auto"`, `voice: "default"`, `rate: 1.0`, `volume: 0.5`, `mode: "sound-then-speak"`)
+- Backend contract: `speak(text, voice, rate, volume)` → async fire-and-forget
+- `auto` backend resolution: detect available TTS engine, pick best for platform
+- Hook pipeline integration: after sound selection, if TTS enabled, resolve speech text and invoke backend
+- Speech text resolution: notification template for category → default template (`"{project} — {status}"`). The `speech_text` manifest field ships in Phase 2.
+- TTS respects all existing suppression rules: `headphones_only`, `suppress_sound_when_tab_focused`, pause/mute state
+- TTS mode config: `sound-then-speak` (default), `speak-only`, `speak-then-sound`
+
+*Platform-native backends (tts-native):*
+- macOS: `say -v {voice} -r {rate} --volume={volume} "{text}"` via `nohup ... &`
+- Windows: `System.Speech.Synthesis.SpeechSynthesizer` via `Start-Process` (detached, matching `win-play.ps1` pattern)
+- Linux: `espeak-ng` (fallback) → `piper` (preferred if installed, BYO) priority chain
+- Voice enumeration logic per platform for the voices command
+
+*CLI commands (tts-cli):*
+- `peon tts on`, `peon tts off`, `peon tts status`, `peon tts test`, `peon tts voices`, `peon tts voice {name}`, `peon tts backend {name}`
+- Shell completions (bash, fish) for all new subcommands
+- `peon status --verbose` shows TTS state
+
+*Testing:*
+- BATS tests (Unix) and Pester tests (Windows) for integration, backends, and CLI
+- `peon update` backfills `tts` config section for existing installs
+
+**Launch criteria:**
+- `peon tts on && peon tts test` speaks on macOS, Windows, and Linux (with espeak-ng)
+- Hook events trigger TTS after sound file with no measurable hook latency increase
+- `peon tts voices` enumerates available voices on each platform
+- `peon tts off` fully disables TTS with no residual behavior
+- All existing tests pass (no regressions in sound-only behavior)
+
+**Dependencies:**
+- None. The hook pipeline, config system, async playback pattern, and CLI framework all exist.
+
+### Phase 2: Spoken notifications, trainer reminders, and pack speech
+
+**Value statement:** Trainer reminders speak your exercise progress aloud, notification templates become audible, and pack authors can script dynamic spoken content — the peon tells you *what happened*, not just *that something happened*.
+
+This phase adds the dynamic content sources that make TTS genuinely useful beyond default templates. It builds on Phase 1's working TTS pipeline and CLI.
+
+**What ships:**
+
+*Notification template speech (tts-notifications):*
+- All five notification template categories (`stop`, `error`, `permission`, `idle`, `question`) spoken with full variable interpolation (`{project}`, `{summary}`, `{tool_name}`, `{status}`, `{event}`)
+- Missing variables render as empty strings (no `{undefined}` in speech)
+
+*Trainer spoken progress (tts-notifications):*
+- After trainer reminder sound, speak progress string ("75 of 300 pushups. 50 of 300 squats. 21 percent.")
+- Trainer slacking TTS: harsher spoken content when behind pace ("30 of 300 pushups. 10 percent. Pick it up.")
+
+*Pack manifest speech_text (tts-notifications):*
+- `speech_text` field in CESP manifest sound entries — optional template string with event variables
+- Speech text resolution chain updated: manifest `speech_text` → notification template → default template
+- Per-pack voice hint in manifest (`"tts_voice": "Alex"`) — advisory, user config overrides
+- At least one official pack (likely `peon`) updated with `speech_text` entries demonstrating the feature
+
+**Launch criteria:**
+- Trainer reminders with TTS enabled speak accurate rep counts and percentages
+- Pack with `speech_text` entries has dynamic text spoken after sound files
+- All five notification template categories produce correct spoken output
+- Missing template variables render as empty (no literal `{undefined}` in speech)
+
+**Dependencies:**
+- Phase 1 (working TTS pipeline, native backends, and CLI)
+
+### Phase 3: Documentation
+
+**Value statement:** Users and pack creators have complete guides for using and extending TTS, and the feature is discoverable from every documentation surface.
+
+Ships after Phases 1 and 2 so documentation covers the full feature including trainer speech, notification templates, and manifest `speech_text`.
+
+**What ships:**
+- README.md TTS section: setup, configuration, mode comparison, voice selection, troubleshooting
+- README_zh.md: Chinese translation of TTS section
+- `docs/public/llms.txt` updated with TTS context
+- `peon help` output updated with TTS commands
+- Pack author guide: how to add `speech_text` to manifests
+- Voice quality comparison per platform (managing expectations for espeak-ng vs. macOS Neural vs. SAPI5)
+
+**Dependencies:**
+- Phase 2 (spoken notifications, trainer, and manifest speech — so docs cover everything)
+
+## Technical Considerations
+
+### Platform-native TTS capabilities and constraints
+
+**macOS `say`:**
+- Ships on every macOS install since 10.0
+- 50+ voices, Siri Neural voices on macOS 14+ (dramatically better quality)
+- Async via `nohup say ... &` — matches existing `afplay` pattern
+- Rate: words per minute (default 175-200). Volume: 0.0-1.0 float
+- Gotcha: `say` writes to default audio output device. If `use_sound_effects_device` is enabled for pack sounds (routing to Sound Effects device via `peon-play.swift`), TTS needs the same routing or it goes to a different device. Phase 1 should document this — full device routing for TTS is a follow-up.
+
+**Windows `System.Speech.Synthesis`:**
+- Ships on every Windows 10/11 install
+- 2-3 built-in voices (David, Zira, Mark). More installable via Settings
+- Async via `SpeakAsync()` in the same `Start-Process -WindowStyle Hidden` pattern as `win-play.ps1`
+- Rate: -10 to 10 integer scale. Volume: 0-100 integer
+- Gotcha: PowerShell startup cost (~200ms) for `Start-Process`. Same cost as `win-play.ps1` — already budgeted in the hook timing.
+
+**Linux `espeak-ng` / `piper`:**
+- `espeak-ng`: available in apt/dnf/pacman. Robotic quality but universal. Rate: words per minute. Volume: 0-200 amplitude.
+- `piper`: Neural quality, C++ binary, ~50MB model download. Growing fast in the Linux TTS space (Rhasspy/Home Assistant ecosystem). If installed, dramatically better than espeak-ng.
+- Priority chain mirrors the existing audio backend chain (`pw-play` → `paplay` → `ffplay` → ...) — pick the best available.
+
+### Async playback contract
+
+TTS must follow the exact same async contract as sound playback:
+1. Fire-and-forget via background process (`nohup ... &` on Unix, `Start-Process` on Windows)
+2. PID tracked for kill-previous-sound behavior (`.sound.pid` or new `.tts.pid`)
+3. Safety timeout (8 seconds, matching `win-play.ps1`)
+4. No blocking of hook return under any circumstances
+5. `PEON_TEST=1` runs TTS synchronously for test capture
+
+### Config schema addition
+
+```json
+{
+  "tts": {
+    "enabled": false,
+    "backend": "auto",
+    "voice": "default",
+    "rate": 1.0,
+    "volume": 0.5,
+    "mode": "sound-then-speak"
+  }
+}
+```
+
+- `backend`: `"auto"` | `"native"` | (future: `"elevenlabs"`, `"openai"`, `"piper"`)
+- `voice`: `"default"` (platform default) or voice name string
+- `rate`: float multiplier, 1.0 = normal speed. Normalized per backend.
+- `volume`: float 0.0-1.0, normalized per backend (same pattern as main volume)
+- `mode`: `"sound-then-speak"` (default) | `"speak-only"` | `"speak-then-sound"`
+
+### Manifest schema extension
+
+```json
+{
+  "file": "sounds/task_complete/work_work.mp3",
+  "label": "Work, work.",
+  "speech_text": "{project} task complete. {summary}"
+}
+```
+
+- `speech_text`: optional string with template variables. When present and TTS enabled, spoken after (or instead of, per mode) the sound file.
+- Falls back to notification template → default template → no TTS if absent.
+- Template variables: same set as notification templates (`{project}`, `{summary}`, `{tool_name}`, `{status}`, `{event}`).
+
+### Debug logging integration
+
+The structured logging system (v2/m4) already covers all hook decision phases. TTS adds new log entries:
+- `[tts]` phase: backend resolution, voice selection, text interpolation, speak command, PID
+- Follows existing `[play]`, `[notify]`, `[trainer]` log format patterns
+- Zero overhead when debug disabled (same no-op pattern)
+
+### Observability
+
+- `peon tts status` shows current config, detected backend, active voice
+- `peon status --verbose` includes TTS state in its output
+- Debug logs capture every TTS decision (backend, voice, resolved text, command invoked, PID)
+- Failed TTS (backend not found, process error) logged at `[tts]` phase but never causes hook failure
+
+## Risks & Open Questions
+
+### Risks
+| Risk | Impact | Likelihood | Mitigation |
+|------|--------|------------|------------|
+| TTS quality too robotic on Linux (espeak-ng) | Users disable TTS after trying it once — poor first impression | Medium | Detect piper availability and prefer it. Document voice quality tiers in README. Don't oversell native quality. |
+| TTS latency adds perceived delay | Users feel peon-ping is slower even though hook return isn't blocked | Low | TTS fires in background. `sound-then-speak` mode means the immediate sound file plays instantly — TTS follows. User perceives responsiveness from the sound, information from TTS. |
+| Audio device routing mismatch | TTS speaks on different device than pack sounds (macOS Sound Effects device) | Medium | Phase 1 documents the limitation. Follow-up adds device routing for TTS (extend `peon-play.swift` or use `say -a` device flag). |
+| Pack authors don't adopt speech_text | Feature exists but no packs use it — community adoption stalls | Low | Ship at least one official pack (peon) with speech_text entries. Make speech_text optional so it doesn't burden pack authors who don't want it. Fallback to notification templates means TTS works without any manifest changes. |
+| Config migration complexity | Existing users need tts section backfilled on update | Low | Same pattern as every prior config addition — `peon update` merges new defaults. Runtime code uses `.get('tts', {})` with fallback defaults. Battle-tested pattern. |
+
+### Resolved Questions
+- **TTS volume is independent of main volume.** `tts.volume` is separate from the top-level `volume`. Users mixing character voice lines with system TTS voice will want different levels — pack sounds loud, TTS quiet, or vice versa.
+- **`speak-only` mode still fires desktop notifications.** Even when TTS replaces the sound file, desktop notifications still appear with the rendered template text. Audio and visual are different modalities serving different situations — a user may miss the spoken text but catch the popup, or vice versa.
+- **Piper is BYO on Linux.** Phase 1 treats piper as "use if already installed with a model." No auto-download of piper models. `peon tts on` detects piper if present, falls back to espeak-ng otherwise. Managed piper setup (model downloads, default model selection) can follow in a later phase. Note: primary development and testing happens on Windows and macOS — Linux TTS will be best-effort with CI validation on espeak-ng availability.
+
+## Related Documents
+
+- **v2/m5 "The peon speaks to you"** — parent roadmap milestone defining TTS features and success criteria
+- **[PRD-002: Hook Observability](PRD-002-hook-observability.md)** — structured logging (v2/m4) that TTS integrates with via `[tts]` log phase
+- **[Trainer mode design](../plans/2026-02-16-trainer-mode-design.md)** — trainer architecture that TTS extends with spoken progress
+- **[Notification templates design](../plans/2026-02-24-notification-templates-design.md)** — template system that TTS renders as speech
+- **Async audio and safe state on Windows** — the `Start-Process -WindowStyle Hidden` pattern, atomic state writes, and 8-second safety timeout established during the Windows native port; TTS backends inherit this pattern (see `scripts/win-play.ps1` and `peon.ps1` async invocation)
+- **[Structured hook logging design](../designs/structured-hook-logging.md)** — debug logging format TTS emits to
+- **[CESP v1.0 spec](https://github.com/PeonPing/openpeon)** — pack manifest schema that gains optional `speech_text` field
+
+---
+
+## Revision History
+
+| Date | Author | Notes |
+|------|--------|-------|
+| 2026-03-28 | cameron | Initial draft |
+| 2026-03-28 | cameron | Align delivery phases with updated roadmap sequencing; resolve speech_text Phase 1/2 contradiction; individual backends replace generic cloud/AI layers; resolve open questions (independent TTS volume, speak-only keeps notifications, piper BYO) |

--- a/peon.sh
+++ b/peon.sh
@@ -4912,7 +4912,7 @@ _relay_guidance() {
   fi
 }
 if [ "$EVENT" = "SessionStart" ] && { [ "$PEON_PLATFORM" = "devcontainer" ] || [ "$PEON_PLATFORM" = "ssh" ]; }; then
-  if [ "${PEON_TEST:-0}" = "1" ]; then
+  if [ "$_PEON_SYNC" = "true" ]; then
     _relay_guidance
   else
     _relay_guidance &

--- a/peon.sh
+++ b/peon.sh
@@ -1638,8 +1638,9 @@ print(f'peon-ping: label override set to "{label}"')
         _rc=$?; [ "$_rc" -ne 0 ] && exit "$_rc"
         sync_adapter_configs; exit 0 ;;
       marker)
-        MARKER_ARG="${3:-}"
-        if [ -z "$MARKER_ARG" ]; then
+        # Distinguish "no arg" (show current) from "explicit empty arg"
+        # (disable marker). `${3:-}` collapses both cases; use $# instead.
+        if [ "$#" -lt 3 ]; then
           python3 -c "
 import json, os
 config_path = os.environ.get('PEON_ENV_CONFIG', '')
@@ -1657,6 +1658,7 @@ except Exception:
 "
           exit 0
         fi
+        MARKER_ARG="$3"
         python3 -c "
 import json, sys, os
 config_path = os.environ.get('PEON_ENV_GLOBAL_CONFIG', '')

--- a/scripts/notify.sh
+++ b/scripts/notify.sh
@@ -298,7 +298,12 @@ case "$PEON_PLATFORM" in
           wait "$_last_wd" 2>/dev/null || true
         done
         rm -rf "$slot_dir/slot-$slot"
-        [ -n "$session_file" ] && rm -f "$session_file"
+        # Use `if` instead of `&&` so the subshell's exit code is 0 even
+        # when session_file is empty (the `[ -n "" ]` test returns 1,
+        # which would propagate as notify.sh's exit code).
+        if [ -n "$session_file" ]; then
+          rm -f "$session_file"
+        fi
       )
       if [ "$use_bg" = true ]; then _run_overlay & else _run_overlay; fi
     else

--- a/scripts/notify.sh
+++ b/scripts/notify.sh
@@ -258,6 +258,13 @@ case "$PEON_PLATFORM" in
         if [ "$all_screens" = "true" ]; then
           local screen_count
           screen_count=$(osascript -l JavaScript -e 'ObjC.import("Cocoa"); $.NSScreen.screens.count' 2>/dev/null || echo 1)
+          # Fall back to 1 if probe returned empty or non-numeric output
+          # (e.g. restricted Macs, test environments with mock osascript).
+          # Without this, `seq 0 -1` runs the overlay loop zero times and
+          # no notification displays.
+          if ! [[ "$screen_count" =~ ^[0-9]+$ ]] || [ "$screen_count" -lt 1 ]; then
+            screen_count=1
+          fi
           for _si in $(seq 0 $((screen_count - 1))); do
             osascript -l JavaScript "$overlay_script" "$msg" "$color" "$local_icon_arg" "$slot" "$dismiss_secs" "$bundle_id" "$ide_pid" "$session_tty" "$subtitle" "$notif_position" "$notify_type" "$all_screens" "$_si" "$close_button" >/dev/null 2>&1 &
             _overlay_pids="$_overlay_pids $!"
@@ -307,8 +314,8 @@ case "$PEON_PLATFORM" in
           ;;
         *)
           # Native macOS Notification Center (grouped by session, rich subtitle)
-          local notif_subtitle="${PEON_MSG_SUBTITLE:-}"
-          local notif_group="peon-ping-${PEON_SESSION_ID:-default}"
+          notif_subtitle="${PEON_MSG_SUBTITLE:-}"
+          notif_group="peon-ping-${PEON_SESSION_ID:-default}"
           if command -v terminal-notifier &>/dev/null; then
             tn_icon_flag=""
             [ -f "$icon_path" ] && tn_icon_flag="-appIcon $icon_path"

--- a/tests/adapters-windows.Tests.ps1
+++ b/tests/adapters-windows.Tests.ps1
@@ -734,8 +734,10 @@ Describe "win-play.ps1 Audio Backend" {
         $script:winPlayContent | Should -Match '\[double\]\$vol'
     }
 
-    It "uses MediaPlayer for WAV files with volume control" {
-        $script:winPlayContent | Should -Match '\.wav\$'
+    It "uses MediaPlayer for WAV/MP3/WMA files with volume control" {
+        # Extension regex must include wav; mp3 and wma are also routed to MediaPlayer
+        # since the WSL/WMA support was added (see the MediaPlayer block in win-play.ps1).
+        $script:winPlayContent | Should -Match '\.\(wav\|mp3\|wma\)\$'
         $script:winPlayContent | Should -Match 'PresentationCore'
         $script:winPlayContent | Should -Match 'System\.Windows\.Media\.MediaPlayer'
         $script:winPlayContent | Should -Match '\$player\.Volume = \$vol'

--- a/tests/peon-debug.Tests.ps1
+++ b/tests/peon-debug.Tests.ps1
@@ -35,18 +35,20 @@ Describe "win-play.ps1 PEON_DEBUG warnings" {
         }
     }
 
-    It "emits warning when no CLI player found for non-WAV file and PEON_DEBUG=1" {
+    It "emits warning when no CLI player found for exotic file and PEON_DEBUG=1" {
         $env:PEON_DEBUG = "1"
         try {
-            # Use a non-WAV extension to trigger the CLI player chain;
-            # mock all players unavailable by using a clean PATH
+            # Use an exotic extension (.ogg) that is NOT matched by the
+            # MediaPlayer regex (\.(wav|mp3|wma)$), so win-play.ps1 goes
+            # straight to the CLI player chain. Mock all players unavailable
+            # by using a clean PATH and nonexistent Program Files paths.
             $warnings = powershell -NoProfile -NonInteractive -Command "
                 `$env:PEON_DEBUG = '1'
                 `$env:PATH = 'C:\Windows\System32'
                 `$env:ProgramFiles = 'C:\nonexistent_programs'
                 `${env:ProgramFiles(x86)} = 'C:\nonexistent_programs_x86'
                 `$WarningPreference = 'Continue'
-                & '$($script:WinPlayPath)' -path 'C:\nonexistent\fake.mp3' -vol 0.5 3>&1
+                & '$($script:WinPlayPath)' -path 'C:\nonexistent\fake.ogg' -vol 0.5 3>&1
             "
             $warningText = ($warnings | Where-Object { $_ -is [System.Management.Automation.WarningRecord] -or ($_ -match 'no audio player found') }) -join "`n"
             $warningText | Should -Match "no audio player found"

--- a/tests/peon-security.Tests.ps1
+++ b/tests/peon-security.Tests.ps1
@@ -295,11 +295,15 @@ Describe "win-play.ps1: WAV/MP3 Branching and Player Chain" {
         # No log file also means ffplay was not called -- pass
     }
 
-    # Scenario 11: MP3 file tries ffplay first with correct volume
-    It "Scenario 11: MP3 file uses ffplay with volume = vol * 100" {
+    # Scenarios 11-16 exercise the CLI player fallback chain. They use .ogg
+    # (an "exotic" extension) because wav/mp3/wma are now handled by the
+    # MediaPlayer branch in win-play.ps1 and would never reach the CLI chain.
+
+    # Scenario 11: exotic file tries ffplay first with correct volume
+    It "Scenario 11: exotic file uses ffplay with volume = vol * 100" {
         script:New-MockPlayer -Name "ffplay" -Dir $script:mockDir -LogFile $script:mockLog
-        $mp3File = Join-Path $script:wpDir "test.mp3"
-        script:Invoke-WinPlay -AudioPath $mp3File -Vol 0.7 -MockPath "$($script:mockDir);$env:PATH" | Out-Null
+        $oggFile = Join-Path $script:wpDir "test.ogg"
+        script:Invoke-WinPlay -AudioPath $oggFile -Vol 0.7 -MockPath "$($script:mockDir);$env:PATH" | Out-Null
 
         Test-Path $script:mockLog | Should -Be $true
         $logContent = Get-Content $script:mockLog -Raw
@@ -311,8 +315,8 @@ Describe "win-play.ps1: WAV/MP3 Branching and Player Chain" {
     # Scenario 12: Volume boundary vol=0.0 -> ffplay -volume 0
     It "Scenario 12: Volume clamped to 0 for ffplay when vol=0.0" {
         script:New-MockPlayer -Name "ffplay" -Dir $script:mockDir -LogFile $script:mockLog
-        $mp3File = Join-Path $script:wpDir "test.mp3"
-        script:Invoke-WinPlay -AudioPath $mp3File -Vol 0.0 -MockPath "$($script:mockDir);$env:PATH" | Out-Null
+        $oggFile = Join-Path $script:wpDir "test.ogg"
+        script:Invoke-WinPlay -AudioPath $oggFile -Vol 0.0 -MockPath "$($script:mockDir);$env:PATH" | Out-Null
 
         $logContent = Get-Content $script:mockLog -Raw
         $logContent | Should -Match "-volume 0"
@@ -321,8 +325,8 @@ Describe "win-play.ps1: WAV/MP3 Branching and Player Chain" {
     # Scenario 13: Volume boundary vol=1.0 -> ffplay -volume 100
     It "Scenario 13: Volume clamped to 100 for ffplay when vol=1.0" {
         script:New-MockPlayer -Name "ffplay" -Dir $script:mockDir -LogFile $script:mockLog
-        $mp3File = Join-Path $script:wpDir "test.mp3"
-        script:Invoke-WinPlay -AudioPath $mp3File -Vol 1.0 -MockPath "$($script:mockDir);$env:PATH" | Out-Null
+        $oggFile = Join-Path $script:wpDir "test.ogg"
+        script:Invoke-WinPlay -AudioPath $oggFile -Vol 1.0 -MockPath "$($script:mockDir);$env:PATH" | Out-Null
 
         $logContent = Get-Content $script:mockLog -Raw
         $logContent | Should -Match "-volume 100"
@@ -331,9 +335,9 @@ Describe "win-play.ps1: WAV/MP3 Branching and Player Chain" {
     # Scenario 14: Falls through to mpv when ffplay not available
     It "Scenario 14: Falls through to mpv when no ffplay" {
         script:New-MockPlayer -Name "mpv" -Dir $script:mockDir -LogFile $script:mockLog
-        $mp3File = Join-Path $script:wpDir "test.mp3"
+        $oggFile = Join-Path $script:wpDir "test.ogg"
         # Only mock dir in PATH, so ffplay is not found
-        script:Invoke-WinPlay -AudioPath $mp3File -Vol 0.5 -MockPath $script:mockDir | Out-Null
+        script:Invoke-WinPlay -AudioPath $oggFile -Vol 0.5 -MockPath $script:mockDir | Out-Null
 
         Test-Path $script:mockLog | Should -Be $true
         $logContent = Get-Content $script:mockLog -Raw
@@ -344,8 +348,8 @@ Describe "win-play.ps1: WAV/MP3 Branching and Player Chain" {
     # Scenario 15: Falls through to vlc when ffplay and mpv not available
     It "Scenario 15: Falls through to vlc when no ffplay or mpv" {
         script:New-MockPlayer -Name "vlc" -Dir $script:mockDir -LogFile $script:mockLog
-        $mp3File = Join-Path $script:wpDir "test.mp3"
-        script:Invoke-WinPlay -AudioPath $mp3File -Vol 0.5 -MockPath $script:mockDir | Out-Null
+        $oggFile = Join-Path $script:wpDir "test.ogg"
+        script:Invoke-WinPlay -AudioPath $oggFile -Vol 0.5 -MockPath $script:mockDir | Out-Null
 
         Test-Path $script:mockLog | Should -Be $true
         $logContent = Get-Content $script:mockLog -Raw
@@ -356,9 +360,9 @@ Describe "win-play.ps1: WAV/MP3 Branching and Player Chain" {
 
     # Scenario 16: Exits silently when no player available
     It "Scenario 16: Exits silently when no player available" {
-        $mp3File = Join-Path $script:wpDir "test.mp3"
+        $oggFile = Join-Path $script:wpDir "test.ogg"
         # Only mock dir (empty) in PATH -- no players
-        $r = script:Invoke-WinPlay -AudioPath $mp3File -Vol 0.5 -MockPath $script:mockDir
+        $r = script:Invoke-WinPlay -AudioPath $oggFile -Vol 0.5 -MockPath $script:mockDir
         $r.ExitCode | Should -Be 0
         if ($r.Output) {
             ($r.Output -join "`n") | Should -Not -Match "(?i)error|exception"

--- a/tests/peon.bats
+++ b/tests/peon.bats
@@ -3237,10 +3237,19 @@ json.dump(m, open('$TEST_DIR/packs/peon/manifest.json', 'w'))
   run_peon '{"hook_event_name":"Stop","cwd":"/tmp/myproject","session_id":"s1","permission_mode":"default"}'
   [ "$PEON_EXIT" -eq 0 ]
   [ -f "$TEST_DIR/overlay.log" ]
-  # Fields from end: ... bundle_id ide_pid session_tty subtitle notif_position notify_type all_screens
-  # With awk (empty fields collapse): ... bundle_id ide_pid session_tty notif_position notify_type all_screens
-  # ide_pid is NF-4 (session_tty=NF-3, notif_position=NF-2, notify_type=NF-1, all_screens=NF)
-  ide_pid=$(tail -1 "$TEST_DIR/overlay.log" | awk '{print $(NF-4)}')
+  # Extract ide_pid using notif_position (\"top-center\") as an anchor, since
+  # it is always present and always non-empty. ide_pid is the field
+  # immediately before notif_position when bundle_id/session_tty/subtitle
+  # are empty (the default in a bare test environment). Using a positional
+  # NF-N index is too brittle against msg token count and optional-field
+  # collapsing by awk.
+  ide_pid=$(tail -1 "$TEST_DIR/overlay.log" | awk '
+    {
+      for (i = 1; i <= NF; i++) {
+        if ($i == "top-center") { print $(i-1); exit }
+      }
+    }
+  ')
   [[ "$ide_pid" =~ ^[0-9]+$ ]]
 }
 


### PR DESCRIPTION
Relands #470 after GitHub's mergeability state got stuck on \"unknown\" and the original PR branch on the contributor's fork was auto-deleted during a close/reopen recovery attempt. All commits here are the exact commits from #470 (cherry-picked as-is), authored by @muunkky (Cameron Rout).

Original PR body: https://github.com/PeonPing/peon-ping/pull/470

## Summary

Four real bug fixes plus the TTS architecture docs that should have shipped with #442.

### Code fixes
- `scripts/notify.sh`: `local` outside a function caused notify.sh to abort with `set -u` on every terminal that isn't iTerm2/kitty (Terminal.app, Warp, Ghostty, Zed, etc.) — removed `local`, variables become script-scoped.
- `scripts/notify.sh`: `screen_count` fallback only triggered on non-zero exit, not empty stdout — added numeric-and-≥1 validation so `seq 0 -1` never runs zero iterations.
- `scripts/notify.sh`: `_run_overlay` subshell's final `&&` returned exit code 1 when `session_file` was empty — replaced with `if/then`.
- `peon.sh`: `peon notifications marker \"\"` couldn't disable the marker because `${3:-}` collapsed \"unset\" and \"empty\" — switched to `[ \"$#\" -lt 3 ]`. **Behavior change**: `peon notifications marker \"\"` now disables the marker; use `peon notifications marker` (no arg) to show current.

### Pester test updates
Mechanical updates to match the MediaPlayer MP3/WMA routing change from #442. Seven tests in `adapters-windows.Tests.ps1`, `peon-debug.Tests.ps1`, `peon-security.Tests.ps1`.

### bats test harden
`tests/peon.bats` ide_pid extraction anchored on `notif_position` instead of a brittle `NF-N` index.

### Docs
Three design docs referenced in #442's PR body but never committed:
- `docs/adr/ADR-001-tts-backend-architecture.md` (Accepted)
- `docs/designs/tts-integration.md`
- `docs/prds/PRD-003-tts-spoken-feedback.md` (Draft)

## Verification
Both CI jobs went green on #470 (8m10s bats on macOS + 5m30s Pester on Windows), fixing 32 tests that were red on main. Same commits here.

---

Credit: @muunkky (Cameron Rout). See #470 for full original context.