### PR TITLE
support configuring exercises by day of the week

### DIFF
--- a/README.md
+++ b/README.md
@@ -548,8 +548,28 @@ Trainer reminders piggyback on your coding session. When you start a new session
 | `peon trainer off` | Disable trainer mode |
 | `peon trainer status` | Show today's progress |
 | `peon trainer log <n> <exercise>` | Log reps (e.g. `log 25 pushups`) |
-| `peon trainer goal <n>` | Set goal for all exercises |
-| `peon trainer goal <exercise> <n>` | Set goal for one exercise |
+| `peon trainer goal <n>` | Set uniform daily goal for all exercises |
+| `peon trainer goal <exercise> <n>` | Set uniform daily goal for one exercise |
+| `peon trainer goal <exercise> <day> <n>` | Set goal for specific day (mon, tue, etc.) |
+| `peon trainer goal <day> <n>` | Set all exercises for a specific day |
+
+### Schedule vs uniform goals
+
+Exercises can have either a **uniform daily goal** (same every day) or a **per-day schedule** (different goals on different days). These are mutually exclusive:
+
+- Setting a uniform goal removes any schedule for that exercise
+- Setting a day-specific goal removes any uniform goal for that exercise
+
+Days use short names: `mon`, `tue`, `wed`, `thu`, `fri`, `sat`, `sun`
+
+```bash
+peon trainer goal pushups 300         # 300 pushups every day (uniform)
+peon trainer goal pushups mon 400     # Override: 400 on Monday (creates schedule)
+peon trainer goal squats sun 0        # Rest day for squats on Sunday
+peon trainer goal fri 150             # Light day for all exercises on Friday
+```
+
+On rest days (goal=0), reminders are skipped and status shows `[REST DAY]`. You can still log reps on rest days if you want.
 
 ### Claude Code skill
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -472,8 +472,28 @@ peon trainer status          # 查看进度
 | `peon trainer off` | 禁用教练模式 |
 | `peon trainer status` | 显示今日进度 |
 | `peon trainer log <n> <exercise>` | 记录次数（例如 `log 25 pushups`） |
-| `peon trainer goal <n>` | 设置所有运动的目标 |
-| `peon trainer goal <exercise> <n>` | 设置单项运动的目标 |
+| `peon trainer goal <n>` | 设置所有运动的统一每日目标 |
+| `peon trainer goal <exercise> <n>` | 设置单项运动的统一每日目标 |
+| `peon trainer goal <exercise> <day> <n>` | 设置特定日期的目标（mon、tue 等） |
+| `peon trainer goal <day> <n>` | 设置某天所有运动的目标 |
+
+### 日程表与统一目标
+
+运动可以设置**统一每日目标**（每天相同）或**按日日程表**（不同日期不同目标）。两者互斥：
+
+- 设置统一目标会移除该运动的所有日程安排
+- 设置特定日期目标会移除该运动的统一目标
+
+日期使用缩写：`mon`、`tue`、`wed`、`thu`、`fri`、`sat`、`sun`
+
+```bash
+peon trainer goal pushups 300         # 每天 300 俯卧撑（统一目标）
+peon trainer goal pushups mon 400     # 覆盖：周一 400（创建日程表）
+peon trainer goal squats sun 0        # 周日深蹲休息
+peon trainer goal fri 150             # 周五所有运动轻松日
+```
+
+在休息日（目标=0），提醒会被跳过，状态显示 `[REST DAY]`。如果你愿意，仍然可以在休息日记录运动次数。
 
 ### Claude Code 技能
 

--- a/completions.bash
+++ b/completions.bash
@@ -84,12 +84,21 @@ _peon_completions() {
           COMPREPLY=( $(compgen -W "--all" -- "$cur") )
         fi
         return 0 ;;
+      trainer)
+        if [ "$cword" -eq 2 ]; then
+          COMPREPLY=( $(compgen -W "on off status log goal help" -- "$cur") )
+        elif [ "$cword" -ge 3 ] && [ "${words[2]}" = "goal" ]; then
+          # trainer goal completions: short weekday names
+          local weekdays="mon tue wed thu fri sat sun"
+          COMPREPLY=( $(compgen -W "$weekdays" -- "$cur") )
+        fi
+        return 0 ;;
     esac
     return 0
   fi
 
   # Top-level commands
-  COMPREPLY=( $(compgen -W "pause resume mute unmute toggle status volume rotation packs notifications mobile relay debug logs update help" -- "$cur") )
+  COMPREPLY=( $(compgen -W "pause resume mute unmute toggle status volume rotation packs notifications mobile relay debug logs trainer update help" -- "$cur") )
   return 0
 }
 

--- a/completions.fish
+++ b/completions.fish
@@ -37,6 +37,7 @@ complete -c peon -n __peon_no_subcommand -a mobile -d "Configure mobile push not
 complete -c peon -n __peon_no_subcommand -a debug -d "Toggle debug logging"
 complete -c peon -n __peon_no_subcommand -a logs -d "View or manage log files"
 complete -c peon -n __peon_no_subcommand -a relay -d "Start audio relay for devcontainers"
+complete -c peon -n __peon_no_subcommand -a trainer -d "Exercise trainer mode"
 complete -c peon -n __peon_no_subcommand -a update -d "Update peon-ping and refresh sound packs"
 complete -c peon -n __peon_no_subcommand -a help -d "Show help message"
 
@@ -165,3 +166,26 @@ complete -c peon -n "__peon_notif_subcommand label" -a reset -d "Clear label ove
 
 # logs --session --all (conditional: only after --session)
 complete -c peon -n "__peon_using_subcommand logs; and __fish_seen_argument -l session" -a "--all" -d "Search across all log files"
+
+# trainer subcommands
+complete -c peon -n "__peon_using_subcommand trainer" -a on -d "Enable trainer mode"
+complete -c peon -n "__peon_using_subcommand trainer" -a off -d "Disable trainer mode"
+complete -c peon -n "__peon_using_subcommand trainer" -a status -d "Show today's progress"
+complete -c peon -n "__peon_using_subcommand trainer" -a log -d "Log completed reps"
+complete -c peon -n "__peon_using_subcommand trainer" -a goal -d "Set exercise goals"
+complete -c peon -n "__peon_using_subcommand trainer" -a help -d "Show trainer help"
+
+# Helper: true when trainer goal subcommand is active
+function __peon_trainer_goal
+  set -l cmd (commandline -opc)
+  test (count $cmd) -ge 3; and test $cmd[2] = trainer; and test $cmd[3] = goal
+end
+
+# trainer goal weekday completions (short names)
+complete -c peon -n __peon_trainer_goal -a mon -d "Monday"
+complete -c peon -n __peon_trainer_goal -a tue -d "Tuesday"
+complete -c peon -n __peon_trainer_goal -a wed -d "Wednesday"
+complete -c peon -n __peon_trainer_goal -a thu -d "Thursday"
+complete -c peon -n __peon_trainer_goal -a fri -d "Friday"
+complete -c peon -n __peon_trainer_goal -a sat -d "Saturday"
+complete -c peon -n __peon_trainer_goal -a sun -d "Sunday"

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -145,7 +145,7 @@ peon debug on / off / status
 peon logs [--last N] [--session ID] [--clear]
 peon mobile ntfy <topic>
 peon relay --daemon
-peon trainer on / off / log / status
+peon trainer on / off / log / status / goal
 ```
 
 ## Debugging

--- a/peon.sh
+++ b/peon.sh
@@ -3394,6 +3394,26 @@ state_path = os.environ.get('PEON_ENV_STATE', '')
 
 ${_PEON_STATE_PY_HELPERS}
 
+WEEKDAY_ABBREV = {
+    'monday': 'mon', 'tuesday': 'tue', 'wednesday': 'wed',
+    'thursday': 'thu', 'friday': 'fri', 'saturday': 'sat', 'sunday': 'sun'
+}
+
+def resolve_goal(exercise, exercises, schedule, day_abbrev):
+    \"\"\"Resolve exercise goal: check schedule first, then uniform goal.\"\"\"
+    # Check schedule for this day
+    if day_abbrev in schedule and exercise in schedule[day_abbrev]:
+        return schedule[day_abbrev][exercise]
+    # Fall back to uniform daily goal
+    return exercises.get(exercise, 0)
+
+def get_all_exercises(exercises, schedule):
+    \"\"\"Get union of all exercises from both exercises and schedule.\"\"\"
+    all_ex = set(exercises.keys())
+    for day_goals in schedule.values():
+        all_ex.update(day_goals.keys())
+    return sorted(all_ex)
+
 try:
     cfg = json.load(open(config_path))
 except Exception:
@@ -3406,32 +3426,46 @@ if not trainer_cfg.get('enabled', False):
     sys.exit(0)
 
 exercises = trainer_cfg.get('exercises', {'pushups': 300, 'squats': 300})
+schedule = trainer_cfg.get('schedule', {})
+all_exercises = get_all_exercises(exercises, schedule)
 
 state = _read_state(state_path)
 
 trainer_state = state.get('trainer', {})
-today = datetime.date.today().isoformat()
+today = datetime.date.today()
+today_iso = today.isoformat()
+weekday_full = today.strftime('%A').lower()
+weekday_cap = today.strftime('%A')
+day_abbrev = WEEKDAY_ABBREV[weekday_full]
 
 # Auto-reset if date changed
-if trainer_state.get('date', '') != today:
-    trainer_state = {'date': today, 'reps': {k: 0 for k in exercises}, 'last_reminder_ts': 0}
+if trainer_state.get('date', '') != today_iso:
+    trainer_state = {'date': today_iso, 'reps': {k: 0 for k in all_exercises}, 'last_reminder_ts': 0}
     state['trainer'] = trainer_state
     _write_state(state, state_path, indent=2)
 
 reps = trainer_state.get('reps', {})
 
-print('peon-ping: trainer status (' + today + ')')
+print(f'peon-ping: trainer status ({today_iso}, {weekday_cap})')
 print('')
 
 bar_width = 16
-for ex, goal in exercises.items():
+for ex in all_exercises:
+    goal = resolve_goal(ex, exercises, schedule, day_abbrev)
     done = reps.get(ex, 0)
-    pct = min(done / goal, 1.0) if goal > 0 else 0
-    filled = int(pct * bar_width)
-    empty = bar_width - filled
-    bar = '\u2588' * filled + '\u2591' * empty
-    pct_str = str(int(pct * 100))
-    print(f'{ex}:  {bar}  {done}/{goal}  ({pct_str}%)')
+    if goal == 0:
+        # Rest day for this exercise
+        if done > 0:
+            print(f'{ex}:  [REST DAY] ({done} logged)')
+        else:
+            print(f'{ex}:  [REST DAY]')
+    else:
+        pct = min(done / goal, 1.0)
+        filled = int(pct * bar_width)
+        empty = bar_width - filled
+        bar = '\u2588' * filled + '\u2591' * empty
+        pct_str = str(int(pct * 100))
+        print(f'{ex}:  {bar}  {done}/{goal}  ({pct_str}%)')
 "
         exit 0 ;;
       log)
@@ -3457,6 +3491,24 @@ exercise = os.environ.get('EXERCISE', '')
 
 ${_PEON_STATE_PY_HELPERS}
 
+WEEKDAY_ABBREV = {
+    'monday': 'mon', 'tuesday': 'tue', 'wednesday': 'wed',
+    'thursday': 'thu', 'friday': 'fri', 'saturday': 'sat', 'sunday': 'sun'
+}
+
+def resolve_goal(ex, exercises, schedule, day_abbrev):
+    \"\"\"Resolve exercise goal: check schedule first, then uniform goal.\"\"\"
+    if day_abbrev in schedule and ex in schedule[day_abbrev]:
+        return schedule[day_abbrev][ex]
+    return exercises.get(ex, 0)
+
+def get_all_exercises(exercises, schedule):
+    \"\"\"Get union of all exercises from both exercises and schedule.\"\"\"
+    all_ex = set(exercises.keys())
+    for day_goals in schedule.values():
+        all_ex.update(day_goals.keys())
+    return sorted(all_ex)
+
 try:
     cfg = json.load(open(config_path))
 except Exception:
@@ -3464,57 +3516,115 @@ except Exception:
 
 trainer_cfg = cfg.get('trainer', {})
 exercises = trainer_cfg.get('exercises', {'pushups': 300, 'squats': 300})
+schedule = trainer_cfg.get('schedule', {})
+all_exercises = get_all_exercises(exercises, schedule)
 
-if exercise not in exercises:
+if exercise not in all_exercises:
     print('peon-ping: unknown exercise \"' + exercise + '\"', file=sys.stderr)
-    if exercises:
-        print('Known exercises: ' + ', '.join(exercises.keys()), file=sys.stderr)
+    if all_exercises:
+        print('Known exercises: ' + ', '.join(all_exercises), file=sys.stderr)
     print('Add it first: peon trainer goal ' + exercise + ' <daily-goal>', file=sys.stderr)
     sys.exit(1)
 
-goal = exercises[exercise]
+today = datetime.date.today()
+today_iso = today.isoformat()
+weekday_full = today.strftime('%A').lower()
+day_abbrev = WEEKDAY_ABBREV[weekday_full]
+goal = resolve_goal(exercise, exercises, schedule, day_abbrev)
 
 state = _read_state(state_path)
 
 trainer_state = state.get('trainer', {})
-today = datetime.date.today().isoformat()
 
 # Auto-reset if date changed
-if trainer_state.get('date', '') != today:
-    trainer_state = {'date': today, 'reps': {k: 0 for k in exercises}, 'last_reminder_ts': 0}
+if trainer_state.get('date', '') != today_iso:
+    trainer_state = {'date': today_iso, 'reps': {k: 0 for k in all_exercises}, 'last_reminder_ts': 0}
 
 reps = trainer_state.get('reps', {})
 reps[exercise] = reps.get(exercise, 0) + count
 trainer_state['reps'] = reps
-trainer_state['date'] = today
+trainer_state['date'] = today_iso
 state['trainer'] = trainer_state
 _write_state(state, state_path, indent=2)
 
 done = reps[exercise]
-pct = min(done / goal, 1.0) if goal > 0 else 0
-bar_width = 16
-filled = int(pct * bar_width)
-empty = bar_width - filled
-bar = '\u2588' * filled + '\u2591' * empty
-print(f'peon-ping: logged {count} {exercise} ({done}/{goal})')
-print(f'  {bar}  {int(pct*100)}%')
+
+if goal == 0:
+    # Rest day - allow logging but show info message
+    print(f'peon-ping: logged {count} {exercise} ({done} total)')
+    print(f'  (Today is a rest day for {exercise})')
+else:
+    pct = min(done / goal, 1.0)
+    bar_width = 16
+    filled = int(pct * bar_width)
+    empty = bar_width - filled
+    bar = '\u2588' * filled + '\u2591' * empty
+    print(f'peon-ping: logged {count} {exercise} ({done}/{goal})')
+    print(f'  {bar}  {int(pct*100)}%')
 "
         exit $? ;;
       goal)
         shift
         ARG1="${1:-}"
         ARG2="${2:-}"
+        ARG3="${3:-}"
         if [ -z "$ARG1" ]; then
-          echo "Usage: peon trainer goal <number>           Set all exercises" >&2
-          echo "       peon trainer goal <exercise> <number> Set one exercise" >&2
+          echo "Usage: peon trainer goal <number>                  Set all exercises (every day)" >&2
+          echo "       peon trainer goal <exercise> <number>       Set uniform daily goal" >&2
+          echo "       peon trainer goal <exercise> <weekday> <n>  Set goal for specific day" >&2
+          echo "       peon trainer goal <weekday> <number>        Set all exercises for that day" >&2
           exit 1
         fi
-        ARG1="$ARG1" ARG2="$ARG2" python3 -c "
+        ARG1="$ARG1" ARG2="$ARG2" ARG3="$ARG3" python3 -c "
 import json, sys, os
 
 config_path = os.environ.get('PEON_ENV_GLOBAL_CONFIG', '')
 arg1 = os.environ.get('ARG1', '')
 arg2 = os.environ.get('ARG2', '')
+arg3 = os.environ.get('ARG3', '')
+
+# Short weekday abbreviations
+WEEKDAYS = {'mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'}
+WEEKDAY_FULL = {
+    'monday': 'mon', 'tuesday': 'tue', 'wednesday': 'wed',
+    'thursday': 'thu', 'friday': 'fri', 'saturday': 'sat', 'sunday': 'sun'
+}
+
+def normalize_weekday(s):
+    \"\"\"Convert weekday input to short form (mon, tue, etc.).\"\"\"
+    s = s.lower()
+    if s in WEEKDAYS:
+        return s
+    if s in WEEKDAY_FULL:
+        return WEEKDAY_FULL[s]
+    return None
+
+def is_weekday(s):
+    return normalize_weekday(s) is not None
+
+def is_number(s):
+    try:
+        int(s)
+        return True
+    except ValueError:
+        return False
+
+def get_all_exercises(exercises, schedule):
+    \"\"\"Get union of all exercises from both exercises and schedule.\"\"\"
+    all_ex = set(exercises.keys())
+    for day_goals in schedule.values():
+        all_ex.update(day_goals.keys())
+    return sorted(all_ex)
+
+def remove_from_schedule(schedule, exercise):
+    \"\"\"Remove an exercise from all days in schedule.\"\"\"
+    for day in schedule:
+        if exercise in schedule[day]:
+            del schedule[day][exercise]
+    # Clean up empty days
+    empty_days = [d for d, goals in schedule.items() if not goals]
+    for d in empty_days:
+        del schedule[d]
 
 try:
     cfg = json.load(open(config_path))
@@ -3523,33 +3633,91 @@ except Exception:
 
 trainer = cfg.get('trainer', {})
 exercises = trainer.get('exercises', {'pushups': 300, 'squats': 300})
+schedule = trainer.get('schedule', {})
 
-if arg2:
-    # goal <exercise> <number>
+# Determine which form was used based on arguments
+if arg3:
+    # goal <exercise> <weekday> <n>
     exercise = arg1
+    day_abbrev = normalize_weekday(arg2)
+    if day_abbrev is None:
+        print(f'peon-ping: unknown weekday \"{arg2}\"', file=sys.stderr)
+        print('Valid weekdays: mon, tue, wed, thu, fri, sat, sun', file=sys.stderr)
+        sys.exit(1)
     try:
-        num = int(arg2)
+        num = int(arg3)
     except ValueError:
         print('peon-ping: goal must be a number', file=sys.stderr)
         sys.exit(1)
-    is_new = exercise not in exercises
-    exercises[exercise] = num
-    if is_new:
-        print(f'peon-ping: new exercise added — {exercise} goal set to {num}')
+
+    # Add to schedule
+    if day_abbrev not in schedule:
+        schedule[day_abbrev] = {}
+    schedule[day_abbrev][exercise] = num
+
+    # Remove from uniform exercises (mutual exclusion)
+    if exercise in exercises:
+        del exercises[exercise]
+        print(f'peon-ping: {exercise} {day_abbrev} goal set to {num} (removed uniform goal)')
     else:
-        print(f'peon-ping: {exercise} goal set to {num}')
+        print(f'peon-ping: {exercise} {day_abbrev} goal set to {num}')
+
+elif arg2:
+    if is_weekday(arg1) and is_number(arg2):
+        # goal <weekday> <n> — set all current exercises for that weekday
+        day_abbrev = normalize_weekday(arg1)
+        num = int(arg2)
+        all_ex = get_all_exercises(exercises, schedule)
+        if not all_ex:
+            print('peon-ping: no exercises configured', file=sys.stderr)
+            sys.exit(1)
+        if day_abbrev not in schedule:
+            schedule[day_abbrev] = {}
+        for ex in all_ex:
+            schedule[day_abbrev][ex] = num
+            # Remove from uniform exercises
+            if ex in exercises:
+                del exercises[ex]
+        print(f'peon-ping: all exercises on {day_abbrev} set to {num}')
+    elif is_number(arg2):
+        # goal <exercise> <n> — set uniform daily goal
+        exercise = arg1
+        num = int(arg2)
+        is_new = exercise not in get_all_exercises(exercises, schedule)
+
+        # Set uniform goal
+        exercises[exercise] = num
+
+        # Remove from schedule (mutual exclusion)
+        had_schedule = any(exercise in schedule.get(d, {}) for d in schedule)
+        remove_from_schedule(schedule, exercise)
+
+        if is_new:
+            print(f'peon-ping: new exercise added — {exercise} goal set to {num}')
+        elif had_schedule:
+            print(f'peon-ping: {exercise} goal set to {num} (cleared schedule)')
+        else:
+            print(f'peon-ping: {exercise} goal set to {num}')
+    else:
+        print('peon-ping: goal must be a number', file=sys.stderr)
+        sys.exit(1)
+
 else:
-    # goal <number>
+    # goal <n> — reset all exercises to uniform, clear schedule
     try:
         num = int(arg1)
     except ValueError:
         print('peon-ping: goal must be a number', file=sys.stderr)
         sys.exit(1)
-    for k in exercises:
-        exercises[k] = num
-    print(f'peon-ping: all exercise goals set to {num}')
+    all_ex = get_all_exercises(exercises, schedule)
+    if not all_ex:
+        all_ex = ['pushups', 'squats']  # Default if nothing configured
+    exercises = {ex: num for ex in all_ex}
+    schedule = {}  # Clear all schedules
+    print(f'peon-ping: all exercise goals set to {num} (cleared schedule)')
 
 trainer['exercises'] = exercises
+trainer['schedule'] = schedule
 cfg['trainer'] = trainer
 json.dump(cfg, open(config_path, 'w'), indent=2)
 "
@@ -3563,11 +3731,28 @@ Commands:
   off                  Disable trainer mode
   status               Show today's progress
   log <count> <exercise>  Log completed reps (e.g. log 25 pushups)
-  goal <number>        Set daily goal for all exercises
-  goal <exercise> <n>  Set daily goal for one exercise
+  goal <number>        Set daily goal for all exercises (uniform)
+  goal <exercise> <n>  Set uniform daily goal for one exercise
+  goal <exercise> <day> <n>  Set goal for specific day of week
+  goal <day> <n>       Set all exercises for a specific day
   help                 Show this help
 
-Exercises: pushups, squats
+Schedule vs Uniform Goals:
+  Exercises can have either a uniform daily goal OR a per-day schedule.
+  Setting a uniform goal removes any schedule for that exercise.
+  Setting a day-specific goal removes any uniform goal.
+
+  Days: mon, tue, wed, thu, fri, sat, sun
+
+  Examples:
+    peon trainer goal pushups 300         # 300 pushups every day
+    peon trainer goal pushups mon 400     # Override: 400 on Monday
+    peon trainer goal squats sun 0        # Rest day for squats on Sunday
+    peon trainer goal fri 150             # Light day for all exercises
+
+  On rest days (goal=0), reminders are skipped and status shows "[REST DAY]".
+
+Exercises: pushups, squats (add more with goal <name> <n>)
 TRAINER_HELP
         exit 0 ;;
     esac ;;
@@ -4519,17 +4704,48 @@ trainer_sound = ''
 trainer_msg = ''
 trainer_cfg = cfg.get('trainer', {})
 if trainer_cfg.get('enabled', False):
+    import datetime
     from datetime import date as _date
     today = _date.today().isoformat()
+    weekday_full = _date.today().strftime('%A').lower()
+    _weekday_abbrev = {
+        'monday': 'mon', 'tuesday': 'tue', 'wednesday': 'wed',
+        'thursday': 'thu', 'friday': 'fri', 'saturday': 'sat', 'sunday': 'sun'
+    }
+    day_abbrev = _weekday_abbrev[weekday_full]
+
+    def resolve_goal(ex, exercises, schedule, day):
+        # Check schedule first, then uniform goal
+        if day in schedule and ex in schedule[day]:
+            return schedule[day][ex]
+        return exercises.get(ex, 0)
+
+    def get_all_exercises(exercises, schedule):
+        all_ex = set(exercises.keys())
+        for dg in schedule.values():
+            all_ex.update(dg.keys())
+        return sorted(all_ex)
+
     trainer_state = state.get('trainer', {})
     _default_ex = dict(pushups=300, squats=300)
-    if trainer_state.get('date') != today:
-        exercises = trainer_cfg.get('exercises', _default_ex)
-        trainer_state = dict(date=today, reps=dict.fromkeys(exercises, 0), last_reminder_ts=0)
     exercises = trainer_cfg.get('exercises', _default_ex)
+    schedule = trainer_cfg.get('schedule', {})
+    all_exercises = get_all_exercises(exercises, schedule)
+    if trainer_state.get('date') != today:
+        trainer_state = dict(date=today, reps=dict.fromkeys(all_exercises, 0), last_reminder_ts=0)
     reps = trainer_state.get('reps', {})
-    all_done = all(reps.get(ex, 0) >= goal for ex, goal in exercises.items())
-    if not all_done:
+    # Resolve goals for today
+    resolved_goals = {}
+    for ex in all_exercises:
+        resolved_goals[ex] = resolve_goal(ex, exercises, schedule, day_abbrev)
+    # Check if all exercises with goal > 0 are done
+    active_exercises = {}
+    for ex, g in resolved_goals.items():
+        if g > 0:
+            active_exercises[ex] = g
+    all_done = all(reps.get(ex, 0) >= goal for ex, goal in active_exercises.items()) if active_exercises else True
+    # Skip reminder if all goals are 0 (full rest day)
+    if not all_done and active_exercises:
         now_ts = time.time()
         last_ts = trainer_state.get('last_reminder_ts', 0)
         interval = trainer_cfg.get('reminder_interval_minutes', 20) * 60
@@ -4543,10 +4759,9 @@ if trainer_cfg.get('enabled', False):
                 if is_session_start:
                     tcat = 'trainer.session_start'
                 else:
-                    import datetime
                     hour = datetime.datetime.now().hour
-                    total_reps = sum(reps.get(ex, 0) for ex in exercises)
-                    total_goal = sum(exercises.values())
+                    total_reps = sum(reps.get(ex, 0) for ex in active_exercises)
+                    total_goal = sum(active_exercises.values())
                     pct = total_reps / total_goal if total_goal > 0 else 1.0
                     if hour >= 12 and pct < 0.25:
                         tcat = 'trainer.slacking'
@@ -4559,9 +4774,10 @@ if trainer_cfg.get('enabled', False):
                     if os.path.isfile(sfile):
                         trainer_sound = sfile
                         parts = []
-                        for ex, goal in exercises.items():
-                            done = reps.get(ex, 0)
-                            parts.append(f'{ex}: {done}/{goal}')
+                        for ex, goal in resolved_goals.items():
+                            if goal > 0:
+                                done = reps.get(ex, 0)
+                                parts.append(f'{ex}: {done}/{goal}')
                         trainer_msg = ' | '.join(parts)
             except Exception:
                 pass

--- a/tests/trainer.bats
+++ b/tests/trainer.bats
@@ -287,3 +287,148 @@ json.dump(s, open('$TEST_DIR/.state.json', 'w'))
   count=$(afplay_call_count)
   [ "$count" = "1" ]
 }
+
+# ============================================================
+# Day-specific schedule goals
+# ============================================================
+
+@test "trainer goal sets day-specific goal in schedule" {
+  bash "$PEON_SH" trainer on
+  run bash "$PEON_SH" trainer goal pushups mon 400
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"mon"* ]]
+  [[ "$output" == *"400"* ]]
+
+  # Verify schedule structure
+  mon_goal=$(python3 -c "import json; c=json.load(open('$TEST_DIR/config.json')); s=c.get('trainer',{}).get('schedule',{}); print(s.get('mon',{}).get('pushups',0))")
+  [ "$mon_goal" = "400" ]
+
+  # Pushups should be removed from uniform exercises (mutual exclusion)
+  in_exercises=$(python3 -c "import json; c=json.load(open('$TEST_DIR/config.json')); print('pushups' in c.get('trainer',{}).get('exercises',{}))")
+  [ "$in_exercises" = "False" ]
+}
+
+@test "trainer goal accepts full weekday names" {
+  bash "$PEON_SH" trainer on
+  run bash "$PEON_SH" trainer goal pushups monday 400
+  [ "$status" -eq 0 ]
+
+  # Should be stored with short name
+  mon_goal=$(python3 -c "import json; c=json.load(open('$TEST_DIR/config.json')); s=c.get('trainer',{}).get('schedule',{}); print(s.get('mon',{}).get('pushups',0))")
+  [ "$mon_goal" = "400" ]
+}
+
+@test "trainer uniform goal removes exercise from schedule" {
+  bash "$PEON_SH" trainer on
+  # First set day-specific goals
+  bash "$PEON_SH" trainer goal pushups mon 400
+  bash "$PEON_SH" trainer goal pushups sun 0
+  # Then reset to uniform goal
+  run bash "$PEON_SH" trainer goal pushups 250
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"250"* ]]
+  [[ "$output" == *"cleared schedule"* ]]
+
+  # Verify pushups is in exercises as simple int
+  goal=$(python3 -c "import json; c=json.load(open('$TEST_DIR/config.json')); print(c.get('trainer',{}).get('exercises',{}).get('pushups',0))")
+  [ "$goal" = "250" ]
+
+  # Verify pushups is NOT in schedule
+  in_schedule=$(python3 -c "import json; c=json.load(open('$TEST_DIR/config.json')); s=c.get('trainer',{}).get('schedule',{}); print(any('pushups' in d for d in s.values()))")
+  [ "$in_schedule" = "False" ]
+}
+
+@test "trainer goal <weekday> <n> sets all exercises for that day" {
+  bash "$PEON_SH" trainer on
+  run bash "$PEON_SH" trainer goal fri 150
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"fri"* ]]
+  [[ "$output" == *"150"* ]]
+
+  pushups_fri=$(python3 -c "import json; c=json.load(open('$TEST_DIR/config.json')); s=c.get('trainer',{}).get('schedule',{}); print(s.get('fri',{}).get('pushups',0))")
+  squats_fri=$(python3 -c "import json; c=json.load(open('$TEST_DIR/config.json')); s=c.get('trainer',{}).get('schedule',{}); print(s.get('fri',{}).get('squats',0))")
+  [ "$pushups_fri" = "150" ]
+  [ "$squats_fri" = "150" ]
+}
+
+@test "trainer status shows REST DAY for goal=0" {
+  bash "$PEON_SH" trainer on
+  # Get current weekday abbreviation
+  weekday=$(python3 -c "import datetime; d={'monday':'mon','tuesday':'tue','wednesday':'wed','thursday':'thu','friday':'fri','saturday':'sat','sunday':'sun'}; print(d[datetime.date.today().strftime('%A').lower()])")
+  # Set current weekday to rest day
+  bash "$PEON_SH" trainer goal pushups "$weekday" 0
+
+  run bash "$PEON_SH" trainer status
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"REST DAY"* ]]
+}
+
+@test "trainer status shows weekday in header" {
+  bash "$PEON_SH" trainer on
+  run bash "$PEON_SH" trainer status
+  [ "$status" -eq 0 ]
+  # Output should contain the weekday name (capitalized)
+  weekday_cap=$(python3 -c "import datetime; print(datetime.date.today().strftime('%A'))")
+  [[ "$output" == *"$weekday_cap"* ]]
+}
+
+@test "trainer log shows rest day message when goal=0" {
+  bash "$PEON_SH" trainer on
+  weekday=$(python3 -c "import datetime; d={'monday':'mon','tuesday':'tue','wednesday':'wed','thursday':'thu','friday':'fri','saturday':'sat','sunday':'sun'}; print(d[datetime.date.today().strftime('%A').lower()])")
+  bash "$PEON_SH" trainer goal pushups "$weekday" 0
+
+  run bash "$PEON_SH" trainer log 10 pushups
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"rest day"* ]]
+}
+
+@test "trainer log accumulates reps on rest day" {
+  bash "$PEON_SH" trainer on
+  weekday=$(python3 -c "import datetime; d={'monday':'mon','tuesday':'tue','wednesday':'wed','thursday':'thu','friday':'fri','saturday':'sat','sunday':'sun'}; print(d[datetime.date.today().strftime('%A').lower()])")
+  bash "$PEON_SH" trainer goal pushups "$weekday" 0
+
+  bash "$PEON_SH" trainer log 10 pushups
+  run bash "$PEON_SH" trainer log 15 pushups
+  [ "$status" -eq 0 ]
+
+  reps=$(python3 -c "import json; s=json.load(open('$TEST_DIR/.state.json')); print(s.get('trainer',{}).get('reps',{}).get('pushups',0))")
+  [ "$reps" = "25" ]
+}
+
+@test "hook skips trainer reminder on full rest day" {
+  bash "$PEON_SH" trainer on
+  weekday=$(python3 -c "import datetime; d={'monday':'mon','tuesday':'tue','wednesday':'wed','thursday':'thu','friday':'fri','saturday':'sat','sunday':'sun'}; print(d[datetime.date.today().strftime('%A').lower()])")
+  # Set both exercises to rest day
+  bash "$PEON_SH" trainer goal pushups "$weekday" 0
+  bash "$PEON_SH" trainer goal squats "$weekday" 0
+
+  python3 -c "
+import json, time
+s = json.load(open('$TEST_DIR/.state.json'))
+s['trainer'] = {'date': '$(date +%Y-%m-%d)', 'reps': {'pushups': 0, 'squats': 0}, 'last_reminder_ts': int(time.time()) - 3600}
+json.dump(s, open('$TEST_DIR/.state.json', 'w'))
+"
+  run_peon '{"hook_event_name":"Stop","cwd":"/tmp/myproject","session_id":"s1","permission_mode":"default"}'
+  [ "$PEON_EXIT" -eq 0 ]
+  # Only 1 sound (main event), no trainer reminder
+  count=$(afplay_call_count)
+  [ "$count" = "1" ]
+}
+
+@test "trainer backwards compatibility with simple integer goals" {
+  bash "$PEON_SH" trainer on
+  # Set simple integer goals
+  bash "$PEON_SH" trainer goal pushups 200
+  bash "$PEON_SH" trainer goal squats 150
+
+  # Status should work
+  run bash "$PEON_SH" trainer status
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"200"* ]]
+  [[ "$output" == *"150"* ]]
+
+  # Log should work
+  run bash "$PEON_SH" trainer log 50 pushups
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"50/200"* ]]
+}


### PR DESCRIPTION
This was done in a backwards-compatible manner, meaning
you can still use the old uniform (same every day) config, or
you can specify a schedule:

{
     "trainer": {
          "exercises": { "pushups": 300, "squats": 300 },
          // or
          "schedule": {
               "mon": { "pushups": 400 },
               "sun": { "squats": 0 }
          }
     }
}

At run-time, the schedule value for an exercise is prioritized over any value
for it that might be in the "exercises" object, in the case that both are in the
JSON config. However, from the command line if you set a schedule for
an exercise, then its uniform goal is removed, and vice versa if a uniform goal
is set.

Uses short weekday names: mon, tue, wed, thu, fri, sat, sun (full names like "monday" are also accepted and normalized)

All 28 trainer tests pass. There are some others that fail on my machine, but they're not anything that I touched as far as I can tell.

This was done with Claude. The agent got into some kind of forever-failing
loop related to some Python code getting messed up when piped into the
shell, so I ended up removing two usages of dictionary comprehensions to
get around that.

Fixes #323.