### PR TITLE
fix: populate summary template from hook payload fallbacks

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -598,6 +598,26 @@ function Resolve-NotificationTemplate {
     return $rendered
 }
 
+function Resolve-TemplateSummary {
+    param([object]$Event)
+
+    foreach ($key in @('last_assistant_message', 'last-assistant-message', 'prompt_response', 'transcript_summary', 'message')) {
+        $prop = $Event.PSObject.Properties[$key]
+        if ($prop) {
+            $value = [string]$prop.Value
+            if ($value) {
+                $value = $value.Trim()
+                if ($value) {
+                    if ($value.Length -gt 120) { return $value.Substring(0, 120) }
+                    return $value
+                }
+            }
+        }
+    }
+
+    return ''
+}
+
 # --- TTS backend resolution ---
 function Resolve-TtsBackend {
     param([string]$Backend = "auto")
@@ -2181,7 +2201,7 @@ $resolvedTemplate = ""
 if ($category) {
     $tplCfg0 = $config.notification_templates
     if ($tplCfg0) {
-        $tplSum0 = if ($event.transcript_summary) { [string]$event.transcript_summary } else { '' }
+        $tplSum0 = Resolve-TemplateSummary $event
         $tplTool0 = if ($event.tool_name) { [string]$event.tool_name } else { '' }
         $resolvedTemplate = Resolve-NotificationTemplate `
             -Templates $tplCfg0 `
@@ -2384,8 +2404,7 @@ if ($ttsEnabled -and $category) {
     # rendering block (~lines 1710-1725). Intentional for now to keep TTS text
     # resolution self-contained. If this area is touched again, consolidate into
     # a shared $tplVars hashtable built once and reused by both paths.
-    $tplSummary = if ($event.transcript_summary) { [string]$event.transcript_summary } else { '' }
-    if ($tplSummary -and $tplSummary.Length -gt 120) { $tplSummary = $tplSummary.Substring(0, 120) }
+    $tplSummary = Resolve-TemplateSummary $event
     $tplToolName = if ($event.tool_name) { [string]$event.tool_name } else { '' }
     $ttsVars = @{
         project   = $project
@@ -2595,7 +2614,7 @@ if ($trainerMsg) {
 if ($notify) {
     $tplCfg = $config.notification_templates
     if ($tplCfg) {
-        $tplSummary = if ($event.transcript_summary) { [string]$event.transcript_summary } else { '' }
+        $tplSummary = Resolve-TemplateSummary $event
         $tplToolName = if ($event.tool_name) { [string]$event.tool_name } else { '' }
         $resolved = Resolve-NotificationTemplate `
             -Templates $tplCfg `
@@ -2648,7 +2667,7 @@ if ($ttsEnabled -and $category) {
     # Interpolate template variables (same set as notification templates)
     $ttsVars = @{
         project   = $project
-        summary   = if ($event.transcript_summary) { [string]$event.transcript_summary } else { '' }
+        summary   = Resolve-TemplateSummary $event
         tool_name = if ($event.tool_name) { [string]$event.tool_name } else { '' }
         status    = $notifyStatus
         event     = $hookEvent

--- a/peon.sh
+++ b/peon.sh
@@ -4834,6 +4834,21 @@ if tab_color_enabled:
 
 # --- Notification message template resolution ---
 from collections import defaultdict as _defaultdict
+def _template_summary(d):
+    for key in (
+        'last_assistant_message',
+        'last-assistant-message',
+        'prompt_response',
+        'transcript_summary',
+        'message',
+    ):
+        value = d.get(key, '')
+        if isinstance(value, str):
+            value = value.strip()
+            if value:
+                return value[:120]
+    return ''
+
 _templates = cfg.get('notification_templates', {})
 _tpl_key_map = {
     'task.complete': 'stop',
@@ -4848,7 +4863,7 @@ elif event == 'PermissionRequest':
 _tpl = _templates.get(_tpl_key, '')
 _tpl_vars = _defaultdict(str, {
     'project': project,
-    'summary': event_data.get('transcript_summary', '').strip()[:120],
+    'summary': _template_summary(event_data),
     'tool_name': event_data.get('tool_name', ''),
     'status': status,
     'event': event,

--- a/tests/peon.bats
+++ b/tests/peon.bats
@@ -4438,6 +4438,46 @@ json.dump(cfg, open('$TEST_DIR/config.json', 'w'))
   [ "$tts_text" = "myproject is done" ]
 }
 
+@test "TTS: stop template summary falls back to last_assistant_message" {
+  /usr/bin/python3 -c "
+import json
+cfg = json.load(open('$TEST_DIR/config.json'))
+cfg['tts'] = {'enabled': True}
+cfg['notification_templates'] = {'stop': '{summary}'}
+json.dump(cfg, open('$TEST_DIR/config.json', 'w'))
+"
+  run_peon '{"hook_event_name":"Stop","cwd":"/tmp/myproject","session_id":"s1","last_assistant_message":"Fixed the hook payload fallback"}'
+  [ "$PEON_EXIT" -eq 0 ]
+  tts_text=$(cat "$TEST_DIR/.tts_text")
+  [ "$tts_text" = "Fixed the hook payload fallback" ]
+}
+
+@test "TTS: stop template summary falls back to codex payload field" {
+  /usr/bin/python3 -c "
+import json
+cfg = json.load(open('$TEST_DIR/config.json'))
+cfg['tts'] = {'enabled': True}
+cfg['notification_templates'] = {'stop': '{summary}'}
+json.dump(cfg, open('$TEST_DIR/config.json', 'w'))
+"
+  run_peon '{"hook_event_name":"Stop","cwd":"/tmp/myproject","session_id":"codex-stop","last-assistant-message":"Codex says the branch is ready"}'
+  [ "$PEON_EXIT" -eq 0 ]
+  [ "$(cat "$TEST_DIR/.tts_text")" = "Codex says the branch is ready" ]
+}
+
+@test "TTS: stop template summary falls back to gemini payload field" {
+  /usr/bin/python3 -c "
+import json
+cfg = json.load(open('$TEST_DIR/config.json'))
+cfg['tts'] = {'enabled': True}
+cfg['notification_templates'] = {'stop': '{summary}'}
+json.dump(cfg, open('$TEST_DIR/config.json', 'w'))
+"
+  run_peon '{"hook_event_name":"Stop","cwd":"/tmp/myproject","session_id":"gemini-stop","prompt_response":"Gemini says the branch is ready"}'
+  [ "$PEON_EXIT" -eq 0 ]
+  [ "$(cat "$TEST_DIR/.tts_text")" = "Gemini says the branch is ready" ]
+}
+
 @test "TTS: falls back to default template when no notification template" {
   # Enable TTS but no notification templates
   /usr/bin/python3 -c "


### PR DESCRIPTION
Fixes #476

## Summary
- populate `{summary}` from common hook payload fallback fields used by Claude, Codex, Gemini, and notification events
- reuse the same fallback order in the Windows hook path so templates behave the same cross-platform
- add regression coverage for the Claude, Codex, and Gemini stop payload variants

## Testing
- `bats tests/peon.bats -f 'TTS:'` (via temporary local bats-core install)
