### PR TITLE
fix(nix): add optional Claude Code hook setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ in {
   programs.peon-ping = {
     enable = true;
     package = inputs.peon-ping.packages.${pkgs.system}.default;
+    claudeCodeIntegration = true;
 
     settings = {
       default_pack = "glados";
@@ -169,7 +170,7 @@ in {
     enableZshIntegration = true;
   };
 
-  # Cursor hooks
+  # Optional extra IDE hooks, like Cursor
   home.file.".cursor/hooks.json".text = builtins.toJSON {
     version = 1;
     hooks = {
@@ -197,13 +198,13 @@ For packs listed on [openpeon.com](https://openpeon.com/), find the GitHub repos
 }
 ```
 
-**IDE hooks**: peon-ping Home Manager module will not setup your IDE hooks to avoid conflicting updates. You must define these hooks yourself (see example above) depending on how you usually manage your IDE configuration.
-- peon-ping provide adapters scripts for various IDE such as `cursor.sh` - see [`adapters/`](https://github.com/PeonPing/peon-ping/tree/main/adapters)
-- You need to call them as your hook such command like
+**Claude Code hooks**: set `programs.peon-ping.claudeCodeIntegration = true;` to install the Claude Code hook scripts under `~/.claude/hooks/peon-ping/` and merge the standard peon-ping hook entries into `~/.claude/settings.json`.
+
+**Other IDE hooks**: adapters for other IDEs are still opt-in so the module does not overwrite unrelated IDE settings. peon-ping provides adapter scripts such as `cursor.sh` in [`adapters/`](https://github.com/PeonPing/peon-ping/tree/main/adapters), and you can wire them like this:
   ```sh
   ${inputs.peon-ping.packages.${pkgs.system}.default}/share/peon-ping/adapters/$YOUR_IDE.sh EVENT_NAME
   ```
-  See Cursor example above
+  See the Cursor example above.
 
 ## What you'll hear
 

--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -5,6 +5,7 @@ with lib;
 let
   cfg = config.programs.peon-ping;
   jsonFormat = pkgs.formats.json { };
+  claudeHooksJsonFormat = pkgs.formats.json { };
 
   ogPacksVersion = "1.4.0";
 
@@ -118,6 +119,15 @@ in
         Whether to enable Bash completions and alias.
       '';
     };
+
+    claudeCodeIntegration = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Whether to install Claude Code hook files under ~/.claude/hooks/peon-ping
+        and merge peon-ping hook registrations into ~/.claude/settings.json.
+      '';
+    };
   };
 
   config = mkIf cfg.enable {
@@ -140,6 +150,110 @@ in
     # Create the config file at the location peon-ping expects.
     # Overrides any config.json that may be present in the package.
     home.file.".openpeon/config.json".source = jsonFormat.generate "peon-ping-config" cfg.settings;
+
+    home.file = mkIf cfg.claudeCodeIntegration {
+      ".claude/hooks/peon-ping/peon.sh".source = "${cfg.package}/bin/peon";
+      ".claude/hooks/peon-ping/scripts/hook-handle-use.sh".source = "${cfg.package}/share/peon-ping/scripts/hook-handle-use.sh";
+      ".claude/hooks/peon-ping/scripts/hook-handle-rename.sh".source = "${cfg.package}/share/peon-ping/scripts/hook-handle-rename.sh";
+    };
+
+    home.activation.peonPingClaudeCodeHooks = mkIf cfg.claudeCodeIntegration (lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+      hooks_json='${claudeHooksJsonFormat.generate "peon-claude-hooks" {
+        hooks = {
+          SessionStart = [{
+            matcher = "";
+            hooks = [{
+              type = "command";
+              command = "${config.home.homeDirectory}/.claude/hooks/peon-ping/peon.sh";
+              timeout = 10;
+            }];
+          }];
+          SessionEnd = [{
+            matcher = "";
+            hooks = [{ type = "command"; command = "${config.home.homeDirectory}/.claude/hooks/peon-ping/peon.sh"; timeout = 10; async = true; }];
+          }];
+          SubagentStart = [{
+            matcher = "";
+            hooks = [{ type = "command"; command = "${config.home.homeDirectory}/.claude/hooks/peon-ping/peon.sh"; timeout = 10; async = true; }];
+          }];
+          UserPromptSubmit = [
+            {
+              matcher = "";
+              hooks = [{ type = "command"; command = "${config.home.homeDirectory}/.claude/hooks/peon-ping/peon.sh"; timeout = 10; async = true; }];
+            }
+            {
+              matcher = "";
+              hooks = [
+                { type = "command"; command = "${config.home.homeDirectory}/.claude/hooks/peon-ping/scripts/hook-handle-use.sh"; timeout = 5; }
+                { type = "command"; command = "${config.home.homeDirectory}/.claude/hooks/peon-ping/scripts/hook-handle-rename.sh"; timeout = 5; }
+              ];
+            }
+          ];
+          Stop = [{
+            matcher = "";
+            hooks = [{ type = "command"; command = "${config.home.homeDirectory}/.claude/hooks/peon-ping/peon.sh"; timeout = 10; async = true; }];
+          }];
+          Notification = [{
+            matcher = "";
+            hooks = [{ type = "command"; command = "${config.home.homeDirectory}/.claude/hooks/peon-ping/peon.sh"; timeout = 10; async = true; }];
+          }];
+          PermissionRequest = [{
+            matcher = "";
+            hooks = [{ type = "command"; command = "${config.home.homeDirectory}/.claude/hooks/peon-ping/peon.sh"; timeout = 10; async = true; }];
+          }];
+          PostToolUseFailure = [{
+            matcher = "Bash";
+            hooks = [{ type = "command"; command = "${config.home.homeDirectory}/.claude/hooks/peon-ping/peon.sh"; timeout = 10; async = true; }];
+          }];
+          PreCompact = [{
+            matcher = "";
+            hooks = [{ type = "command"; command = "${config.home.homeDirectory}/.claude/hooks/peon-ping/peon.sh"; timeout = 10; async = true; }];
+          }];
+        };
+      }}'
+
+      settings_path="$HOME/.claude/settings.json"
+      mkdir -p "$(dirname "$settings_path")"
+
+      ${pkgs.python3}/bin/python3 - "$settings_path" "$hooks_json" <<'PY'
+import json
+import pathlib
+import sys
+
+settings_path = pathlib.Path(sys.argv[1]).expanduser()
+hooks_path = pathlib.Path(sys.argv[2])
+
+if settings_path.exists():
+    settings = json.loads(settings_path.read_text())
+else:
+    settings = {}
+
+incoming = json.loads(hooks_path.read_text())["hooks"]
+hooks = settings.setdefault("hooks", {})
+
+def command_contains(entry, needles):
+    return any(any(needle in hook.get("command", "") for needle in needles) for hook in entry.get("hooks", []))
+
+for event, event_hooks in incoming.items():
+    existing = hooks.get(event, [])
+    if event == "UserPromptSubmit":
+        existing = [
+            entry for entry in existing
+            if not command_contains(entry, ("peon.sh", "hook-handle-use", "hook-handle-rename"))
+        ]
+    elif event == "PostToolUseFailure":
+        existing = [entry for entry in existing if not command_contains(entry, ("peon.sh", "notify.sh"))]
+    else:
+        existing = [entry for entry in existing if not command_contains(entry, ("peon.sh", "notify.sh"))]
+    hooks[event] = existing + event_hooks
+
+    if event == "UserPromptSubmit" and "beforeSubmitPrompt" in hooks:
+        hooks.pop("beforeSubmitPrompt", None)
+
+settings["hooks"] = hooks
+settings_path.write_text(json.dumps(settings, indent=2) + "\n")
+PY
+    '');
 
     # Install sound packs from og-packs and/or custom sources
     home.file.".openpeon/packs" = lib.mkIf (cfg.installPacks != [ ]) (let

--- a/tests/nix-home-manager.bats
+++ b/tests/nix-home-manager.bats
@@ -1,0 +1,17 @@
+#!/usr/bin/env bats
+
+setup() {
+  REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+  MODULE="$REPO_ROOT/nix/hm-module.nix"
+}
+
+@test "home-manager module exposes Claude Code integration option" {
+  grep -q 'claudeCodeIntegration = mkOption' "$MODULE"
+}
+
+@test "home-manager Claude Code integration installs hook files and settings merge" {
+  grep -q '".claude/hooks/peon-ping/peon.sh".source' "$MODULE"
+  grep -q '".claude/hooks/peon-ping/scripts/hook-handle-use.sh".source' "$MODULE"
+  grep -q 'settings_path=\"\$HOME/.claude/settings.json\"' "$MODULE"
+  grep -q 'hooks.pop("beforeSubmitPrompt", None)' "$MODULE"
+}


### PR DESCRIPTION
## Summary
- add an optional `programs.peon-ping.claudeCodeIntegration` Home Manager flag
- install the Claude Code hook scripts into `~/.claude/hooks/peon-ping/`
- merge the standard peon-ping hook entries into `~/.claude/settings.json` and document the new option in the README

## Test plan
- `grep -q 'claudeCodeIntegration = mkOption' nix/hm-module.nix`
- `grep -q '".claude/hooks/peon-ping/peon.sh".source' nix/hm-module.nix`
- `grep -q 'settings_path="\$HOME/.claude/settings.json"' nix/hm-module.nix`
- `grep -q 'hooks.pop("beforeSubmitPrompt", None)' nix/hm-module.nix`
- attempted `bats tests/nix-home-manager.bats tests/install.bats` but `bats` is not installed in this environment

Closes #368.
