### PR TITLE
fix: preserve sibling custom hooks on install/uninstall (#484)

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -3196,16 +3196,21 @@ $events = @("SessionStart", "SessionEnd", "SubagentStart", "Stop", "Notification
 foreach ($evt in $events) {
     $eventHooks = @()
     if ($settings.hooks | Get-Member -Name $evt -MemberType NoteProperty) {
-        # Remove existing peon entries, keep others
-        $eventHooks = @($settings.hooks.$evt | Where-Object {
-            $dominated = $false
-            foreach ($h in $_.hooks) {
-                if ($h.command -and ($h.command -match "peon" -or $h.command -match "notify\.sh")) {
-                    $dominated = $true
+        # Strip only peon/notify hooks from each matcher entry; keep sibling
+        # hooks users registered alongside ours. Drop a matcher entry only if
+        # its hooks list becomes empty.
+        $eventHooks = @($settings.hooks.$evt | ForEach-Object {
+            $entry = $_
+            $keptHooks = @($entry.hooks | Where-Object {
+                -not ($_.command -and ($_.command -match "peon\.(ps1|sh)" -or $_.command -match "notify\.sh"))
+            })
+            if ($keptHooks.Count -gt 0) {
+                [PSCustomObject]@{
+                    matcher = $entry.matcher
+                    hooks   = $keptHooks
                 }
             }
-            -not $dominated
-        })
+        } | Where-Object { $_ -ne $null })
     }
     $eventHooks += $peonEntry
 
@@ -3243,16 +3248,21 @@ $beforeSubmitEntry = [PSCustomObject]@{
 # Register under UserPromptSubmit (valid Claude Code event)
 $eventHooks = @()
 if ($settings.hooks | Get-Member -Name "UserPromptSubmit" -MemberType NoteProperty) {
-    # Remove existing handle-use entries, keep peon.ps1 entries
-    $eventHooks = @($settings.hooks.UserPromptSubmit | Where-Object {
-        $dominated = $false
-        foreach ($h in $_.hooks) {
-            if ($h.command -and $h.command -match "hook-handle-use") {
-                $dominated = $true
+    # Strip only handle-use hooks from each matcher entry; keep sibling hooks
+    # (peon.ps1 and any user-registered hooks). Drop a matcher entry only if
+    # its hooks list becomes empty.
+    $eventHooks = @($settings.hooks.UserPromptSubmit | ForEach-Object {
+        $entry = $_
+        $keptHooks = @($entry.hooks | Where-Object {
+            -not ($_.command -and $_.command -match "hook-handle-use")
+        })
+        if ($keptHooks.Count -gt 0) {
+            [PSCustomObject]@{
+                matcher = $entry.matcher
+                hooks   = $keptHooks
             }
         }
-        -not $dominated
-    })
+    } | Where-Object { $_ -ne $null })
 }
 $eventHooks += $beforeSubmitEntry
 

--- a/install.sh
+++ b/install.sh
@@ -1035,14 +1035,20 @@ for event in events:
     else:
         peon_entry = dict(matcher='', hooks=[hook])
     event_hooks = hooks.get(event, [])
-    # Remove any existing notify.sh or peon.sh entries
-    event_hooks = [
-        h for h in event_hooks
-        if not any(
-            'notify.sh' in hk.get('command', '') or 'peon.sh' in hk.get('command', '')
-            for hk in h.get('hooks', [])
-        )
-    ]
+    # Strip only peon.sh/notify.sh hooks from each matcher entry; keep sibling
+    # hooks that users registered alongside ours. Drop the matcher entry only
+    # if its hooks list is emptied out.
+    cleaned = []
+    for h in event_hooks:
+        h = dict(h)
+        h['hooks'] = [
+            hk for hk in h.get('hooks', [])
+            if 'notify.sh' not in hk.get('command', '')
+            and 'peon.sh' not in hk.get('command', '')
+        ]
+        if h['hooks']:
+            cleaned.append(h)
+    event_hooks = cleaned
     event_hooks.append(peon_entry)
     hooks[event] = event_hooks
 
@@ -1101,14 +1107,20 @@ before_submit_entry = {
 
 # Register under UserPromptSubmit (valid Claude Code event)
 event_hooks = hooks.get('UserPromptSubmit', [])
-# Remove any existing hook-handle-use/rename entries (keep peon.sh entries)
-event_hooks = [
-    h for h in event_hooks
-    if not any(
-        'hook-handle-use' in hk.get('command', '') or 'hook-handle-rename' in hk.get('command', '')
-        for hk in h.get('hooks', [])
-    )
-]
+# Strip only hook-handle-use/rename hooks from each matcher entry; keep
+# sibling hooks (including peon.sh and any user-registered hooks). Drop the
+# matcher entry only if its hooks list is emptied out.
+cleaned = []
+for h in event_hooks:
+    h = dict(h)
+    h['hooks'] = [
+        hk for hk in h.get('hooks', [])
+        if 'hook-handle-use' not in hk.get('command', '')
+        and 'hook-handle-rename' not in hk.get('command', '')
+    ]
+    if h['hooks']:
+        cleaned.append(h)
+event_hooks = cleaned
 event_hooks.append(before_submit_entry)
 hooks['UserPromptSubmit'] = event_hooks
 

--- a/tests/install.bats
+++ b/tests/install.bats
@@ -135,6 +135,45 @@ print('OK')
 "
 }
 
+@test "update preserves sibling custom hooks registered under same matcher entry (issue #484)" {
+  # First install to establish peon hooks
+  bash "$CLONE_DIR/install.sh"
+  [ -f "$TEST_HOME/.claude/settings.json" ]
+
+  # Simulate a user adding a custom hook *inside* peon's SessionStart matcher entry.
+  # Also add a custom entry in UserPromptSubmit alongside hook-handle-use.
+  /usr/bin/python3 -c "
+import json
+p = '$TEST_HOME/.claude/settings.json'
+s = json.load(open(p))
+for entry in s['hooks']['SessionStart']:
+    if any('peon.sh' in h.get('command','') for h in entry.get('hooks', [])):
+        entry['hooks'].append({'type': 'command', 'command': '~/.claude/hooks/my-custom/sync.sh'})
+        break
+for entry in s['hooks']['UserPromptSubmit']:
+    if any('hook-handle-use' in h.get('command','') for h in entry.get('hooks', [])):
+        entry['hooks'].append({'type': 'command', 'command': '~/.claude/hooks/my-custom/prompt.sh'})
+        break
+json.dump(s, open(p, 'w'), indent=2)
+"
+
+  # Re-run install (simulates peon update)
+  bash "$CLONE_DIR/install.sh"
+
+  # Custom sibling hooks should still be present
+  /usr/bin/python3 -c "
+import json
+s = json.load(open('$TEST_HOME/.claude/settings.json'))
+session_cmds = [h.get('command','') for entry in s['hooks']['SessionStart'] for h in entry.get('hooks', [])]
+prompt_cmds = [h.get('command','') for entry in s['hooks']['UserPromptSubmit'] for h in entry.get('hooks', [])]
+assert any('my-custom/sync.sh' in c for c in session_cmds), 'Custom SessionStart hook was wiped: ' + repr(session_cmds)
+assert any('my-custom/prompt.sh' in c for c in prompt_cmds), 'Custom UserPromptSubmit hook was wiped: ' + repr(prompt_cmds)
+assert any('peon.sh' in c for c in session_cmds), 'peon.sh missing from SessionStart after update'
+assert any('hook-handle-use' in c for c in prompt_cmds), 'hook-handle-use missing from UserPromptSubmit after update'
+print('OK')
+"
+}
+
 @test "fresh install creates VERSION file" {
   bash "$CLONE_DIR/install.sh"
   [ -f "$INSTALL_DIR/VERSION" ]

--- a/uninstall.ps1
+++ b/uninstall.ps1
@@ -41,21 +41,28 @@ if (Test-Path $SettingsFile) {
 
             foreach ($event in $eventNames) {
                 $entries = @($hooksObj.$event)
-                $originalCount = $entries.Count
+                $originalInnerTotal = 0
+                foreach ($entry in $entries) { $originalInnerTotal += @($entry.hooks).Count }
 
-                # Filter out entries that contain peon.ps1, peon.sh, notify.sh, or hook-handle-use
-                $filtered = @($entries | Where-Object {
-                    $hasPeon = $false
-                    foreach ($h in $_.hooks) {
-                        if ($h.command -and ($h.command -match "peon\.ps1" -or $h.command -match "peon\.sh" -or $h.command -match "notify\.sh" -or $h.command -match "hook-handle-use")) {
-                            $hasPeon = $true
-                            break
+                # Strip only peon/notify/hook-handle-use hooks from each matcher
+                # entry; keep sibling hooks users registered alongside ours.
+                # Drop a matcher entry only if its hooks list becomes empty.
+                $filtered = @($entries | ForEach-Object {
+                    $entry = $_
+                    $keptHooks = @(@($entry.hooks) | Where-Object {
+                        -not ($_.command -and ($_.command -match "peon\.ps1" -or $_.command -match "peon\.sh" -or $_.command -match "notify\.sh" -or $_.command -match "hook-handle-use"))
+                    })
+                    if ($keptHooks.Count -gt 0) {
+                        [PSCustomObject]@{
+                            matcher = $entry.matcher
+                            hooks   = $keptHooks
                         }
                     }
-                    -not $hasPeon
-                })
+                } | Where-Object { $_ -ne $null })
 
-                if ($filtered.Count -lt $originalCount) {
+                $keptInnerTotal = 0
+                foreach ($entry in $filtered) { $keptInnerTotal += @($entry.hooks).Count }
+                if ($keptInnerTotal -lt $originalInnerTotal) {
                     $eventsChanged += $event
                 }
 

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -38,18 +38,28 @@ hooks = settings.get('hooks', {})
 events_cleaned = []
 
 for event, entries in list(hooks.items()):
-    original_count = len(entries)
-    entries = [
-        h for h in entries
-        if not any(
-            'peon.sh' in hk.get('command', '') or 'hook-handle-use.sh' in hk.get('command', '')
-            for hk in h.get('hooks', [])
-        )
-    ]
-    if len(entries) < original_count:
+    changed = False
+    cleaned = []
+    for h in entries:
+        original_inner = h.get('hooks', [])
+        kept = [
+            hk for hk in original_inner
+            if 'peon.sh' not in hk.get('command', '')
+            and 'hook-handle-use.sh' not in hk.get('command', '')
+            and 'notify.sh' not in hk.get('command', '')
+        ]
+        if len(kept) != len(original_inner):
+            changed = True
+        # Preserve entries that started empty (malformed/stale but not ours to
+        # drop); only skip entries we emptied by stripping peon hooks.
+        if kept or not original_inner:
+            new_entry = dict(h)
+            new_entry['hooks'] = kept
+            cleaned.append(new_entry)
+    if changed:
         events_cleaned.append(event)
-    if entries:
-        hooks[event] = entries
+    if cleaned:
+        hooks[event] = cleaned
     else:
         del hooks[event]
 


### PR DESCRIPTION
## Summary

Fixes #484. `install.sh` / `peon update` filtered `settings.json` hooks at the matcher-entry level: if any inner hook command contained `peon.sh` or `notify.sh`, the whole matcher entry (with all its siblings) was dropped. Users composing peon-ping under the same matcher as other hooks — a natural thing to do when `matcher: ""` is the default — silently lost those hooks on every update.

The fix filters at the inner-hook level instead: strip only peon/notify/handle-use hooks, and drop the containing entry only when its hooks list becomes empty. Applied symmetrically to `install.sh`, `install.ps1`, `uninstall.sh`, and `uninstall.ps1`.

## Incidental fixes uncovered during review

- `install.ps1` regex `-match "peon"` narrowed to `peon\.(ps1|sh)`. Matches the precision already in `install.sh` and `uninstall.ps1`; previously would match any path containing the string `peon` (e.g. `openpeon-*`, `peony-*`). Pre-existing, but made subtler by the new surgical filter.
- `uninstall.sh` now strips `notify.sh` hooks (parity with `install.sh` and `uninstall.ps1`).
- `uninstall.sh` preserves matcher entries that already had `hooks: []` — the old code silently dropped them.

## Test plan

- [x] New BATS regression test in `tests/install.bats` injects a custom sibling hook into peon's `SessionStart` and `UserPromptSubmit` entries, re-runs install, and asserts both the custom hooks and peon hooks survive.
- [x] All 47 `bats tests/install.bats` tests pass locally.
- [ ] CI: BATS (macOS) + Pester (Windows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)