### PR TITLE
fix: Windows install first-run parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,30 +63,37 @@ sudo apt update; sudo apt install -y ffmpeg
 ### Option 3: Installer for Windows
 
 ```powershell
-Invoke-WebRequest -Uri "https://raw.githubusercontent.com/PeonPing/peon-ping/main/install.ps1" -UseBasicParsing | Invoke-Expression
+Invoke-WebRequest -Uri "https://raw.githubusercontent.com/PeonPing/peon-ping/main/install.ps1" -OutFile ".\install.ps1" -UseBasicParsing
+powershell -ExecutionPolicy Bypass -File .\install.ps1
 ```
 
-Installs 5 curated packs by default (Warcraft, StarCraft, Portal). Re-run to update while preserving config/state. Or **[pick your packs interactively at peonping.com](https://peonping.com/#picker)** and get a custom install command.
+Installs a curated starter set of packs by default. Re-run to update while preserving config/state. Or **[pick your packs interactively at peonping.com](https://peonping.com/#picker)** and get a custom install command.
 
-Useful installer flags:
+Windows installer parameters:
 
-- `--all` — install all available packs
-- `--packs=peon,sc_kerrigan,...` — install specific packs only
-- `--local` — install packs, config, and hooks into `./.claude/` for the current project
-- `--global` — explicit global install (same as default)
-- `--init-local-config` — create `./.claude/hooks/peon-ping/config.json` only
+- `-All` — install all available packs
+- `-Packs peon,sc_kerrigan,...` — install specific packs only
+- `-Lang en,fr,...` — install only packs matching language(s)
+- `-Local` — install packs, config, hooks, and skills into `./.claude/` for the current project
+- `-Global` — explicit global install (same as default)
+- `-InitLocalConfig` — create `./.claude/hooks/peon-ping/config.json` only
 
-`--local` does not modify your shell rc files (no global `peon` alias/completion injection). Hooks are registered in the project-level `./.claude/settings.json` with absolute paths so they work from any working directory within the project.
+`-Local` does not install the global `peon` CLI shim or modify your user `PATH`. Hooks are registered in the project-level `./.claude/settings.json` with absolute paths so they work from any working directory within the project.
 
-Examples:
+Windows examples:
 
-```bash
-curl -fsSL https://raw.githubusercontent.com/PeonPing/peon-ping/main/install.sh | bash -s -- --all
-curl -fsSL https://raw.githubusercontent.com/PeonPing/peon-ping/main/install.sh | bash -s -- --packs=peon,sc_kerrigan
-curl -fsSL https://raw.githubusercontent.com/PeonPing/peon-ping/main/install.sh | bash -s -- --local
+```powershell
+powershell -ExecutionPolicy Bypass -File .\install.ps1 -All
+powershell -ExecutionPolicy Bypass -File .\install.ps1 -Packs peon,sc_kerrigan
+powershell -ExecutionPolicy Bypass -File .\install.ps1 -Local
+powershell -ExecutionPolicy Bypass -File .\install.ps1 -InitLocalConfig
 ```
 
-If a global install exists and you install local (or vice versa), the installer prompts you to remove the existing one to avoid conflicts.
+If the initial download fails with a TLS error on older Windows PowerShell, run this once in the same session and retry:
+
+```powershell
+[Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
+```
 
 ### Option 4: Clone and inspect first
 
@@ -94,6 +101,14 @@ If a global install exists and you install local (or vice versa), the installer 
 git clone https://github.com/PeonPing/peon-ping.git
 cd peon-ping
 ./install.sh
+```
+
+On Windows PowerShell:
+
+```powershell
+git clone https://github.com/PeonPing/peon-ping.git
+Set-Location peon-ping
+.\install.ps1
 ```
 
 ### Option 5: Nix (macOS, Linux)
@@ -232,6 +247,8 @@ Need to mute sounds and notifications during a meeting or pairing session? Two o
 | **CLI** | `peon toggle` | From any terminal tab |
 
 Other CLI commands:
+
+> Windows note: Windows currently supports the day-one controls (`status`, `toggle`, `volume`, core `packs`, `notifications on/off`, `debug`, `logs`, `trainer`). More advanced commands like `setup`, `rotation`, `preview`, and `mobile` are tracked as follow-up Windows parity work.
 
 ```bash
 peon setup                # Interactive setup wizard (volume, categories, notifications)
@@ -1207,7 +1224,7 @@ Mobile notifications fire on every event regardless of window focus — they're 
 
 ## Sound packs
 
-165 packs across Warcraft, StarCraft, Red Alert, Portal, Zelda, Dota 2, Helldivers 2, Elder Scrolls, and more. The default install includes 5 curated packs:
+165 packs across Warcraft, StarCraft, Red Alert, Portal, Zelda, Dota 2, Helldivers 2, Elder Scrolls, and more. The default install includes a curated starter set; commonly used packs include:
 
 | Pack | Character | Sounds |
 |---|---|---|

--- a/README.md
+++ b/README.md
@@ -63,30 +63,37 @@ sudo apt update; sudo apt install -y ffmpeg
 ### Option 3: Installer for Windows
 
 ```powershell
-Invoke-WebRequest -Uri "https://raw.githubusercontent.com/PeonPing/peon-ping/main/install.ps1" -UseBasicParsing | Invoke-Expression
+Invoke-WebRequest -Uri "https://raw.githubusercontent.com/PeonPing/peon-ping/main/install.ps1" -OutFile ".\install.ps1" -UseBasicParsing
+powershell -ExecutionPolicy Bypass -File .\install.ps1
 ```
 
-Installs 5 curated packs by default (Warcraft, StarCraft, Portal). Re-run to update while preserving config/state. Or **[pick your packs interactively at peonping.com](https://peonping.com/#picker)** and get a custom install command.
+Installs a curated starter set of packs by default. Re-run to update while preserving config/state. Or **[pick your packs interactively at peonping.com](https://peonping.com/#picker)** and get a custom install command.
 
-Useful installer flags:
+Windows installer parameters:
 
-- `--all` — install all available packs
-- `--packs=peon,sc_kerrigan,...` — install specific packs only
-- `--local` — install packs, config, and hooks into `./.claude/` for the current project
-- `--global` — explicit global install (same as default)
-- `--init-local-config` — create `./.claude/hooks/peon-ping/config.json` only
+- `-All` — install all available packs
+- `-Packs peon,sc_kerrigan,...` — install specific packs only
+- `-Lang en,fr,...` — install only packs matching language(s)
+- `-Local` — install packs, config, hooks, and skills into `./.claude/` for the current project
+- `-Global` — explicit global install (same as default)
+- `-InitLocalConfig` — create `./.claude/hooks/peon-ping/config.json` only
 
-`--local` does not modify your shell rc files (no global `peon` alias/completion injection). Hooks are registered in the project-level `./.claude/settings.json` with absolute paths so they work from any working directory within the project.
+`-Local` does not install the global `peon` CLI shim or modify your user `PATH`. Hooks are registered in the project-level `./.claude/settings.json` with absolute paths so they work from any working directory within the project.
 
-Examples:
+Windows examples:
 
-```bash
-curl -fsSL https://raw.githubusercontent.com/PeonPing/peon-ping/main/install.sh | bash -s -- --all
-curl -fsSL https://raw.githubusercontent.com/PeonPing/peon-ping/main/install.sh | bash -s -- --packs=peon,sc_kerrigan
-curl -fsSL https://raw.githubusercontent.com/PeonPing/peon-ping/main/install.sh | bash -s -- --local
+```powershell
+powershell -ExecutionPolicy Bypass -File .\install.ps1 -All
+powershell -ExecutionPolicy Bypass -File .\install.ps1 -Packs peon,sc_kerrigan
+powershell -ExecutionPolicy Bypass -File .\install.ps1 -Local
+powershell -ExecutionPolicy Bypass -File .\install.ps1 -InitLocalConfig
 ```
 
-If a global install exists and you install local (or vice versa), the installer prompts you to remove the existing one to avoid conflicts.
+If the initial download fails with a TLS error on older Windows PowerShell, run this once in the same session and retry:
+
+```powershell
+[Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
+```
 
 ### Option 4: Clone and inspect first
 
@@ -94,6 +101,14 @@ If a global install exists and you install local (or vice versa), the installer 
 git clone https://github.com/PeonPing/peon-ping.git
 cd peon-ping
 ./install.sh
+```
+
+On Windows PowerShell:
+
+```powershell
+git clone https://github.com/PeonPing/peon-ping.git
+Set-Location peon-ping
+.\install.ps1
 ```
 
 ### Option 5: Nix (macOS, Linux)
@@ -232,6 +247,8 @@ Need to mute sounds and notifications during a meeting or pairing session? Two o
 | **CLI** | `peon toggle` | From any terminal tab |
 
 Other CLI commands:
+
+> Windows note: Windows currently supports the day-one controls (`status`, `toggle`, `volume`, core `packs`, `notifications on/off`, `debug`, `logs`, `trainer`). More advanced commands like `setup`, `rotation`, `preview`, and `mobile` are tracked as follow-up Windows parity work.
 
 ```bash
 peon setup                # Interactive setup wizard (volume, categories, notifications)
@@ -1224,7 +1241,7 @@ Mobile notifications fire on every event regardless of window focus — they're 
 
 ## Sound packs
 
-165 packs across Warcraft, StarCraft, Red Alert, Portal, Zelda, Dota 2, Helldivers 2, Elder Scrolls, and more. The default install includes 5 curated packs:
+165 packs across Warcraft, StarCraft, Red Alert, Portal, Zelda, Dota 2, Helldivers 2, Elder Scrolls, and more. The default install includes a curated starter set; commonly used packs include:
 
 | Pack | Character | Sounds |
 |---|---|---|

--- a/install.ps1
+++ b/install.ps1
@@ -5,9 +5,12 @@
 
 param(
     [Parameter()]
-    $Packs = @(),
+    [string[]]$Packs = @(),
     [switch]$All,
-    [string]$Lang = ""
+    [string]$Lang = "",
+    [switch]$Local,
+    [switch]$Global,
+    [switch]$InitLocalConfig
 )
 
 # When run via Invoke-Expression (one-liner install), $PSScriptRoot is empty.
@@ -15,6 +18,22 @@ param(
 $ScriptDir = if ($PSScriptRoot) { $PSScriptRoot } else { $PWD.Path }
 
 $ErrorActionPreference = "Stop"
+
+if ($Local -and $Global) {
+    throw "Use either -Local or -Global, not both."
+}
+
+# Windows PowerShell 5.1 can default to older TLS versions, which breaks the
+# one-liner install against GitHub raw URLs on some systems.
+if ($PSVersionTable.PSEdition -ne "Core") {
+    try {
+        [Net.ServicePointManager]::SecurityProtocol = `
+            [Net.ServicePointManager]::SecurityProtocol -bor `
+            [Net.SecurityProtocolType]::Tls12
+    } catch {
+        # Best effort only.
+    }
+}
 
 # --- Input validation & config helpers (dot-sourced from scripts/install-utils.ps1) ---
 if (-not $PSScriptRoot) {
@@ -45,11 +64,39 @@ if ($policy -eq "Restricted") {
 
 
 # --- Paths ---
-$ClaudeDir = Join-Path $env:USERPROFILE ".claude"
+$GlobalClaudeDir = Join-Path $env:USERPROFILE ".claude"
+$LocalClaudeDir = Join-Path $PWD.Path ".claude"
+$ClaudeDir = if ($Local) { $LocalClaudeDir } else { $GlobalClaudeDir }
 $InstallDir = Join-Path $ClaudeDir "hooks\peon-ping"
 $SettingsFile = Join-Path $ClaudeDir "settings.json"
 $RegistryUrl = "https://peonping.github.io/registry/index.json"
 $RepoBase = "https://raw.githubusercontent.com/PeonPing/peon-ping/main"
+
+# --- Local config bootstrap ---
+if ($InitLocalConfig) {
+    $localConfigDir = Join-Path $LocalClaudeDir "hooks\peon-ping"
+    $localConfigFile = Join-Path $localConfigDir "config.json"
+    New-Item -ItemType Directory -Path $localConfigDir -Force | Out-Null
+
+    if (Test-Path $localConfigFile) {
+        Write-Host "Local config already exists: $localConfigFile" -ForegroundColor Yellow
+        return
+    }
+
+    $globalConfigFile = Join-Path $GlobalClaudeDir "hooks\peon-ping\config.json"
+    $repoConfigFile = if ($PSScriptRoot) { Join-Path $ScriptDir "config.json" } else { $null }
+
+    if (Test-Path $globalConfigFile) {
+        Copy-Item -Path $globalConfigFile -Destination $localConfigFile -Force
+    } elseif ($repoConfigFile -and (Test-Path $repoConfigFile)) {
+        Copy-Item -Path $repoConfigFile -Destination $localConfigFile -Force
+    } else {
+        Invoke-WebRequest -Uri "$RepoBase/config.json" -OutFile $localConfigFile -UseBasicParsing -ErrorAction Stop
+    }
+
+    Write-Host "Created local config: $localConfigFile" -ForegroundColor Green
+    return
+}
 
 # --- Check Claude Code is installed ---
 $Updating = $false
@@ -59,7 +106,12 @@ if (Test-Path (Join-Path $InstallDir "peon.ps1")) {
 }
 
 $ClaudeCodeDetected = $true
-if (-not (Test-Path $ClaudeDir)) {
+if ($Local) {
+    if (-not (Test-Path $ClaudeDir)) {
+        Write-Host "Creating project-local Claude config at $ClaudeDir" -ForegroundColor DarkGray
+        New-Item -ItemType Directory -Path $ClaudeDir -Force | Out-Null
+    }
+} elseif (-not (Test-Path $ClaudeDir)) {
     $ClaudeCodeDetected = $false
     Write-Host "Note: $ClaudeDir not found (Claude Code may not be installed)." -ForegroundColor Yellow
     Write-Host "Installing adapters and packs only. Claude Code hooks will be skipped." -ForegroundColor Yellow
@@ -513,21 +565,65 @@ function Detect-SessionIde {
 }
 
 # Install a pack from the registry by name. Returns $true on success, $false on failure.
-function Install-PackFromRegistry {
-    param([string]$PackName, [string]$PacksDir)
+function Get-PackRegistry {
     $regUrl = "https://peonping.github.io/registry/index.json"
     try {
         $regResp = Invoke-WebRequest -Uri $regUrl -UseBasicParsing -ErrorAction Stop
-        $reg = $regResp.Content | ConvertFrom-Json
+        return ($regResp.Content | ConvertFrom-Json)
     } catch {
         Write-Host "Error: could not fetch registry." -ForegroundColor Red
-        return $false
+        return $null
     }
-    $packInfo = $reg.packs | Where-Object { $_.name -eq $PackName }
-    if (-not $packInfo) { return $false }
-    $srcRepo = $packInfo.source_repo
-    $srcRef = $packInfo.source_ref
-    $srcPath = $packInfo.source_path
+}
+
+function Get-InstalledPackNames {
+    param([string]$PacksDir)
+
+    if (-not (Test-Path $PacksDir)) {
+        return @()
+    }
+
+    return @(Get-ChildItem -Path $PacksDir -Directory | Where-Object {
+        (Get-ChildItem -Path (Join-Path $_.FullName "sounds") -File -ErrorAction SilentlyContinue | Measure-Object).Count -gt 0
+    } | ForEach-Object { $_.Name } | Sort-Object)
+}
+
+function Get-NextPackName {
+    param([string[]]$Available, [string]$CurrentPack)
+
+    if (-not $Available -or $Available.Count -eq 0) {
+        return $null
+    }
+
+    $idx = [array]::IndexOf($Available, $CurrentPack)
+    if ($idx -lt 0) {
+        return $Available[0]
+    }
+
+    return $Available[($idx + 1) % $Available.Count]
+}
+
+function Set-SelectedPack {
+    param([string]$ConfigPath, [string]$PackName)
+
+    $raw = Get-Content $ConfigPath -Raw
+    $updated = $raw -replace '"default_pack"\s*:\s*"[^"]*"', "`"default_pack`": `"$PackName`""
+    $updated = $updated -replace '"active_pack"\s*:\s*"[^"]*"', "`"active_pack`": `"$PackName`""
+    if ($updated -ne $raw) {
+        Set-Content $ConfigPath -Value $updated -Encoding UTF8
+    }
+}
+
+function Install-PackFromRegistryEntry {
+    param($PackInfo, [string]$PacksDir)
+
+    if (-not $PackInfo -or -not $PackInfo.name) { return $false }
+
+    $PackName = $PackInfo.name
+    $regUrl = "https://peonping.github.io/registry/index.json"
+    $srcRepo = $PackInfo.source_repo
+    $srcRef = $PackInfo.source_ref
+    $srcPath = $PackInfo.source_path
     if (-not $srcRepo -or -not $srcRef -or ($null -eq $srcPath)) {
         Write-Host "Error: incomplete registry entry for '$PackName'." -ForegroundColor Red
         return $false
@@ -561,6 +657,57 @@ function Install-PackFromRegistry {
     }
     Write-Host "`r[$PackName] $total/$total done.          "
     return $true
+}
+
+function Install-PackFromRegistry {
+    param([string]$PackName, [string]$PacksDir)
+
+    $reg = Get-PackRegistry
+    if (-not $reg) { return $false }
+
+    $packInfo = $reg.packs | Where-Object { $_.name -eq $PackName }
+    if (-not $packInfo) { return $false }
+
+    return (Install-PackFromRegistryEntry -PackInfo $packInfo -PacksDir $PacksDir)
+}
+
+function Install-PackFromLocal {
+    param([string]$SourceDir, [string]$PacksDir)
+
+    if (-not $SourceDir) {
+        Write-Host "Usage: peon packs install-local <path>" -ForegroundColor Yellow
+        return $null
+    }
+
+    if (-not (Test-Path $SourceDir -PathType Container)) {
+        Write-Host "Error: local pack path not found: $SourceDir" -ForegroundColor Red
+        return $null
+    }
+
+    $resolvedSource = (Resolve-Path -LiteralPath $SourceDir).Path
+    $manifestPath = Join-Path $resolvedSource "openpeon.json"
+    $legacyManifestPath = Join-Path $resolvedSource "manifest.json"
+    $soundsDir = Join-Path $resolvedSource "sounds"
+
+    if (-not (Test-Path $soundsDir -PathType Container)) {
+        Write-Host "Error: local pack must contain a sounds directory." -ForegroundColor Red
+        return $null
+    }
+
+    if (-not (Test-Path $manifestPath) -and -not (Test-Path $legacyManifestPath)) {
+        Write-Host "Error: local pack must contain openpeon.json or manifest.json." -ForegroundColor Red
+        return $null
+    }
+
+    $packName = Split-Path $resolvedSource -Leaf
+    $targetDir = Join-Path $PacksDir $packName
+
+    if (Test-Path $targetDir) {
+        Remove-Item -Path $targetDir -Recurse -Force
+    }
+
+    Copy-Item -Path $resolvedSource -Destination $targetDir -Recurse -Force
+    return $packName
 }
 
 # Helper function to convert PSCustomObject to hashtable (PS 5.1 compat)
@@ -802,7 +949,7 @@ if ($Command) {
     }
 
     switch -Regex ($Command) {
-        "^--toggle$" {
+        "^(--)?toggle$" {
             $raw = Get-PeonConfigRaw $ConfigPath
             $cfg = $raw | ConvertFrom-Json
             $newState = -not $cfg.enabled
@@ -813,24 +960,24 @@ if ($Command) {
             Write-Host "peon-ping: $state" -ForegroundColor Cyan
             return
         }
-        "^--(pause|mute)$" {
+        "^(--)?(pause|mute)$" {
             $raw = Get-Content $ConfigPath -Raw
             $updated = $raw -replace '"enabled"\s*:\s*(true|false)', '"enabled": false'
             if ($updated -ne $raw) { Set-Content $ConfigPath -Value $updated -Encoding UTF8 }
             Write-Host "peon-ping: PAUSED" -ForegroundColor Yellow
             return
         }
-        "^--(resume|unmute)$" {
+        "^(--)?(resume|unmute)$" {
             $raw = Get-Content $ConfigPath -Raw
             $updated = $raw -replace '"enabled"\s*:\s*(true|false)', '"enabled": true'
             if ($updated -ne $raw) { Set-Content $ConfigPath -Value $updated -Encoding UTF8 }
             Write-Host "peon-ping: ENABLED" -ForegroundColor Green
             return
         }
-        "^--status$" {
+        "^(--)?status$" {
             try {
                 $cfg = Get-PeonConfigRaw $ConfigPath | ConvertFrom-Json
-                $isVerbose = ($Arg1 -eq "--verbose")
+                $isVerbose = ($Arg1 -eq "--verbose" -or $Arg1 -eq "verbose")
 
                 # --- Essential info (always shown) ---
                 $state = if ($cfg.enabled) { "ENABLED" } else { "PAUSED" }
@@ -957,46 +1104,129 @@ if ($Command) {
             }
             return
         }
-        "^--packs$" {
+        "^(--)?packs$" {
             $packsDir = Join-Path $InstallDir "packs"
             $cfg = Get-PeonConfigRaw $ConfigPath | ConvertFrom-Json
-            $available = Get-ChildItem -Path $packsDir -Directory | Where-Object {
-                (Get-ChildItem -Path (Join-Path $_.FullName "sounds") -File -ErrorAction SilentlyContinue | Measure-Object).Count -gt 0
-            } | ForEach-Object { $_.Name } | Sort-Object
+            $available = Get-InstalledPackNames -PacksDir $packsDir
+            $packsAction = if ($Arg1) { $Arg1 } else { "list" }
+            if ($packsAction -eq "list" -and $Arg2 -eq "--registry") {
+                $packsAction = "community"
+            }
 
-            switch ($Arg1) {
+            switch ($packsAction) {
                 "use" {
-                    if (-not $Arg2) {
-                        Write-Host "Usage: peon packs use <pack-name>" -ForegroundColor Yellow
+                    $installRequested = $false
+                    if ($Arg2 -eq "--install") {
+                        $installRequested = $true
+                        $newPack = if ($ExtraArgs.Count -gt 0) { $ExtraArgs[0] } else { "" }
+                    } else {
+                        $newPack = $Arg2
+                    }
+
+                    if (-not $newPack) {
+                        Write-Host "Usage: peon packs use [--install] <pack-name>" -ForegroundColor Yellow
                         return
                     }
-                    $newPack = $Arg2
-                    if ($newPack -notin $available) {
+
+                    if ($installRequested -or $newPack -notin $available) {
                         Write-Host "Pack '$newPack' not installed locally. Fetching from registry..." -ForegroundColor Yellow
                         $ok = Install-PackFromRegistry -PackName $newPack -PacksDir $packsDir
                         if (-not $ok) {
                             Write-Host "Pack '$newPack' not found in registry." -ForegroundColor Red
                             return
                         }
+                        $available = Get-InstalledPackNames -PacksDir $packsDir
                         Write-Host "peon-ping: installed and switched to '$newPack'" -ForegroundColor Green
                     } else {
                         Write-Host "peon-ping: switched to '$newPack'" -ForegroundColor Green
                     }
-                    $raw = Get-Content $ConfigPath -Raw
-                    $updated = $raw -replace '"default_pack"\s*:\s*"[^"]*"', "`"default_pack`": `"$newPack`""
-                    $updated = $updated -replace '"active_pack"\s*:\s*"[^"]*"', "`"active_pack`": `"$newPack`""
-                    if ($updated -ne $raw) { Set-Content $ConfigPath -Value $updated -Encoding UTF8 }
+                    Set-SelectedPack -ConfigPath $ConfigPath -PackName $newPack
+                    return
+                }
+                "install" {
+                    if (-not $Arg2) {
+                        Write-Host "Usage: peon packs install <pack1,pack2> | --all" -ForegroundColor Yellow
+                        return
+                    }
+
+                    $targets = @()
+                    if ($Arg2 -eq "--all") {
+                        $reg = Get-PackRegistry
+                        if (-not $reg) { return }
+                        $targets = @($reg.packs | ForEach-Object { $_.name })
+                    } else {
+                        $targets = @($Arg2 -split ',' | ForEach-Object { $_.Trim() } | Where-Object { $_ })
+                    }
+
+                    if ($targets.Count -eq 0) {
+                        Write-Host "Usage: peon packs install <pack1,pack2> | --all" -ForegroundColor Yellow
+                        return
+                    }
+
+                    $failed = @()
+                    foreach ($packName in $targets) {
+                        if (Install-PackFromRegistry -PackName $packName -PacksDir $packsDir) {
+                            Write-Host "peon-ping: installed '$packName'" -ForegroundColor Green
+                        } else {
+                            $failed += $packName
+                        }
+                    }
+
+                    if ($failed.Count -gt 0) {
+                        Write-Host "Error: failed to install: $($failed -join ', ')" -ForegroundColor Red
+                    }
+                    return
+                }
+                "install-local" {
+                    $installedPack = Install-PackFromLocal -SourceDir $Arg2 -PacksDir $packsDir
+                    if ($installedPack) {
+                        Write-Host "peon-ping: installed local pack '$installedPack'" -ForegroundColor Green
+                    }
                     return
                 }
                 "next" {
                     $currentPack = Get-ActivePack $cfg
-                    $idx = [array]::IndexOf($available, $currentPack)
-                    $newPack = $available[($idx + 1) % $available.Count]
-                    $raw = Get-Content $ConfigPath -Raw
-                    $updated = $raw -replace '"default_pack"\s*:\s*"[^"]*"', "`"default_pack`": `"$newPack`""
-                    $updated = $updated -replace '"active_pack"\s*:\s*"[^"]*"', "`"active_pack`": `"$newPack`""
-                    if ($updated -ne $raw) { Set-Content $ConfigPath -Value $updated -Encoding UTF8 }
+                    $newPack = Get-NextPackName -Available $available -CurrentPack $currentPack
+                    if (-not $newPack) {
+                        Write-Host "No packs installed." -ForegroundColor Yellow
+                        return
+                    }
+                    Set-SelectedPack -ConfigPath $ConfigPath -PackName $newPack
                     Write-Host "peon-ping: switched to '$newPack'" -ForegroundColor Green
+                    return
+                }
+                "remove" {
+                    if (-not $Arg2) {
+                        Write-Host "Usage: peon packs remove <pack1,pack2>" -ForegroundColor Yellow
+                        return
+                    }
+
+                    $targets = @($Arg2 -split ',' | ForEach-Object { $_.Trim() } | Where-Object { $_ })
+                    $currentPack = Get-ActivePack $cfg
+                    $removedCurrent = $false
+                    foreach ($packName in $targets) {
+                        if ($packName -notmatch '^[A-Za-z0-9_-]+$') {
+                            Write-Host "Error: invalid pack name '$packName'." -ForegroundColor Red
+                            continue
+                        }
+                        $packPath = Join-Path $packsDir $packName
+                        if (-not (Test-Path $packPath -PathType Container)) {
+                            Write-Host "Warning: pack '$packName' is not installed." -ForegroundColor Yellow
+                            continue
+                        }
+                        Remove-Item -LiteralPath $packPath -Recurse -Force
+                        Write-Host "peon-ping: removed '$packName'" -ForegroundColor Green
+                        if ($packName -eq $currentPack) {
+                            $removedCurrent = $true
+                        }
+                    }
+
+                    if ($removedCurrent) {
+                        $available = Get-InstalledPackNames -PacksDir $packsDir
+                        $fallbackPack = if ($available.Count -gt 0) { $available[0] } else { "peon" }
+                        Set-SelectedPack -ConfigPath $ConfigPath -PackName $fallbackPack
+                        Write-Host "peon-ping: active pack removed, switched to '$fallbackPack'" -ForegroundColor Yellow
+                    }
                     return
                 }
                 "bind" {
@@ -1027,45 +1257,9 @@ if ($Command) {
 
                     # If --install, download pack first
                     if ($bindInstall) {
-                        # Download the pack using the installer's pack download logic
-                        $regUrl = "https://peonping.github.io/registry/index.json"
-                        try {
-                            $regResp = Invoke-WebRequest -Uri $regUrl -UseBasicParsing -ErrorAction Stop
-                            $reg = $regResp.Content | ConvertFrom-Json
-                            $packInfo = $reg.packs | Where-Object { $_.name -eq $packName }
-                            if ($packInfo) {
-                                $srcRepo = $packInfo.source_repo
-                                $srcRef = $packInfo.source_ref
-                                $srcPath = $packInfo.source_path
-                                $packBase = "https://raw.githubusercontent.com/$srcRepo/$srcRef/$srcPath"
-                                $pDir = Join-Path $packsDir $packName
-                                $sDir = Join-Path $pDir "sounds"
-                                New-Item -ItemType Directory -Path $sDir -Force | Out-Null
-                                Invoke-WebRequest -Uri "$packBase/openpeon.json" -OutFile (Join-Path $pDir "openpeon.json") -UseBasicParsing -ErrorAction Stop
-                                $mf = Get-Content (Join-Path $pDir "openpeon.json") -Raw | ConvertFrom-Json
-                                $total = 0
-                                $downloaded = 0
-                                foreach ($catN in $mf.categories.PSObject.Properties.Name) {
-                                    $total += $mf.categories.$catN.sounds.Count
-                                }
-                                foreach ($catN in $mf.categories.PSObject.Properties.Name) {
-                                    foreach ($snd in $mf.categories.$catN.sounds) {
-                                        $sf = Split-Path $snd.file -Leaf
-                                        $sp = Join-Path $sDir $sf
-                                        $downloaded++
-                                        if (-not (Test-Path $sp)) {
-                                            Write-Host "`r[$packName] $downloaded/$total downloading..." -NoNewline
-                                            Invoke-WebRequest -Uri "$packBase/sounds/$sf" -OutFile $sp -UseBasicParsing -ErrorAction SilentlyContinue
-                                        }
-                                    }
-                                }
-                                Write-Host "`r[$packName] $total/$total done.          "
-                                # Refresh available list
-                                $available = Get-ChildItem -Path $packsDir -Directory | Where-Object {
-                                    (Get-ChildItem -Path (Join-Path $_.FullName "sounds") -File -ErrorAction SilentlyContinue | Measure-Object).Count -gt 0
-                                } | ForEach-Object { $_.Name } | Sort-Object
-                            }
-                        } catch {
+                        if (Install-PackFromRegistry -PackName $packName -PacksDir $packsDir) {
+                            $available = Get-InstalledPackNames -PacksDir $packsDir
+                        } else {
                             Write-Host "Warning: could not download pack '$packName'" -ForegroundColor Yellow
                         }
                     }
@@ -1362,14 +1556,8 @@ if ($Command) {
                     }
                 }
                 "community" {
-                    $regUrl = "https://peonping.github.io/registry/index.json"
-                    try {
-                        $regResp = Invoke-WebRequest -Uri $regUrl -UseBasicParsing -ErrorAction Stop
-                        $reg = $regResp.Content | ConvertFrom-Json
-                    } catch {
-                        Write-Host "Error: could not fetch registry." -ForegroundColor Red
-                        return
-                    }
+                    $reg = Get-PackRegistry
+                    if (-not $reg) { return }
                     $packs = $reg.packs
                     Write-Host ""
                     Write-Host "  Registry packs ($($packs.Count) available)" -ForegroundColor Cyan
@@ -1418,14 +1606,8 @@ if ($Command) {
                         return
                     }
                     $query = $Arg2.ToLower()
-                    $regUrl = "https://peonping.github.io/registry/index.json"
-                    try {
-                        $regResp = Invoke-WebRequest -Uri $regUrl -UseBasicParsing -ErrorAction Stop
-                        $reg = $regResp.Content | ConvertFrom-Json
-                    } catch {
-                        Write-Host "Error: could not fetch registry." -ForegroundColor Red
-                        return
-                    }
+                    $reg = Get-PackRegistry
+                    if (-not $reg) { return }
                     $matches = @($reg.packs | Where-Object { $_.name.ToLower().Contains($query) })
                     if ($matches.Count -eq 0) {
                         Write-Host "No packs matching '$Arg2'." -ForegroundColor Yellow
@@ -1456,9 +1638,12 @@ if ($Command) {
                     }
                     return
                 }
-                default {
-                    # "list" or no subcommand - show available packs
+                "list" {
                     Write-Host "Available packs:" -ForegroundColor Cyan
+                    if ($available.Count -eq 0) {
+                        Write-Host "  No packs installed." -ForegroundColor Yellow
+                        return
+                    }
                     $currentPack = Get-ActivePack $cfg
                     foreach ($packName in $available) {
                         $soundCount = (Get-ChildItem -Path (Join-Path $packsDir "$packName\sounds") -File -ErrorAction SilentlyContinue | Measure-Object).Count
@@ -1467,16 +1652,22 @@ if ($Command) {
                     }
                     return
                 }
+                default {
+                    Write-Host "Usage: peon packs <list|use|install|install-local|next|remove|community|search|bind|unbind|bindings|ide-bind|ide-unbind|ide-bindings|exclude>" -ForegroundColor Yellow
+                    return
+                }
             }
         }
-        "^--pack$" {
+        "^(--)?pack$" {
             $cfg = Get-PeonConfigRaw $ConfigPath | ConvertFrom-Json
             $packsDir = Join-Path $InstallDir "packs"
-            $available = Get-ChildItem -Path $packsDir -Directory | Where-Object {
-                (Get-ChildItem -Path (Join-Path $_.FullName "sounds") -File -ErrorAction SilentlyContinue | Measure-Object).Count -gt 0
-            } | ForEach-Object { $_.Name } | Sort-Object
+            $available = Get-InstalledPackNames -PacksDir $packsDir
 
             $currentPack = Get-ActivePack $cfg
+            if ($available.Count -eq 0) {
+                Write-Host "No packs installed." -ForegroundColor Yellow
+                return
+            }
             if ($Arg1 -eq "use") {
                 # "peon pack use <name>" - treat Arg2 as the pack name
                 if (-not $Arg2) {
@@ -1486,13 +1677,11 @@ if ($Command) {
                 $newPack = $Arg2
             } elseif ($Arg1 -eq "next") {
                 # "peon pack next" - cycle to next
-                $idx = [array]::IndexOf($available, $currentPack)
-                $newPack = $available[($idx + 1) % $available.Count]
+                $newPack = Get-NextPackName -Available $available -CurrentPack $currentPack
             } elseif ($Arg1) {
                 $newPack = $Arg1
             } else {
-                $idx = [array]::IndexOf($available, $currentPack)
-                $newPack = $available[($idx + 1) % $available.Count]
+                $newPack = Get-NextPackName -Available $available -CurrentPack $currentPack
             }
 
             if ($newPack -notin $available) {
@@ -1500,14 +1689,11 @@ if ($Command) {
                 return
             }
 
-            $raw = Get-Content $ConfigPath -Raw
-            $updated = $raw -replace '"default_pack"\s*:\s*"[^"]*"', "`"default_pack`": `"$newPack`""
-            $updated = $updated -replace '"active_pack"\s*:\s*"[^"]*"', "`"active_pack`": `"$newPack`""
-            if ($updated -ne $raw) { Set-Content $ConfigPath -Value $updated -Encoding UTF8 }
+            Set-SelectedPack -ConfigPath $ConfigPath -PackName $newPack
             Write-Host "peon-ping: switched to '$newPack'" -ForegroundColor Green
             return
         }
-        "^--volume$" {
+        "^(--)?volume$" {
             if ($Arg1) {
                 $vol = [math]::Round([math]::Max(0.0, [math]::Min(1.0, [double]::Parse($Arg1.Trim(), [System.Globalization.CultureInfo]::InvariantCulture))), 2)
                 $volStr = $vol.ToString([System.Globalization.CultureInfo]::InvariantCulture)
@@ -1516,7 +1702,8 @@ if ($Command) {
                 if ($updated -ne $raw) { Set-Content $ConfigPath -Value $updated -Encoding UTF8 }
                 Write-Host "peon-ping: volume set to $vol" -ForegroundColor Green
             } else {
-                Write-Host "Usage: peon --volume 0.5" -ForegroundColor Yellow
+                $cfg = Get-PeonConfigRaw $ConfigPath | ConvertFrom-Json
+                Write-Host "peon-ping: volume $($cfg.volume)" -ForegroundColor Cyan
             }
             return
         }
@@ -1735,7 +1922,7 @@ if ($Command) {
                 }
             }
         }
-        "^--update$" {
+        "^(--)?update$" {
             Write-Host "Updating peon-ping..." -ForegroundColor Cyan
             # Migrate config keys (active_pack → default_pack, agentskill → session_override)
             $cfgObj = Get-PeonConfigRaw $ConfigPath | ConvertFrom-Json
@@ -1781,32 +1968,40 @@ if ($Command) {
             }
             return
         }
-        "^--help$" {
+        "^(--)?help$" {
             Write-Host "peon-ping commands:" -ForegroundColor Cyan
-            Write-Host "  --toggle              Toggle enabled/paused"
-            Write-Host "  --pause               Pause sounds"
-            Write-Host "  --resume              Resume sounds"
-            Write-Host "  --mute                Alias for --pause"
-            Write-Host "  --unmute              Alias for --resume"
-            Write-Host "  --status              Show current status"
-            Write-Host "  --volume N            Set volume (0.0-1.0)"
-            Write-Host "  --update              Update peon-ping (migrate config + reinstall)"
-            Write-Host "  --help                Show this help"
+            Write-Host "  peon toggle           Toggle enabled/paused"
+            Write-Host "  peon pause            Pause sounds"
+            Write-Host "  peon resume           Resume sounds"
+            Write-Host "  peon mute             Alias for pause"
+            Write-Host "  peon unmute           Alias for resume"
+            Write-Host "  peon status           Show current status"
+            Write-Host "  peon status --verbose Show expanded status details"
+            Write-Host "  peon volume           Show current volume"
+            Write-Host "  peon volume N         Set volume (0.0-1.0)"
+            Write-Host "  peon update           Update peon-ping (migrate config + reinstall)"
+            Write-Host "  peon help             Show this help"
             Write-Host ""
             Write-Host "Pack management:" -ForegroundColor Cyan
-            Write-Host "  --packs               List installed sound packs"
-            Write-Host "  --packs use <name>    Switch to pack (auto-installs from registry)"
-            Write-Host "  --packs next          Cycle to the next pack"
-            Write-Host "  --packs community     List all packs from registry"
-            Write-Host "  --packs search <q>    Search registry packs by name"
-            Write-Host "  --packs bind          Bind a pack to current directory"
-            Write-Host "  --packs unbind        Remove a pack binding"
-            Write-Host "  --packs bindings      List all pack bindings"
-            Write-Host "  --packs ide-bind      Bind a pack to an IDE id"
-            Write-Host "  --packs ide-unbind    Remove an IDE binding"
-            Write-Host "  --packs ide-bindings  List all IDE bindings"
-            Write-Host "  --packs exclude       Manage excluded paths for path_rules"
-            Write-Host "  --pack [name]         Switch pack (or cycle)"
+            Write-Host "  peon packs list              List installed sound packs"
+            Write-Host "  peon packs list --registry   List all packs from registry"
+            Write-Host "  peon packs use <name>        Switch to pack (auto-installs from registry)"
+            Write-Host "  peon packs use --install <name> Install/update then switch"
+            Write-Host "  peon packs install <p1,p2>   Install pack(s) from registry"
+            Write-Host "  peon packs install --all     Install every registry pack"
+            Write-Host "  peon packs install-local <path> Install a local pack directory"
+            Write-Host "  peon packs next              Cycle to the next pack"
+            Write-Host "  peon packs remove <p1,p2>    Remove installed pack(s)"
+            Write-Host "  peon packs community         List all packs from registry"
+            Write-Host "  peon packs search <q>        Search registry packs by name"
+            Write-Host "  peon packs bind              Bind a pack to current directory"
+            Write-Host "  peon packs unbind            Remove a pack binding"
+            Write-Host "  peon packs bindings          List all pack bindings"
+            Write-Host "  peon packs ide-bind          Bind a pack to an IDE id"
+            Write-Host "  peon packs ide-unbind        Remove an IDE binding"
+            Write-Host "  peon packs ide-bindings      List all IDE bindings"
+            Write-Host "  peon packs exclude           Manage excluded paths for path_rules"
+            Write-Host "  peon pack [name]             Switch pack (or cycle)"
             Write-Host ""
             Write-Host "Trainer:" -ForegroundColor Cyan
             Write-Host "  trainer on            Enable trainer mode"
@@ -1818,12 +2013,12 @@ if ($Command) {
             Write-Host "  trainer help          Show trainer help"
             Write-Host ""
             Write-Host "Notifications:" -ForegroundColor Cyan
-            Write-Host "  --notifications on    Enable desktop notifications"
-            Write-Host "  --notifications off   Disable desktop notifications"
-            Write-Host "  --notifications template            Show all templates"
-            Write-Host "  --notifications template <key> <fmt> Set a template"
-            Write-Host "  --notifications template --reset    Clear all templates"
-            Write-Host "  --popups on/off       Alias for --notifications on/off"
+            Write-Host "  peon notifications on         Enable desktop notifications"
+            Write-Host "  peon notifications off        Disable desktop notifications"
+            Write-Host "  peon notifications template               Show all templates"
+            Write-Host "  peon notifications template <key> <fmt>  Set a template"
+            Write-Host "  peon notifications template --reset      Clear all templates"
+            Write-Host "  peon popups on/off            Alias for notifications on/off"
             Write-Host ""
             Write-Host "Debug & Logs:" -ForegroundColor Cyan
             Write-Host "  debug on              Enable debug logging"
@@ -1835,9 +2030,11 @@ if ($Command) {
             Write-Host "  logs --session ID --all  Search all log files for session ID"
             Write-Host "  logs --prune          Delete logs older than debug_retention_days"
             Write-Host "  logs --clear          Delete all log files"
+            Write-Host ""
+            Write-Host "Legacy --status/--toggle/--packs/--volume forms still work." -ForegroundColor DarkGray
             return
         }
-        "^--(notifications|popups)$" {
+        "^(--)?(notifications|popups)$" {
             $notifSub = if ($Arg1) { $Arg1 } else { "help" }
             switch ($notifSub) {
                 "on" {
@@ -3127,35 +3324,33 @@ foreach ($adapterFile in $adapterFiles) {
 }
 Write-Host "  Installed $($adapterFiles.Count) adapter scripts to $adaptersDir"
 
-# --- Install CLI shortcut ---
+# --- Install CLI shortcut (global installs only) ---
 # Prefer pwsh (PowerShell 7+) when available, fall back to Windows PowerShell 5.1.
 # pwsh has its own clean module path; powershell.exe can fail when PSModulePath
 # leaks PS 7 module dirs in front of the 5.1 inbox modules (seen on dev
-# environments where CloudSDK or similar polluted PSModulePath) — symptom is
+# environments where CloudSDK or similar polluted PSModulePath), symptom is
 # "Microsoft.PowerShell.Security module could not be loaded" on Get-ExecutionPolicy.
-$peonCli = @"
+$peonPs1Path = Join-Path $InstallDir "peon.ps1"
+$utf8NoBom = New-Object System.Text.UTF8Encoding $false
+if (-not $Local) {
+    $peonCli = @"
 @echo off
 where pwsh >nul 2>&1
 if %ERRORLEVEL% equ 0 (
-    pwsh -NoProfile -NonInteractive -Command "& '%USERPROFILE%\.claude\hooks\peon-ping\peon.ps1' %*"
+    pwsh -NoProfile -NonInteractive -Command "& '$peonPs1Path' %*"
 ) else (
-    powershell -NoProfile -NonInteractive -Command "& '%USERPROFILE%\.claude\hooks\peon-ping\peon.ps1' %*"
+    powershell -NoProfile -NonInteractive -Command "& '$peonPs1Path' %*"
 )
 "@
-$cliBinDir = Join-Path $env:USERPROFILE ".local\bin"
-if (-not (Test-Path $cliBinDir)) {
-    New-Item -ItemType Directory -Path $cliBinDir -Force | Out-Null
-}
-$cliBatPath = Join-Path $cliBinDir "peon.cmd"
-# Use UTF-8 without BOM to support special characters while avoiding BOM issues
-$utf8NoBom = New-Object System.Text.UTF8Encoding $false
-[System.IO.File]::WriteAllLines($cliBatPath, $peonCli.Split("`n"), $utf8NoBom)
+    $cliBinDir = Join-Path $env:USERPROFILE ".local\bin"
+    if (-not (Test-Path $cliBinDir)) {
+        New-Item -ItemType Directory -Path $cliBinDir -Force | Out-Null
+    }
+    $cliBatPath = Join-Path $cliBinDir "peon.cmd"
+    [System.IO.File]::WriteAllLines($cliBatPath, $peonCli.Split("`n"), $utf8NoBom)
 
-# Also create a bash-compatible script for Git Bash / WSL.
-# Use the actual Windows path (resolved at install time) to avoid path translation issues.
-# Same pwsh-then-powershell preference as peon.cmd above.
-$peonPs1Path = Join-Path $InstallDir "peon.ps1"
-$peonShScript = @"
+    # Also create a bash-compatible script for Git Bash / WSL
+    $peonShScript = @"
 #!/usr/bin/env bash
 # peon-ping CLI wrapper for Git Bash / WSL / Unix shells on Windows
 if command -v pwsh >/dev/null 2>&1; then
@@ -3165,19 +3360,34 @@ else
 fi
 "`$PS_EXE" -NoProfile -NonInteractive -Command "& '$peonPs1Path' `$*"
 "@
-$peonShPath = Join-Path $cliBinDir "peon"
-[System.IO.File]::WriteAllLines($peonShPath, $peonShScript.Split("`n"), $utf8NoBom)
-# Make executable (for Git Bash)
-if (Get-Command "icacls" -ErrorAction SilentlyContinue) {
-    icacls $peonShPath /grant:r "$env:USERNAME:(RX)" | Out-Null
-}
+    $peonShPath = Join-Path $cliBinDir "peon"
+    [System.IO.File]::WriteAllLines($peonShPath, $peonShScript.Split("`n"), $utf8NoBom)
 
-# Add to PATH if not already there
-$userPath = [Environment]::GetEnvironmentVariable("PATH", "User")
-if ($userPath -notlike "*$cliBinDir*") {
-    [Environment]::SetEnvironmentVariable("PATH", "$userPath;$cliBinDir", "User")
-    Write-Host ""
-    Write-Host "  Added $cliBinDir to PATH" -ForegroundColor Green
+    # Make executable (for Git Bash)
+    if (Get-Command "icacls" -ErrorAction SilentlyContinue) {
+        $aclPrincipal = "$($env:USERNAME):(RX)"
+        $null = & icacls $peonShPath /grant:r $aclPrincipal 2>$null
+        if ($LASTEXITCODE -ne 0) {
+            Write-Host "  Warning: Could not mark Git Bash shim as executable. Run 'chmod +x $peonShPath' manually if needed." -ForegroundColor Yellow
+        }
+    }
+
+    # Add to PATH if not already there
+    try {
+        $userPath = [Environment]::GetEnvironmentVariable("PATH", "User")
+        if ([string]::IsNullOrWhiteSpace($userPath)) {
+            [Environment]::SetEnvironmentVariable("PATH", $cliBinDir, "User")
+            Write-Host ""
+            Write-Host "  Added $cliBinDir to PATH" -ForegroundColor Green
+        } elseif ($userPath -notlike "*$cliBinDir*") {
+            [Environment]::SetEnvironmentVariable("PATH", "$userPath;$cliBinDir", "User")
+            Write-Host ""
+            Write-Host "  Added $cliBinDir to PATH" -ForegroundColor Green
+        }
+    } catch {
+        Write-Host ""
+        Write-Host "  Warning: Could not update PATH automatically. Add $cliBinDir manually if 'peon' is not found." -ForegroundColor Yellow
+    }
 }
 
 # --- Update Claude Code settings.json with hooks ---
@@ -3317,7 +3527,7 @@ Write-Host "  UserPromptSubmit hook registered for /peon-ping-use" -ForegroundCo
 $CursorDir = Join-Path $env:USERPROFILE ".cursor"
 $CursorHooksFile = Join-Path $CursorDir "hooks.json"
 
-if (Test-Path $CursorDir) {
+if ((-not $Local) -and (Test-Path $CursorDir)) {
     Write-Host ""
     Write-Host "Detected Cursor IDE installation, registering hooks..."
     
@@ -3395,7 +3605,7 @@ if (Test-Path $CursorDir) {
 $DeepagentsDir = Join-Path $env:USERPROFILE ".deepagents"
 $DeepagentsHooksFile = Join-Path $DeepagentsDir "hooks.json"
 
-if (Test-Path $DeepagentsDir) {
+if ((-not $Local) -and (Test-Path $DeepagentsDir)) {
     Write-Host ""
     Write-Host "Detected deepagents-cli installation, registering hooks..."
 
@@ -3579,16 +3789,21 @@ if ($Updating) {
     Write-Host "  Active pack: $activePack" -ForegroundColor Cyan
     Write-Host "  Volume: 0.5" -ForegroundColor Cyan
     Write-Host ""
-    Write-Host "  Commands (open a new terminal first):" -ForegroundColor White
-    Write-Host "    peon --status     Show status"
-    Write-Host "    peon --packs      List sound packs"
-    Write-Host "    peon --pack NAME  Switch pack"
-    Write-Host "    peon --volume N   Set volume (0.0-1.0)"
-    Write-Host "    peon --pause      Mute sounds"
-    Write-Host "    peon --resume     Unmute sounds"
-    Write-Host "    peon --mute       Alias for --pause"
-    Write-Host "    peon --unmute     Alias for --resume"
-    Write-Host "    peon --toggle     Toggle on/off"
+    if ($Local) {
+        Write-Host "  Project-local install: Claude Code hooks and skills were written to $ClaudeDir" -ForegroundColor White
+        Write-Host "  Global 'peon' CLI shim was not installed in local mode." -ForegroundColor DarkGray
+    } else {
+        Write-Host "  Commands (open a new terminal first):" -ForegroundColor White
+        Write-Host "    peon status         Show status"
+        Write-Host "    peon packs list     List sound packs"
+        Write-Host "    peon packs use NAME Switch pack"
+        Write-Host "    peon volume N       Set volume (0.0-1.0)"
+        Write-Host "    peon pause          Mute sounds"
+        Write-Host "    peon resume         Unmute sounds"
+        Write-Host "    peon mute           Alias for pause"
+        Write-Host "    peon unmute         Alias for resume"
+        Write-Host "    peon toggle         Toggle on/off"
+    }
     Write-Host ""
     Write-Host "  Start Claude Code and you'll hear: `"Ready to work?`"" -ForegroundColor Yellow
     Write-Host ""
@@ -3604,6 +3819,8 @@ if ($Updating) {
     }
     Write-Host "  To install specific packs: .\install.ps1 -Packs peon,glados,peasant" -ForegroundColor DarkGray
     Write-Host "  To install ALL packs: .\install.ps1 -All" -ForegroundColor DarkGray
+    Write-Host "  To install project-locally: .\install.ps1 -Local" -ForegroundColor DarkGray
+    Write-Host "  To create only project-local config: .\install.ps1 -InitLocalConfig" -ForegroundColor DarkGray
     Write-Host "  To uninstall: powershell -File `"$InstallDir\uninstall.ps1`"" -ForegroundColor DarkGray
 }
 Write-Host ""

--- a/install.ps1
+++ b/install.ps1
@@ -2019,6 +2019,8 @@ if ($Command) {
             Write-Host "  peon notifications template <key> <fmt>  Set a template"
             Write-Host "  peon notifications template --reset      Clear all templates"
             Write-Host "  peon popups on/off            Alias for notifications on/off"
+            Write-Host "  --notifications on/off        Legacy alias for peon notifications on/off"
+            Write-Host "  --popups on/off               Legacy alias for peon popups on/off"
             Write-Host ""
             Write-Host "Debug & Logs:" -ForegroundColor Cyan
             Write-Host "  debug on              Enable debug logging"

--- a/install.ps1
+++ b/install.ps1
@@ -5,9 +5,12 @@
 
 param(
     [Parameter()]
-    $Packs = @(),
+    [string[]]$Packs = @(),
     [switch]$All,
-    [string]$Lang = ""
+    [string]$Lang = "",
+    [switch]$Local,
+    [switch]$Global,
+    [switch]$InitLocalConfig
 )
 
 # When run via Invoke-Expression (one-liner install), $PSScriptRoot is empty.
@@ -15,6 +18,22 @@ param(
 $ScriptDir = if ($PSScriptRoot) { $PSScriptRoot } else { $PWD.Path }
 
 $ErrorActionPreference = "Stop"
+
+if ($Local -and $Global) {
+    throw "Use either -Local or -Global, not both."
+}
+
+# Windows PowerShell 5.1 can default to older TLS versions, which breaks the
+# one-liner install against GitHub raw URLs on some systems.
+if ($PSVersionTable.PSEdition -ne "Core") {
+    try {
+        [Net.ServicePointManager]::SecurityProtocol = `
+            [Net.ServicePointManager]::SecurityProtocol -bor `
+            [Net.SecurityProtocolType]::Tls12
+    } catch {
+        # Best effort only.
+    }
+}
 
 # --- Input validation & config helpers (dot-sourced from scripts/install-utils.ps1) ---
 if (-not $PSScriptRoot) {
@@ -45,11 +64,39 @@ if ($policy -eq "Restricted") {
 
 
 # --- Paths ---
-$ClaudeDir = Join-Path $env:USERPROFILE ".claude"
+$GlobalClaudeDir = Join-Path $env:USERPROFILE ".claude"
+$LocalClaudeDir = Join-Path $PWD.Path ".claude"
+$ClaudeDir = if ($Local) { $LocalClaudeDir } else { $GlobalClaudeDir }
 $InstallDir = Join-Path $ClaudeDir "hooks\peon-ping"
 $SettingsFile = Join-Path $ClaudeDir "settings.json"
 $RegistryUrl = "https://peonping.github.io/registry/index.json"
 $RepoBase = "https://raw.githubusercontent.com/PeonPing/peon-ping/main"
+
+# --- Local config bootstrap ---
+if ($InitLocalConfig) {
+    $localConfigDir = Join-Path $LocalClaudeDir "hooks\peon-ping"
+    $localConfigFile = Join-Path $localConfigDir "config.json"
+    New-Item -ItemType Directory -Path $localConfigDir -Force | Out-Null
+
+    if (Test-Path $localConfigFile) {
+        Write-Host "Local config already exists: $localConfigFile" -ForegroundColor Yellow
+        return
+    }
+
+    $globalConfigFile = Join-Path $GlobalClaudeDir "hooks\peon-ping\config.json"
+    $repoConfigFile = if ($PSScriptRoot) { Join-Path $ScriptDir "config.json" } else { $null }
+
+    if (Test-Path $globalConfigFile) {
+        Copy-Item -Path $globalConfigFile -Destination $localConfigFile -Force
+    } elseif ($repoConfigFile -and (Test-Path $repoConfigFile)) {
+        Copy-Item -Path $repoConfigFile -Destination $localConfigFile -Force
+    } else {
+        Invoke-WebRequest -Uri "$RepoBase/config.json" -OutFile $localConfigFile -UseBasicParsing -ErrorAction Stop
+    }
+
+    Write-Host "Created local config: $localConfigFile" -ForegroundColor Green
+    return
+}
 
 # --- Check Claude Code is installed ---
 $Updating = $false
@@ -59,7 +106,12 @@ if (Test-Path (Join-Path $InstallDir "peon.ps1")) {
 }
 
 $ClaudeCodeDetected = $true
-if (-not (Test-Path $ClaudeDir)) {
+if ($Local) {
+    if (-not (Test-Path $ClaudeDir)) {
+        Write-Host "Creating project-local Claude config at $ClaudeDir" -ForegroundColor DarkGray
+        New-Item -ItemType Directory -Path $ClaudeDir -Force | Out-Null
+    }
+} elseif (-not (Test-Path $ClaudeDir)) {
     $ClaudeCodeDetected = $false
     Write-Host "Note: $ClaudeDir not found (Claude Code may not be installed)." -ForegroundColor Yellow
     Write-Host "Installing adapters and packs only. Claude Code hooks will be skipped." -ForegroundColor Yellow
@@ -514,21 +566,65 @@ function Detect-SessionIde {
 }
 
 # Install a pack from the registry by name. Returns $true on success, $false on failure.
-function Install-PackFromRegistry {
-    param([string]$PackName, [string]$PacksDir)
+function Get-PackRegistry {
     $regUrl = "https://peonping.github.io/registry/index.json"
     try {
         $regResp = Invoke-WebRequest -Uri $regUrl -UseBasicParsing -ErrorAction Stop
-        $reg = $regResp.Content | ConvertFrom-Json
+        return ($regResp.Content | ConvertFrom-Json)
     } catch {
         Write-Host "Error: could not fetch registry." -ForegroundColor Red
-        return $false
+        return $null
     }
-    $packInfo = $reg.packs | Where-Object { $_.name -eq $PackName }
-    if (-not $packInfo) { return $false }
-    $srcRepo = $packInfo.source_repo
-    $srcRef = $packInfo.source_ref
-    $srcPath = $packInfo.source_path
+}
+
+function Get-InstalledPackNames {
+    param([string]$PacksDir)
+
+    if (-not (Test-Path $PacksDir)) {
+        return @()
+    }
+
+    return @(Get-ChildItem -Path $PacksDir -Directory | Where-Object {
+        (Get-ChildItem -Path (Join-Path $_.FullName "sounds") -File -ErrorAction SilentlyContinue | Measure-Object).Count -gt 0
+    } | ForEach-Object { $_.Name } | Sort-Object)
+}
+
+function Get-NextPackName {
+    param([string[]]$Available, [string]$CurrentPack)
+
+    if (-not $Available -or $Available.Count -eq 0) {
+        return $null
+    }
+
+    $idx = [array]::IndexOf($Available, $CurrentPack)
+    if ($idx -lt 0) {
+        return $Available[0]
+    }
+
+    return $Available[($idx + 1) % $Available.Count]
+}
+
+function Set-SelectedPack {
+    param([string]$ConfigPath, [string]$PackName)
+
+    $raw = Get-Content $ConfigPath -Raw
+    $updated = $raw -replace '"default_pack"\s*:\s*"[^"]*"', "`"default_pack`": `"$PackName`""
+    $updated = $updated -replace '"active_pack"\s*:\s*"[^"]*"', "`"active_pack`": `"$PackName`""
+    if ($updated -ne $raw) {
+        Set-Content $ConfigPath -Value $updated -Encoding UTF8
+    }
+}
+
+function Install-PackFromRegistryEntry {
+    param($PackInfo, [string]$PacksDir)
+
+    if (-not $PackInfo -or -not $PackInfo.name) { return $false }
+
+    $PackName = $PackInfo.name
+    $regUrl = "https://peonping.github.io/registry/index.json"
+    $srcRepo = $PackInfo.source_repo
+    $srcRef = $PackInfo.source_ref
+    $srcPath = $PackInfo.source_path
     if (-not $srcRepo -or -not $srcRef -or ($null -eq $srcPath)) {
         Write-Host "Error: incomplete registry entry for '$PackName'." -ForegroundColor Red
         return $false
@@ -562,6 +658,57 @@ function Install-PackFromRegistry {
     }
     Write-Host "`r[$PackName] $total/$total done.          "
     return $true
+}
+
+function Install-PackFromRegistry {
+    param([string]$PackName, [string]$PacksDir)
+
+    $reg = Get-PackRegistry
+    if (-not $reg) { return $false }
+
+    $packInfo = $reg.packs | Where-Object { $_.name -eq $PackName }
+    if (-not $packInfo) { return $false }
+
+    return (Install-PackFromRegistryEntry -PackInfo $packInfo -PacksDir $PacksDir)
+}
+
+function Install-PackFromLocal {
+    param([string]$SourceDir, [string]$PacksDir)
+
+    if (-not $SourceDir) {
+        Write-Host "Usage: peon packs install-local <path>" -ForegroundColor Yellow
+        return $null
+    }
+
+    if (-not (Test-Path $SourceDir -PathType Container)) {
+        Write-Host "Error: local pack path not found: $SourceDir" -ForegroundColor Red
+        return $null
+    }
+
+    $resolvedSource = (Resolve-Path -LiteralPath $SourceDir).Path
+    $manifestPath = Join-Path $resolvedSource "openpeon.json"
+    $legacyManifestPath = Join-Path $resolvedSource "manifest.json"
+    $soundsDir = Join-Path $resolvedSource "sounds"
+
+    if (-not (Test-Path $soundsDir -PathType Container)) {
+        Write-Host "Error: local pack must contain a sounds directory." -ForegroundColor Red
+        return $null
+    }
+
+    if (-not (Test-Path $manifestPath) -and -not (Test-Path $legacyManifestPath)) {
+        Write-Host "Error: local pack must contain openpeon.json or manifest.json." -ForegroundColor Red
+        return $null
+    }
+
+    $packName = Split-Path $resolvedSource -Leaf
+    $targetDir = Join-Path $PacksDir $packName
+
+    if (Test-Path $targetDir) {
+        Remove-Item -Path $targetDir -Recurse -Force
+    }
+
+    Copy-Item -Path $resolvedSource -Destination $targetDir -Recurse -Force
+    return $packName
 }
 
 # Helper function to convert PSCustomObject to hashtable (PS 5.1 compat)
@@ -803,7 +950,7 @@ if ($Command) {
     }
 
     switch -Regex ($Command) {
-        "^--toggle$" {
+        "^(--)?toggle$" {
             $raw = Get-PeonConfigRaw $ConfigPath
             $cfg = $raw | ConvertFrom-Json
             $newState = -not $cfg.enabled
@@ -814,24 +961,24 @@ if ($Command) {
             Write-Host "peon-ping: $state" -ForegroundColor Cyan
             return
         }
-        "^--(pause|mute)$" {
+        "^(--)?(pause|mute)$" {
             $raw = Get-Content $ConfigPath -Raw
             $updated = $raw -replace '"enabled"\s*:\s*(true|false)', '"enabled": false'
             if ($updated -ne $raw) { Set-Content $ConfigPath -Value $updated -Encoding UTF8 }
             Write-Host "peon-ping: PAUSED" -ForegroundColor Yellow
             return
         }
-        "^--(resume|unmute)$" {
+        "^(--)?(resume|unmute)$" {
             $raw = Get-Content $ConfigPath -Raw
             $updated = $raw -replace '"enabled"\s*:\s*(true|false)', '"enabled": true'
             if ($updated -ne $raw) { Set-Content $ConfigPath -Value $updated -Encoding UTF8 }
             Write-Host "peon-ping: ENABLED" -ForegroundColor Green
             return
         }
-        "^--status$" {
+        "^(--)?status$" {
             try {
                 $cfg = Get-PeonConfigRaw $ConfigPath | ConvertFrom-Json
-                $isVerbose = ($Arg1 -eq "--verbose")
+                $isVerbose = ($Arg1 -eq "--verbose" -or $Arg1 -eq "verbose")
 
                 # --- Essential info (always shown) ---
                 $state = if ($cfg.enabled) { "ENABLED" } else { "PAUSED" }
@@ -956,46 +1103,129 @@ if ($Command) {
             }
             return
         }
-        "^--packs$" {
+        "^(--)?packs$" {
             $packsDir = Join-Path $InstallDir "packs"
             $cfg = Get-PeonConfigRaw $ConfigPath | ConvertFrom-Json
-            $available = Get-ChildItem -Path $packsDir -Directory | Where-Object {
-                (Get-ChildItem -Path (Join-Path $_.FullName "sounds") -File -ErrorAction SilentlyContinue | Measure-Object).Count -gt 0
-            } | ForEach-Object { $_.Name } | Sort-Object
+            $available = Get-InstalledPackNames -PacksDir $packsDir
+            $packsAction = if ($Arg1) { $Arg1 } else { "list" }
+            if ($packsAction -eq "list" -and $Arg2 -eq "--registry") {
+                $packsAction = "community"
+            }
 
-            switch ($Arg1) {
+            switch ($packsAction) {
                 "use" {
-                    if (-not $Arg2) {
-                        Write-Host "Usage: peon packs use <pack-name>" -ForegroundColor Yellow
+                    $installRequested = $false
+                    if ($Arg2 -eq "--install") {
+                        $installRequested = $true
+                        $newPack = if ($ExtraArgs.Count -gt 0) { $ExtraArgs[0] } else { "" }
+                    } else {
+                        $newPack = $Arg2
+                    }
+
+                    if (-not $newPack) {
+                        Write-Host "Usage: peon packs use [--install] <pack-name>" -ForegroundColor Yellow
                         return
                     }
-                    $newPack = $Arg2
-                    if ($newPack -notin $available) {
+
+                    if ($installRequested -or $newPack -notin $available) {
                         Write-Host "Pack '$newPack' not installed locally. Fetching from registry..." -ForegroundColor Yellow
                         $ok = Install-PackFromRegistry -PackName $newPack -PacksDir $packsDir
                         if (-not $ok) {
                             Write-Host "Pack '$newPack' not found in registry." -ForegroundColor Red
                             return
                         }
+                        $available = Get-InstalledPackNames -PacksDir $packsDir
                         Write-Host "peon-ping: installed and switched to '$newPack'" -ForegroundColor Green
                     } else {
                         Write-Host "peon-ping: switched to '$newPack'" -ForegroundColor Green
                     }
-                    $raw = Get-Content $ConfigPath -Raw
-                    $updated = $raw -replace '"default_pack"\s*:\s*"[^"]*"', "`"default_pack`": `"$newPack`""
-                    $updated = $updated -replace '"active_pack"\s*:\s*"[^"]*"', "`"active_pack`": `"$newPack`""
-                    if ($updated -ne $raw) { Set-Content $ConfigPath -Value $updated -Encoding UTF8 }
+                    Set-SelectedPack -ConfigPath $ConfigPath -PackName $newPack
+                    return
+                }
+                "install" {
+                    if (-not $Arg2) {
+                        Write-Host "Usage: peon packs install <pack1,pack2> | --all" -ForegroundColor Yellow
+                        return
+                    }
+
+                    $targets = @()
+                    if ($Arg2 -eq "--all") {
+                        $reg = Get-PackRegistry
+                        if (-not $reg) { return }
+                        $targets = @($reg.packs | ForEach-Object { $_.name })
+                    } else {
+                        $targets = @($Arg2 -split ',' | ForEach-Object { $_.Trim() } | Where-Object { $_ })
+                    }
+
+                    if ($targets.Count -eq 0) {
+                        Write-Host "Usage: peon packs install <pack1,pack2> | --all" -ForegroundColor Yellow
+                        return
+                    }
+
+                    $failed = @()
+                    foreach ($packName in $targets) {
+                        if (Install-PackFromRegistry -PackName $packName -PacksDir $packsDir) {
+                            Write-Host "peon-ping: installed '$packName'" -ForegroundColor Green
+                        } else {
+                            $failed += $packName
+                        }
+                    }
+
+                    if ($failed.Count -gt 0) {
+                        Write-Host "Error: failed to install: $($failed -join ', ')" -ForegroundColor Red
+                    }
+                    return
+                }
+                "install-local" {
+                    $installedPack = Install-PackFromLocal -SourceDir $Arg2 -PacksDir $packsDir
+                    if ($installedPack) {
+                        Write-Host "peon-ping: installed local pack '$installedPack'" -ForegroundColor Green
+                    }
                     return
                 }
                 "next" {
                     $currentPack = Get-ActivePack $cfg
-                    $idx = [array]::IndexOf($available, $currentPack)
-                    $newPack = $available[($idx + 1) % $available.Count]
-                    $raw = Get-Content $ConfigPath -Raw
-                    $updated = $raw -replace '"default_pack"\s*:\s*"[^"]*"', "`"default_pack`": `"$newPack`""
-                    $updated = $updated -replace '"active_pack"\s*:\s*"[^"]*"', "`"active_pack`": `"$newPack`""
-                    if ($updated -ne $raw) { Set-Content $ConfigPath -Value $updated -Encoding UTF8 }
+                    $newPack = Get-NextPackName -Available $available -CurrentPack $currentPack
+                    if (-not $newPack) {
+                        Write-Host "No packs installed." -ForegroundColor Yellow
+                        return
+                    }
+                    Set-SelectedPack -ConfigPath $ConfigPath -PackName $newPack
                     Write-Host "peon-ping: switched to '$newPack'" -ForegroundColor Green
+                    return
+                }
+                "remove" {
+                    if (-not $Arg2) {
+                        Write-Host "Usage: peon packs remove <pack1,pack2>" -ForegroundColor Yellow
+                        return
+                    }
+
+                    $targets = @($Arg2 -split ',' | ForEach-Object { $_.Trim() } | Where-Object { $_ })
+                    $currentPack = Get-ActivePack $cfg
+                    $removedCurrent = $false
+                    foreach ($packName in $targets) {
+                        if ($packName -notmatch '^[A-Za-z0-9_-]+$') {
+                            Write-Host "Error: invalid pack name '$packName'." -ForegroundColor Red
+                            continue
+                        }
+                        $packPath = Join-Path $packsDir $packName
+                        if (-not (Test-Path $packPath -PathType Container)) {
+                            Write-Host "Warning: pack '$packName' is not installed." -ForegroundColor Yellow
+                            continue
+                        }
+                        Remove-Item -LiteralPath $packPath -Recurse -Force
+                        Write-Host "peon-ping: removed '$packName'" -ForegroundColor Green
+                        if ($packName -eq $currentPack) {
+                            $removedCurrent = $true
+                        }
+                    }
+
+                    if ($removedCurrent) {
+                        $available = Get-InstalledPackNames -PacksDir $packsDir
+                        $fallbackPack = if ($available.Count -gt 0) { $available[0] } else { "peon" }
+                        Set-SelectedPack -ConfigPath $ConfigPath -PackName $fallbackPack
+                        Write-Host "peon-ping: active pack removed, switched to '$fallbackPack'" -ForegroundColor Yellow
+                    }
                     return
                 }
                 "bind" {
@@ -1026,45 +1256,9 @@ if ($Command) {
 
                     # If --install, download pack first
                     if ($bindInstall) {
-                        # Download the pack using the installer's pack download logic
-                        $regUrl = "https://peonping.github.io/registry/index.json"
-                        try {
-                            $regResp = Invoke-WebRequest -Uri $regUrl -UseBasicParsing -ErrorAction Stop
-                            $reg = $regResp.Content | ConvertFrom-Json
-                            $packInfo = $reg.packs | Where-Object { $_.name -eq $packName }
-                            if ($packInfo) {
-                                $srcRepo = $packInfo.source_repo
-                                $srcRef = $packInfo.source_ref
-                                $srcPath = $packInfo.source_path
-                                $packBase = "https://raw.githubusercontent.com/$srcRepo/$srcRef/$srcPath"
-                                $pDir = Join-Path $packsDir $packName
-                                $sDir = Join-Path $pDir "sounds"
-                                New-Item -ItemType Directory -Path $sDir -Force | Out-Null
-                                Invoke-WebRequest -Uri "$packBase/openpeon.json" -OutFile (Join-Path $pDir "openpeon.json") -UseBasicParsing -ErrorAction Stop
-                                $mf = Get-Content (Join-Path $pDir "openpeon.json") -Raw | ConvertFrom-Json
-                                $total = 0
-                                $downloaded = 0
-                                foreach ($catN in $mf.categories.PSObject.Properties.Name) {
-                                    $total += $mf.categories.$catN.sounds.Count
-                                }
-                                foreach ($catN in $mf.categories.PSObject.Properties.Name) {
-                                    foreach ($snd in $mf.categories.$catN.sounds) {
-                                        $sf = Split-Path $snd.file -Leaf
-                                        $sp = Join-Path $sDir $sf
-                                        $downloaded++
-                                        if (-not (Test-Path $sp)) {
-                                            Write-Host "`r[$packName] $downloaded/$total downloading..." -NoNewline
-                                            Invoke-WebRequest -Uri "$packBase/sounds/$sf" -OutFile $sp -UseBasicParsing -ErrorAction SilentlyContinue
-                                        }
-                                    }
-                                }
-                                Write-Host "`r[$packName] $total/$total done.          "
-                                # Refresh available list
-                                $available = Get-ChildItem -Path $packsDir -Directory | Where-Object {
-                                    (Get-ChildItem -Path (Join-Path $_.FullName "sounds") -File -ErrorAction SilentlyContinue | Measure-Object).Count -gt 0
-                                } | ForEach-Object { $_.Name } | Sort-Object
-                            }
-                        } catch {
+                        if (Install-PackFromRegistry -PackName $packName -PacksDir $packsDir) {
+                            $available = Get-InstalledPackNames -PacksDir $packsDir
+                        } else {
                             Write-Host "Warning: could not download pack '$packName'" -ForegroundColor Yellow
                         }
                     }
@@ -1362,14 +1556,8 @@ if ($Command) {
                     }
                 }
                 "community" {
-                    $regUrl = "https://peonping.github.io/registry/index.json"
-                    try {
-                        $regResp = Invoke-WebRequest -Uri $regUrl -UseBasicParsing -ErrorAction Stop
-                        $reg = $regResp.Content | ConvertFrom-Json
-                    } catch {
-                        Write-Host "Error: could not fetch registry." -ForegroundColor Red
-                        return
-                    }
+                    $reg = Get-PackRegistry
+                    if (-not $reg) { return }
                     $packs = $reg.packs
                     Write-Host ""
                     Write-Host "  Registry packs ($($packs.Count) available)" -ForegroundColor Cyan
@@ -1418,14 +1606,8 @@ if ($Command) {
                         return
                     }
                     $query = $Arg2.ToLower()
-                    $regUrl = "https://peonping.github.io/registry/index.json"
-                    try {
-                        $regResp = Invoke-WebRequest -Uri $regUrl -UseBasicParsing -ErrorAction Stop
-                        $reg = $regResp.Content | ConvertFrom-Json
-                    } catch {
-                        Write-Host "Error: could not fetch registry." -ForegroundColor Red
-                        return
-                    }
+                    $reg = Get-PackRegistry
+                    if (-not $reg) { return }
                     $matches = @($reg.packs | Where-Object { $_.name.ToLower().Contains($query) })
                     if ($matches.Count -eq 0) {
                         Write-Host "No packs matching '$Arg2'." -ForegroundColor Yellow
@@ -1456,9 +1638,12 @@ if ($Command) {
                     }
                     return
                 }
-                default {
-                    # "list" or no subcommand - show available packs
+                "list" {
                     Write-Host "Available packs:" -ForegroundColor Cyan
+                    if ($available.Count -eq 0) {
+                        Write-Host "  No packs installed." -ForegroundColor Yellow
+                        return
+                    }
                     $currentPack = Get-ActivePack $cfg
                     foreach ($packName in $available) {
                         $soundCount = (Get-ChildItem -Path (Join-Path $packsDir "$packName\sounds") -File -ErrorAction SilentlyContinue | Measure-Object).Count
@@ -1467,16 +1652,22 @@ if ($Command) {
                     }
                     return
                 }
+                default {
+                    Write-Host "Usage: peon packs <list|use|install|install-local|next|remove|community|search|bind|unbind|bindings|ide-bind|ide-unbind|ide-bindings|exclude>" -ForegroundColor Yellow
+                    return
+                }
             }
         }
-        "^--pack$" {
+        "^(--)?pack$" {
             $cfg = Get-PeonConfigRaw $ConfigPath | ConvertFrom-Json
             $packsDir = Join-Path $InstallDir "packs"
-            $available = Get-ChildItem -Path $packsDir -Directory | Where-Object {
-                (Get-ChildItem -Path (Join-Path $_.FullName "sounds") -File -ErrorAction SilentlyContinue | Measure-Object).Count -gt 0
-            } | ForEach-Object { $_.Name } | Sort-Object
+            $available = Get-InstalledPackNames -PacksDir $packsDir
 
             $currentPack = Get-ActivePack $cfg
+            if ($available.Count -eq 0) {
+                Write-Host "No packs installed." -ForegroundColor Yellow
+                return
+            }
             if ($Arg1 -eq "use") {
                 # "peon pack use <name>" - treat Arg2 as the pack name
                 if (-not $Arg2) {
@@ -1486,13 +1677,11 @@ if ($Command) {
                 $newPack = $Arg2
             } elseif ($Arg1 -eq "next") {
                 # "peon pack next" - cycle to next
-                $idx = [array]::IndexOf($available, $currentPack)
-                $newPack = $available[($idx + 1) % $available.Count]
+                $newPack = Get-NextPackName -Available $available -CurrentPack $currentPack
             } elseif ($Arg1) {
                 $newPack = $Arg1
             } else {
-                $idx = [array]::IndexOf($available, $currentPack)
-                $newPack = $available[($idx + 1) % $available.Count]
+                $newPack = Get-NextPackName -Available $available -CurrentPack $currentPack
             }
 
             if ($newPack -notin $available) {
@@ -1500,14 +1689,11 @@ if ($Command) {
                 return
             }
 
-            $raw = Get-Content $ConfigPath -Raw
-            $updated = $raw -replace '"default_pack"\s*:\s*"[^"]*"', "`"default_pack`": `"$newPack`""
-            $updated = $updated -replace '"active_pack"\s*:\s*"[^"]*"', "`"active_pack`": `"$newPack`""
-            if ($updated -ne $raw) { Set-Content $ConfigPath -Value $updated -Encoding UTF8 }
+            Set-SelectedPack -ConfigPath $ConfigPath -PackName $newPack
             Write-Host "peon-ping: switched to '$newPack'" -ForegroundColor Green
             return
         }
-        "^--volume$" {
+        "^(--)?volume$" {
             if ($Arg1) {
                 $vol = [math]::Round([math]::Max(0.0, [math]::Min(1.0, [double]::Parse($Arg1.Trim(), [System.Globalization.CultureInfo]::InvariantCulture))), 2)
                 $volStr = $vol.ToString([System.Globalization.CultureInfo]::InvariantCulture)
@@ -1516,7 +1702,8 @@ if ($Command) {
                 if ($updated -ne $raw) { Set-Content $ConfigPath -Value $updated -Encoding UTF8 }
                 Write-Host "peon-ping: volume set to $vol" -ForegroundColor Green
             } else {
-                Write-Host "Usage: peon --volume 0.5" -ForegroundColor Yellow
+                $cfg = Get-PeonConfigRaw $ConfigPath | ConvertFrom-Json
+                Write-Host "peon-ping: volume $($cfg.volume)" -ForegroundColor Cyan
             }
             return
         }
@@ -1735,7 +1922,7 @@ if ($Command) {
                 }
             }
         }
-        "^--update$" {
+        "^(--)?update$" {
             Write-Host "Updating peon-ping..." -ForegroundColor Cyan
             # Migrate config keys (active_pack → default_pack, agentskill → session_override)
             $cfgObj = Get-PeonConfigRaw $ConfigPath | ConvertFrom-Json
@@ -1785,32 +1972,40 @@ if ($Command) {
             }
             return
         }
-        "^--help$" {
+        "^(--)?help$" {
             Write-Host "peon-ping commands:" -ForegroundColor Cyan
-            Write-Host "  --toggle              Toggle enabled/paused"
-            Write-Host "  --pause               Pause sounds"
-            Write-Host "  --resume              Resume sounds"
-            Write-Host "  --mute                Alias for --pause"
-            Write-Host "  --unmute              Alias for --resume"
-            Write-Host "  --status              Show current status"
-            Write-Host "  --volume N            Set volume (0.0-1.0)"
-            Write-Host "  --update              Update peon-ping (migrate config + reinstall)"
-            Write-Host "  --help                Show this help"
+            Write-Host "  peon toggle           Toggle enabled/paused"
+            Write-Host "  peon pause            Pause sounds"
+            Write-Host "  peon resume           Resume sounds"
+            Write-Host "  peon mute             Alias for pause"
+            Write-Host "  peon unmute           Alias for resume"
+            Write-Host "  peon status           Show current status"
+            Write-Host "  peon status --verbose Show expanded status details"
+            Write-Host "  peon volume           Show current volume"
+            Write-Host "  peon volume N         Set volume (0.0-1.0)"
+            Write-Host "  peon update           Update peon-ping (migrate config + reinstall)"
+            Write-Host "  peon help             Show this help"
             Write-Host ""
             Write-Host "Pack management:" -ForegroundColor Cyan
-            Write-Host "  --packs               List installed sound packs"
-            Write-Host "  --packs use <name>    Switch to pack (auto-installs from registry)"
-            Write-Host "  --packs next          Cycle to the next pack"
-            Write-Host "  --packs community     List all packs from registry"
-            Write-Host "  --packs search <q>    Search registry packs by name"
-            Write-Host "  --packs bind          Bind a pack to current directory"
-            Write-Host "  --packs unbind        Remove a pack binding"
-            Write-Host "  --packs bindings      List all pack bindings"
-            Write-Host "  --packs ide-bind      Bind a pack to an IDE id"
-            Write-Host "  --packs ide-unbind    Remove an IDE binding"
-            Write-Host "  --packs ide-bindings  List all IDE bindings"
-            Write-Host "  --packs exclude       Silence sounds & notifications for matching paths"
-            Write-Host "  --pack [name]         Switch pack (or cycle)"
+            Write-Host "  peon packs list              List installed sound packs"
+            Write-Host "  peon packs list --registry   List all packs from registry"
+            Write-Host "  peon packs use <name>        Switch to pack (auto-installs from registry)"
+            Write-Host "  peon packs use --install <name> Install/update then switch"
+            Write-Host "  peon packs install <p1,p2>   Install pack(s) from registry"
+            Write-Host "  peon packs install --all     Install every registry pack"
+            Write-Host "  peon packs install-local <path> Install a local pack directory"
+            Write-Host "  peon packs next              Cycle to the next pack"
+            Write-Host "  peon packs remove <p1,p2>    Remove installed pack(s)"
+            Write-Host "  peon packs community         List all packs from registry"
+            Write-Host "  peon packs search <q>        Search registry packs by name"
+            Write-Host "  peon packs bind              Bind a pack to current directory"
+            Write-Host "  peon packs unbind            Remove a pack binding"
+            Write-Host "  peon packs bindings          List all pack bindings"
+            Write-Host "  peon packs ide-bind          Bind a pack to an IDE id"
+            Write-Host "  peon packs ide-unbind        Remove an IDE binding"
+            Write-Host "  peon packs ide-bindings      List all IDE bindings"
+            Write-Host "  peon packs exclude           Manage excluded paths for path_rules"
+            Write-Host "  peon pack [name]             Switch pack (or cycle)"
             Write-Host ""
             Write-Host "Trainer:" -ForegroundColor Cyan
             Write-Host "  trainer on            Enable trainer mode"
@@ -1822,12 +2017,12 @@ if ($Command) {
             Write-Host "  trainer help          Show trainer help"
             Write-Host ""
             Write-Host "Notifications:" -ForegroundColor Cyan
-            Write-Host "  --notifications on    Enable desktop notifications"
-            Write-Host "  --notifications off   Disable desktop notifications"
-            Write-Host "  --notifications template            Show all templates"
-            Write-Host "  --notifications template <key> <fmt> Set a template"
-            Write-Host "  --notifications template --reset    Clear all templates"
-            Write-Host "  --popups on/off       Alias for --notifications on/off"
+            Write-Host "  peon notifications on         Enable desktop notifications"
+            Write-Host "  peon notifications off        Disable desktop notifications"
+            Write-Host "  peon notifications template               Show all templates"
+            Write-Host "  peon notifications template <key> <fmt>  Set a template"
+            Write-Host "  peon notifications template --reset      Clear all templates"
+            Write-Host "  peon popups on/off            Alias for notifications on/off"
             Write-Host ""
             Write-Host "Debug & Logs:" -ForegroundColor Cyan
             Write-Host "  debug on              Enable debug logging"
@@ -1839,9 +2034,11 @@ if ($Command) {
             Write-Host "  logs --session ID --all  Search all log files for session ID"
             Write-Host "  logs --prune          Delete logs older than debug_retention_days"
             Write-Host "  logs --clear          Delete all log files"
+            Write-Host ""
+            Write-Host "Legacy --status/--toggle/--packs/--volume forms still work." -ForegroundColor DarkGray
             return
         }
-        "^--(notifications|popups)$" {
+        "^(--)?(notifications|popups)$" {
             $notifSub = if ($Arg1) { $Arg1 } else { "help" }
             switch ($notifSub) {
                 "on" {
@@ -3189,35 +3386,33 @@ foreach ($adapterFile in $adapterFiles) {
 }
 Write-Host "  Installed $($adapterFiles.Count) adapter scripts to $adaptersDir"
 
-# --- Install CLI shortcut ---
+# --- Install CLI shortcut (global installs only) ---
 # Prefer pwsh (PowerShell 7+) when available, fall back to Windows PowerShell 5.1.
 # pwsh has its own clean module path; powershell.exe can fail when PSModulePath
 # leaks PS 7 module dirs in front of the 5.1 inbox modules (seen on dev
-# environments where CloudSDK or similar polluted PSModulePath) — symptom is
+# environments where CloudSDK or similar polluted PSModulePath), symptom is
 # "Microsoft.PowerShell.Security module could not be loaded" on Get-ExecutionPolicy.
-$peonCli = @"
+$peonPs1Path = Join-Path $InstallDir "peon.ps1"
+$utf8NoBom = New-Object System.Text.UTF8Encoding $false
+if (-not $Local) {
+    $peonCli = @"
 @echo off
 where pwsh >nul 2>&1
 if %ERRORLEVEL% equ 0 (
-    pwsh -NoProfile -NonInteractive -Command "& '%USERPROFILE%\.claude\hooks\peon-ping\peon.ps1' %*"
+    pwsh -NoProfile -NonInteractive -Command "& '$peonPs1Path' %*"
 ) else (
-    powershell -NoProfile -NonInteractive -Command "& '%USERPROFILE%\.claude\hooks\peon-ping\peon.ps1' %*"
+    powershell -NoProfile -NonInteractive -Command "& '$peonPs1Path' %*"
 )
 "@
-$cliBinDir = Join-Path $env:USERPROFILE ".local\bin"
-if (-not (Test-Path $cliBinDir)) {
-    New-Item -ItemType Directory -Path $cliBinDir -Force | Out-Null
-}
-$cliBatPath = Join-Path $cliBinDir "peon.cmd"
-# Use UTF-8 without BOM to support special characters while avoiding BOM issues
-$utf8NoBom = New-Object System.Text.UTF8Encoding $false
-[System.IO.File]::WriteAllLines($cliBatPath, $peonCli.Split("`n"), $utf8NoBom)
+    $cliBinDir = Join-Path $env:USERPROFILE ".local\bin"
+    if (-not (Test-Path $cliBinDir)) {
+        New-Item -ItemType Directory -Path $cliBinDir -Force | Out-Null
+    }
+    $cliBatPath = Join-Path $cliBinDir "peon.cmd"
+    [System.IO.File]::WriteAllLines($cliBatPath, $peonCli.Split("`n"), $utf8NoBom)
 
-# Also create a bash-compatible script for Git Bash / WSL.
-# Use the actual Windows path (resolved at install time) to avoid path translation issues.
-# Same pwsh-then-powershell preference as peon.cmd above.
-$peonPs1Path = Join-Path $InstallDir "peon.ps1"
-$peonShScript = @"
+    # Also create a bash-compatible script for Git Bash / WSL
+    $peonShScript = @"
 #!/usr/bin/env bash
 # peon-ping CLI wrapper for Git Bash / WSL / Unix shells on Windows
 if command -v pwsh >/dev/null 2>&1; then
@@ -3227,19 +3422,34 @@ else
 fi
 "`$PS_EXE" -NoProfile -NonInteractive -Command "& '$peonPs1Path' `$*"
 "@
-$peonShPath = Join-Path $cliBinDir "peon"
-[System.IO.File]::WriteAllLines($peonShPath, $peonShScript.Split("`n"), $utf8NoBom)
-# Make executable (for Git Bash)
-if (Get-Command "icacls" -ErrorAction SilentlyContinue) {
-    icacls $peonShPath /grant:r "$env:USERNAME:(RX)" | Out-Null
-}
+    $peonShPath = Join-Path $cliBinDir "peon"
+    [System.IO.File]::WriteAllLines($peonShPath, $peonShScript.Split("`n"), $utf8NoBom)
 
-# Add to PATH if not already there
-$userPath = [Environment]::GetEnvironmentVariable("PATH", "User")
-if ($userPath -notlike "*$cliBinDir*") {
-    [Environment]::SetEnvironmentVariable("PATH", "$userPath;$cliBinDir", "User")
-    Write-Host ""
-    Write-Host "  Added $cliBinDir to PATH" -ForegroundColor Green
+    # Make executable (for Git Bash)
+    if (Get-Command "icacls" -ErrorAction SilentlyContinue) {
+        $aclPrincipal = "$($env:USERNAME):(RX)"
+        $null = & icacls $peonShPath /grant:r $aclPrincipal 2>$null
+        if ($LASTEXITCODE -ne 0) {
+            Write-Host "  Warning: Could not mark Git Bash shim as executable. Run 'chmod +x $peonShPath' manually if needed." -ForegroundColor Yellow
+        }
+    }
+
+    # Add to PATH if not already there
+    try {
+        $userPath = [Environment]::GetEnvironmentVariable("PATH", "User")
+        if ([string]::IsNullOrWhiteSpace($userPath)) {
+            [Environment]::SetEnvironmentVariable("PATH", $cliBinDir, "User")
+            Write-Host ""
+            Write-Host "  Added $cliBinDir to PATH" -ForegroundColor Green
+        } elseif ($userPath -notlike "*$cliBinDir*") {
+            [Environment]::SetEnvironmentVariable("PATH", "$userPath;$cliBinDir", "User")
+            Write-Host ""
+            Write-Host "  Added $cliBinDir to PATH" -ForegroundColor Green
+        }
+    } catch {
+        Write-Host ""
+        Write-Host "  Warning: Could not update PATH automatically. Add $cliBinDir manually if 'peon' is not found." -ForegroundColor Yellow
+    }
 }
 
 # --- Update Claude Code settings.json with hooks ---
@@ -3379,7 +3589,7 @@ Write-Host "  UserPromptSubmit hook registered for /peon-ping-use" -ForegroundCo
 $CursorDir = Join-Path $env:USERPROFILE ".cursor"
 $CursorHooksFile = Join-Path $CursorDir "hooks.json"
 
-if (Test-Path $CursorDir) {
+if ((-not $Local) -and (Test-Path $CursorDir)) {
     Write-Host ""
     Write-Host "Detected Cursor IDE installation, registering hooks..."
     
@@ -3457,7 +3667,7 @@ if (Test-Path $CursorDir) {
 $DeepagentsDir = Join-Path $env:USERPROFILE ".deepagents"
 $DeepagentsHooksFile = Join-Path $DeepagentsDir "hooks.json"
 
-if (Test-Path $DeepagentsDir) {
+if ((-not $Local) -and (Test-Path $DeepagentsDir)) {
     Write-Host ""
     Write-Host "Detected deepagents-cli installation, registering hooks..."
 
@@ -3641,16 +3851,21 @@ if ($Updating) {
     Write-Host "  Active pack: $activePack" -ForegroundColor Cyan
     Write-Host "  Volume: 0.5" -ForegroundColor Cyan
     Write-Host ""
-    Write-Host "  Commands (open a new terminal first):" -ForegroundColor White
-    Write-Host "    peon --status     Show status"
-    Write-Host "    peon --packs      List sound packs"
-    Write-Host "    peon --pack NAME  Switch pack"
-    Write-Host "    peon --volume N   Set volume (0.0-1.0)"
-    Write-Host "    peon --pause      Mute sounds"
-    Write-Host "    peon --resume     Unmute sounds"
-    Write-Host "    peon --mute       Alias for --pause"
-    Write-Host "    peon --unmute     Alias for --resume"
-    Write-Host "    peon --toggle     Toggle on/off"
+    if ($Local) {
+        Write-Host "  Project-local install: Claude Code hooks and skills were written to $ClaudeDir" -ForegroundColor White
+        Write-Host "  Global 'peon' CLI shim was not installed in local mode." -ForegroundColor DarkGray
+    } else {
+        Write-Host "  Commands (open a new terminal first):" -ForegroundColor White
+        Write-Host "    peon status         Show status"
+        Write-Host "    peon packs list     List sound packs"
+        Write-Host "    peon packs use NAME Switch pack"
+        Write-Host "    peon volume N       Set volume (0.0-1.0)"
+        Write-Host "    peon pause          Mute sounds"
+        Write-Host "    peon resume         Unmute sounds"
+        Write-Host "    peon mute           Alias for pause"
+        Write-Host "    peon unmute         Alias for resume"
+        Write-Host "    peon toggle         Toggle on/off"
+    }
     Write-Host ""
     Write-Host "  Start Claude Code and you'll hear: `"Ready to work?`"" -ForegroundColor Yellow
     Write-Host ""
@@ -3666,6 +3881,8 @@ if ($Updating) {
     }
     Write-Host "  To install specific packs: .\install.ps1 -Packs peon,glados,peasant" -ForegroundColor DarkGray
     Write-Host "  To install ALL packs: .\install.ps1 -All" -ForegroundColor DarkGray
+    Write-Host "  To install project-locally: .\install.ps1 -Local" -ForegroundColor DarkGray
+    Write-Host "  To create only project-local config: .\install.ps1 -InitLocalConfig" -ForegroundColor DarkGray
     Write-Host "  To uninstall: powershell -File `"$InstallDir\uninstall.ps1`"" -ForegroundColor DarkGray
 }
 Write-Host ""

--- a/install.ps1
+++ b/install.ps1
@@ -2023,6 +2023,8 @@ if ($Command) {
             Write-Host "  peon notifications template <key> <fmt>  Set a template"
             Write-Host "  peon notifications template --reset      Clear all templates"
             Write-Host "  peon popups on/off            Alias for notifications on/off"
+            Write-Host "  --notifications on/off        Legacy alias for peon notifications on/off"
+            Write-Host "  --popups on/off               Legacy alias for peon popups on/off"
             Write-Host ""
             Write-Host "Debug & Logs:" -ForegroundColor Cyan
             Write-Host "  debug on              Enable debug logging"

--- a/tests/adapters-windows.Tests.ps1
+++ b/tests/adapters-windows.Tests.ps1
@@ -647,6 +647,7 @@ Describe "Category C: Kilo Installer" {
 Describe "install.ps1 Adapter Installation" {
     BeforeAll {
         $script:installContent = Get-Content (Join-Path $script:RepoRoot "install.ps1") -Raw
+        $script:readmeContent = Get-Content (Join-Path $script:RepoRoot "README.md") -Raw
     }
 
     It "installs adapter scripts to adapters/ directory" {
@@ -677,9 +678,63 @@ Describe "install.ps1 Adapter Installation" {
         $script:installContent | Should -Match 'Restricted'
     }
 
+    It "supports local, global, and init-local-config installer parameters" {
+        $script:installContent | Should -Match '\[switch\]\$Local'
+        $script:installContent | Should -Match '\[switch\]\$Global'
+        $script:installContent | Should -Match '\[switch\]\$InitLocalConfig'
+    }
+
+    It "bootstraps TLS 1.2 for legacy Windows PowerShell web requests" {
+        $script:installContent | Should -Match 'SecurityProtocol'
+        $script:installContent | Should -Match 'Tls12'
+    }
+
+    It "documents a simple Windows download-and-run flow with explicit TLS fallback" {
+        $script:readmeContent | Should -Match 'Invoke-WebRequest -Uri "https://raw\.githubusercontent\.com/PeonPing/peon-ping/main/install\.ps1" -OutFile "\.\\install\.ps1"'
+        $script:readmeContent | Should -Match 'powershell -ExecutionPolicy Bypass -File \.\\install\.ps1'
+        $script:readmeContent | Should -Match 'TLS error on older Windows PowerShell'
+        $script:readmeContent | Should -Match 'SecurityProtocol = \[Net\.ServicePointManager\]::SecurityProtocol -bor \[Net\.SecurityProtocolType\]::Tls12'
+    }
+
     It "handles missing Claude Code gracefully" {
         $script:installContent | Should -Match 'ClaudeCodeDetected'
         $script:installContent | Should -Match 'Skipping Claude Code hook registration'
+    }
+
+    It "creates project-local config without running a full install" {
+        $script:installContent | Should -Match 'Created local config'
+        $script:installContent | Should -Match 'InitLocalConfig'
+        $script:installContent | Should -Match '\$repoConfigFile = if \(\$PSScriptRoot\)'
+        $script:installContent | Should -Match '\$repoConfigFile -and \(Test-Path \$repoConfigFile\)'
+        $script:installContent | Should -Match '(?s)if \(\$InitLocalConfig\) \{.*?return\s*\}\s*# --- Check Claude Code is installed ---'
+        $script:installContent | Should -Not -Match '(?s)if \(\$InitLocalConfig\) \{.*?exit 0.*?# --- Check Claude Code is installed ---'
+    }
+
+    It "skips the global CLI shim and PATH mutation in local mode" {
+        $script:installContent | Should -Match 'if \(-not \$Local\)'
+        $script:installContent | Should -Match "Global 'peon' CLI shim was not installed in local mode"
+    }
+
+    It "generates peon.cmd via PowerShell -Command so Windows args reach peon.ps1" {
+        $script:installContent | Should -Match 'peon\.cmd'
+        $script:installContent | Should -Match 'powershell -NoProfile -NonInteractive -Command "& ''\$peonPs1Path'' %\*"'
+        $script:installContent | Should -Not -Match 'peon\.cmd[\s\S]*?-File "\$peonPs1Path" %\*'
+    }
+
+    It "uses correct username interpolation for icacls ACLs" {
+        $script:installContent | Should -Match '\$\(\$env:USERNAME\):\(RX\)'
+    }
+
+    It "warns instead of failing when PATH auto-update is unavailable" {
+        $script:installContent | Should -Match 'Could not update PATH automatically'
+    }
+
+    It "prints README-style first-run commands after install" {
+        $script:installContent | Should -Match 'peon status'
+        $script:installContent | Should -Match 'peon packs list'
+        $script:installContent | Should -Match 'peon packs use NAME'
+        $script:installContent | Should -Match 'peon volume N'
+        $script:installContent | Should -Match 'peon toggle'
     }
 
     It "installs win-notify.ps1 alongside win-play.ps1" {
@@ -1308,43 +1363,51 @@ Describe "Embedded peon.ps1 Hook Script" {
         $script:peonHookContent | Should -Match 'WindowStyle Hidden'
     }
 
-    # --- CLI Commands (mirrors BATS: peon --toggle/--pause/--resume/--status) ---
+    # --- CLI Commands (README-style plus legacy --flags) ---
 
-    It "supports --toggle CLI command" {
-        $script:peonHookContent | Should -Match '--toggle'
+    It "supports toggle CLI command in README-style and legacy form" {
+        $script:peonHookContent | Should -Match '"\^\(--\)\?toggle\$"'
         $script:peonHookContent | Should -Match '-not \$cfg\.enabled'
     }
 
-    It "supports --pause CLI command" {
-        $script:peonHookContent | Should -Match '--pause'
+    It "supports pause CLI command in README-style and legacy form" {
+        $script:peonHookContent | Should -Match '"\^\(--\)\?\(pause\|mute\)\$"'
         $script:peonHookContent | Should -Match '"enabled": false'
     }
 
-    It "supports --resume CLI command" {
-        $script:peonHookContent | Should -Match '--resume'
+    It "supports resume CLI command in README-style and legacy form" {
+        $script:peonHookContent | Should -Match '"\^\(--\)\?\(resume\|unmute\)\$"'
         $script:peonHookContent | Should -Match '"enabled": true'
     }
 
-    It "supports --status CLI command" {
-        $script:peonHookContent | Should -Match '--status'
+    It "supports status CLI command in README-style and legacy form" {
+        $script:peonHookContent | Should -Match '"\^\(--\)\?status\$"'
         $script:peonHookContent | Should -Match 'ENABLED'
         $script:peonHookContent | Should -Match 'PAUSED'
     }
 
-    It "--status shows version from VERSION file" {
+    It "status shows version from VERSION file" {
         $script:peonHookContent | Should -Match 'VERSION'
         $script:peonHookContent | Should -Match 'version'
     }
 
-    It "--status --verbose shows debug logging state" {
+    It "status --verbose shows debug logging state and README hint" {
         $script:peonHookContent | Should -Match 'debug logging'
         $script:peonHookContent | Should -Match 'PEON_DEBUG'
+        $script:peonHookContent | Should -Match 'peon status --verbose'
     }
 
-    It "supports --packs CLI command with use/next/list subcommands" {
-        $script:peonHookContent | Should -Match '--packs'
+    It "supports packs CLI command in README-style and legacy form" {
+        $script:peonHookContent | Should -Match '"\^\(--\)\?packs\$"'
+        $script:peonHookContent | Should -Match '"list"'
         $script:peonHookContent | Should -Match '"use"'
+        $script:peonHookContent | Should -Match '"install"'
+        $script:peonHookContent | Should -Match '"install-local"'
         $script:peonHookContent | Should -Match '"next"'
+        $script:peonHookContent | Should -Match '"remove"'
+        $script:peonHookContent | Should -Match 'No packs installed'
+        $script:peonHookContent | Should -Match 'Get-InstalledPackNames'
+        $script:peonHookContent | Should -Match 'Get-NextPackName'
     }
 
     It "Install-PackFromRegistry allows empty source_path for repo-root packs" {
@@ -1354,20 +1417,29 @@ Describe "Embedded peon.ps1 Hook Script" {
         $script:peonHookContent | Should -Not -Match '-not \$srcPath'
     }
 
-    It "supports --volume CLI command with clamping" {
-        $script:peonHookContent | Should -Match '--volume'
+    It "supports volume CLI command with getter and clamping setter" {
+        $script:peonHookContent | Should -Match '"\^\(--\)\?volume\$"'
         $script:peonHookContent | Should -Match 'Max.*0\.0.*Min.*1\.0'
+        $script:peonHookContent | Should -Match 'peon-ping: volume'
     }
 
-    It "supports --help CLI command" {
-        $script:peonHookContent | Should -Match '--help'
+    It "supports help CLI command with README-style examples" {
+        $script:peonHookContent | Should -Match '"\^\(--\)\?help\$"'
+        $script:peonHookContent | Should -Match 'peon packs list'
+        $script:peonHookContent | Should -Match 'Legacy --status/--toggle/--packs/--volume forms still work'
     }
 
-    It "supports --update CLI command with config migration" {
-        $script:peonHookContent | Should -Match '--update'
+    It "supports update CLI command with config migration" {
+        $script:peonHookContent | Should -Match '"\^\(--\)\?update\$"'
         $script:peonHookContent | Should -Match 'active_pack'
         $script:peonHookContent | Should -Match 'default_pack'
         $script:peonHookContent | Should -Match 'Updating peon-ping'
+    }
+
+    It "supports notifications CLI command in README-style and legacy form" {
+        $script:peonHookContent | Should -Match '"\^\(--\)\?\(notifications\|popups\)\$"'
+        $script:peonHookContent | Should -Match 'desktop notifications on'
+        $script:peonHookContent | Should -Match 'desktop notifications off'
     }
 
     # --- State Persistence ---
@@ -1804,8 +1876,8 @@ Describe "install.ps1 Default Config" {
     }
 
     It "help text has aligned columns and pack management section" {
-        $script:installContent | Should -Match '--packs use <name>'
-        $script:installContent | Should -Match '--packs next'
+        $script:installContent | Should -Match 'peon packs use <name>'
+        $script:installContent | Should -Match 'peon packs next'
         $script:installContent | Should -Match 'Pack management:'
     }
 
@@ -1830,9 +1902,9 @@ Describe "install.ps1 Default Config" {
     }
 
     It "help text includes bind/unbind/bindings" {
-        $script:peonHookContent | Should -Match '--packs bind'
-        $script:peonHookContent | Should -Match '--packs unbind'
-        $script:peonHookContent | Should -Match '--packs bindings'
+        $script:peonHookContent | Should -Match 'peon packs bind'
+        $script:peonHookContent | Should -Match 'peon packs unbind'
+        $script:peonHookContent | Should -Match 'peon packs bindings'
     }
 }
 
@@ -2109,9 +2181,9 @@ Describe "path_rules: CLI Commands - Structural" {
     }
 
     It "help text includes bind/unbind/bindings" {
-        $script:peonHookContent | Should -Match '--packs bind'
-        $script:peonHookContent | Should -Match '--packs unbind'
-        $script:peonHookContent | Should -Match '--packs bindings'
+        $script:peonHookContent | Should -Match 'peon packs bind'
+        $script:peonHookContent | Should -Match 'peon packs unbind'
+        $script:peonHookContent | Should -Match 'peon packs bindings'
     }
 }
 
@@ -2268,10 +2340,10 @@ Describe "Windows IDE rules and exclude_dirs parity" {
     }
 
     It "help text includes IDE and exclude pack commands" {
-        $script:installContent | Should -Match '--packs ide-bind'
-        $script:installContent | Should -Match '--packs ide-unbind'
-        $script:installContent | Should -Match '--packs ide-bindings'
-        $script:installContent | Should -Match '--packs exclude'
+        $script:installContent | Should -Match 'peon packs ide-bind'
+        $script:installContent | Should -Match 'peon packs ide-unbind'
+        $script:installContent | Should -Match 'peon packs ide-bindings'
+        $script:installContent | Should -Match 'peon packs exclude'
     }
 
     It "embedded hook defines IDE/path helper functions" {
@@ -2577,9 +2649,9 @@ Describe "path_rules: CLI Commands - Structural" {
     }
 
     It "help text includes bind/unbind/bindings" {
-        $script:peonHookContent | Should -Match '--packs bind'
-        $script:peonHookContent | Should -Match '--packs unbind'
-        $script:peonHookContent | Should -Match '--packs bindings'
+        $script:peonHookContent | Should -Match 'peon packs bind'
+        $script:peonHookContent | Should -Match 'peon packs unbind'
+        $script:peonHookContent | Should -Match 'peon packs bindings'
     }
 }
 

--- a/tests/adapters-windows.Tests.ps1
+++ b/tests/adapters-windows.Tests.ps1
@@ -1816,8 +1816,8 @@ Describe "install.ps1 Default Config" {
         # Get-ExecutionPolicy. If pwsh is installed, prefer it; else use
         # powershell.exe. Structural test on the install.ps1 here-string.
         $script:installContent | Should -Match 'where pwsh'
-        $script:installContent | Should -Match 'pwsh -NoProfile -NonInteractive -Command "& ''%USERPROFILE%\\.claude\\hooks\\peon-ping\\peon\.ps1'''
-        $script:installContent | Should -Match 'powershell -NoProfile -NonInteractive -Command "& ''%USERPROFILE%\\.claude\\hooks\\peon-ping\\peon\.ps1'''
+        $script:installContent | Should -Match ([regex]::Escape('pwsh -NoProfile -NonInteractive -Command "& ''$peonPs1Path'' %*"'))
+        $script:installContent | Should -Match ([regex]::Escape('powershell -NoProfile -NonInteractive -Command "& ''$peonPs1Path'' %*"'))
     }
 
     It "peon bash shim probes for pwsh before falling back to powershell" {
@@ -1827,6 +1827,7 @@ Describe "install.ps1 Default Config" {
         $script:installContent | Should -Match 'command -v pwsh'
         $script:installContent | Should -Match 'PS_EXE=pwsh'
         $script:installContent | Should -Match 'PS_EXE=powershell\.exe'
+        $script:installContent | Should -Match ([regex]::Escape('"`$PS_EXE" -NoProfile -NonInteractive -Command "& ''$peonPs1Path'' `$*"'))
     }
 
     It "validates pack names with safe charset" {

--- a/tests/adapters-windows.Tests.ps1
+++ b/tests/adapters-windows.Tests.ps1
@@ -647,6 +647,7 @@ Describe "Category C: Kilo Installer" {
 Describe "install.ps1 Adapter Installation" {
     BeforeAll {
         $script:installContent = Get-Content (Join-Path $script:RepoRoot "install.ps1") -Raw
+        $script:readmeContent = Get-Content (Join-Path $script:RepoRoot "README.md") -Raw
     }
 
     It "installs adapter scripts to adapters/ directory" {
@@ -677,9 +678,63 @@ Describe "install.ps1 Adapter Installation" {
         $script:installContent | Should -Match 'Restricted'
     }
 
+    It "supports local, global, and init-local-config installer parameters" {
+        $script:installContent | Should -Match '\[switch\]\$Local'
+        $script:installContent | Should -Match '\[switch\]\$Global'
+        $script:installContent | Should -Match '\[switch\]\$InitLocalConfig'
+    }
+
+    It "bootstraps TLS 1.2 for legacy Windows PowerShell web requests" {
+        $script:installContent | Should -Match 'SecurityProtocol'
+        $script:installContent | Should -Match 'Tls12'
+    }
+
+    It "documents a simple Windows download-and-run flow with explicit TLS fallback" {
+        $script:readmeContent | Should -Match 'Invoke-WebRequest -Uri "https://raw\.githubusercontent\.com/PeonPing/peon-ping/main/install\.ps1" -OutFile "\.\\install\.ps1"'
+        $script:readmeContent | Should -Match 'powershell -ExecutionPolicy Bypass -File \.\\install\.ps1'
+        $script:readmeContent | Should -Match 'TLS error on older Windows PowerShell'
+        $script:readmeContent | Should -Match 'SecurityProtocol = \[Net\.ServicePointManager\]::SecurityProtocol -bor \[Net\.SecurityProtocolType\]::Tls12'
+    }
+
     It "handles missing Claude Code gracefully" {
         $script:installContent | Should -Match 'ClaudeCodeDetected'
         $script:installContent | Should -Match 'Skipping Claude Code hook registration'
+    }
+
+    It "creates project-local config without running a full install" {
+        $script:installContent | Should -Match 'Created local config'
+        $script:installContent | Should -Match 'InitLocalConfig'
+        $script:installContent | Should -Match '\$repoConfigFile = if \(\$PSScriptRoot\)'
+        $script:installContent | Should -Match '\$repoConfigFile -and \(Test-Path \$repoConfigFile\)'
+        $script:installContent | Should -Match '(?s)if \(\$InitLocalConfig\) \{.*?return\s*\}\s*# --- Check Claude Code is installed ---'
+        $script:installContent | Should -Not -Match '(?s)if \(\$InitLocalConfig\) \{.*?exit 0.*?# --- Check Claude Code is installed ---'
+    }
+
+    It "skips the global CLI shim and PATH mutation in local mode" {
+        $script:installContent | Should -Match 'if \(-not \$Local\)'
+        $script:installContent | Should -Match "Global 'peon' CLI shim was not installed in local mode"
+    }
+
+    It "generates peon.cmd via PowerShell -Command so Windows args reach peon.ps1" {
+        $script:installContent | Should -Match 'peon\.cmd'
+        $script:installContent | Should -Match 'powershell -NoProfile -NonInteractive -Command "& ''\$peonPs1Path'' %\*"'
+        $script:installContent | Should -Not -Match 'peon\.cmd[\s\S]*?-File "\$peonPs1Path" %\*'
+    }
+
+    It "uses correct username interpolation for icacls ACLs" {
+        $script:installContent | Should -Match '\$\(\$env:USERNAME\):\(RX\)'
+    }
+
+    It "warns instead of failing when PATH auto-update is unavailable" {
+        $script:installContent | Should -Match 'Could not update PATH automatically'
+    }
+
+    It "prints README-style first-run commands after install" {
+        $script:installContent | Should -Match 'peon status'
+        $script:installContent | Should -Match 'peon packs list'
+        $script:installContent | Should -Match 'peon packs use NAME'
+        $script:installContent | Should -Match 'peon volume N'
+        $script:installContent | Should -Match 'peon toggle'
     }
 
     It "installs win-notify.ps1 alongside win-play.ps1" {
@@ -1311,43 +1366,51 @@ Describe "Embedded peon.ps1 Hook Script" {
         $script:peonHookContent | Should -Match 'WindowStyle Hidden'
     }
 
-    # --- CLI Commands (mirrors BATS: peon --toggle/--pause/--resume/--status) ---
+    # --- CLI Commands (README-style plus legacy --flags) ---
 
-    It "supports --toggle CLI command" {
-        $script:peonHookContent | Should -Match '--toggle'
+    It "supports toggle CLI command in README-style and legacy form" {
+        $script:peonHookContent | Should -Match '"\^\(--\)\?toggle\$"'
         $script:peonHookContent | Should -Match '-not \$cfg\.enabled'
     }
 
-    It "supports --pause CLI command" {
-        $script:peonHookContent | Should -Match '--pause'
+    It "supports pause CLI command in README-style and legacy form" {
+        $script:peonHookContent | Should -Match '"\^\(--\)\?\(pause\|mute\)\$"'
         $script:peonHookContent | Should -Match '"enabled": false'
     }
 
-    It "supports --resume CLI command" {
-        $script:peonHookContent | Should -Match '--resume'
+    It "supports resume CLI command in README-style and legacy form" {
+        $script:peonHookContent | Should -Match '"\^\(--\)\?\(resume\|unmute\)\$"'
         $script:peonHookContent | Should -Match '"enabled": true'
     }
 
-    It "supports --status CLI command" {
-        $script:peonHookContent | Should -Match '--status'
+    It "supports status CLI command in README-style and legacy form" {
+        $script:peonHookContent | Should -Match '"\^\(--\)\?status\$"'
         $script:peonHookContent | Should -Match 'ENABLED'
         $script:peonHookContent | Should -Match 'PAUSED'
     }
 
-    It "--status shows version from VERSION file" {
+    It "status shows version from VERSION file" {
         $script:peonHookContent | Should -Match 'VERSION'
         $script:peonHookContent | Should -Match 'version'
     }
 
-    It "--status --verbose shows debug logging state" {
+    It "status --verbose shows debug logging state and README hint" {
         $script:peonHookContent | Should -Match 'debug logging'
         $script:peonHookContent | Should -Match 'PEON_DEBUG'
+        $script:peonHookContent | Should -Match 'peon status --verbose'
     }
 
-    It "supports --packs CLI command with use/next/list subcommands" {
-        $script:peonHookContent | Should -Match '--packs'
+    It "supports packs CLI command in README-style and legacy form" {
+        $script:peonHookContent | Should -Match '"\^\(--\)\?packs\$"'
+        $script:peonHookContent | Should -Match '"list"'
         $script:peonHookContent | Should -Match '"use"'
+        $script:peonHookContent | Should -Match '"install"'
+        $script:peonHookContent | Should -Match '"install-local"'
         $script:peonHookContent | Should -Match '"next"'
+        $script:peonHookContent | Should -Match '"remove"'
+        $script:peonHookContent | Should -Match 'No packs installed'
+        $script:peonHookContent | Should -Match 'Get-InstalledPackNames'
+        $script:peonHookContent | Should -Match 'Get-NextPackName'
     }
 
     It "Install-PackFromRegistry allows empty source_path for repo-root packs" {
@@ -1357,20 +1420,29 @@ Describe "Embedded peon.ps1 Hook Script" {
         $script:peonHookContent | Should -Not -Match '-not \$srcPath'
     }
 
-    It "supports --volume CLI command with clamping" {
-        $script:peonHookContent | Should -Match '--volume'
+    It "supports volume CLI command with getter and clamping setter" {
+        $script:peonHookContent | Should -Match '"\^\(--\)\?volume\$"'
         $script:peonHookContent | Should -Match 'Max.*0\.0.*Min.*1\.0'
+        $script:peonHookContent | Should -Match 'peon-ping: volume'
     }
 
-    It "supports --help CLI command" {
-        $script:peonHookContent | Should -Match '--help'
+    It "supports help CLI command with README-style examples" {
+        $script:peonHookContent | Should -Match '"\^\(--\)\?help\$"'
+        $script:peonHookContent | Should -Match 'peon packs list'
+        $script:peonHookContent | Should -Match 'Legacy --status/--toggle/--packs/--volume forms still work'
     }
 
-    It "supports --update CLI command with config migration" {
-        $script:peonHookContent | Should -Match '--update'
+    It "supports update CLI command with config migration" {
+        $script:peonHookContent | Should -Match '"\^\(--\)\?update\$"'
         $script:peonHookContent | Should -Match 'active_pack'
         $script:peonHookContent | Should -Match 'default_pack'
         $script:peonHookContent | Should -Match 'Updating peon-ping'
+    }
+
+    It "supports notifications CLI command in README-style and legacy form" {
+        $script:peonHookContent | Should -Match '"\^\(--\)\?\(notifications\|popups\)\$"'
+        $script:peonHookContent | Should -Match 'desktop notifications on'
+        $script:peonHookContent | Should -Match 'desktop notifications off'
     }
 
     # --- State Persistence ---
@@ -1807,8 +1879,8 @@ Describe "install.ps1 Default Config" {
     }
 
     It "help text has aligned columns and pack management section" {
-        $script:installContent | Should -Match '--packs use <name>'
-        $script:installContent | Should -Match '--packs next'
+        $script:installContent | Should -Match 'peon packs use <name>'
+        $script:installContent | Should -Match 'peon packs next'
         $script:installContent | Should -Match 'Pack management:'
     }
 
@@ -1833,9 +1905,9 @@ Describe "install.ps1 Default Config" {
     }
 
     It "help text includes bind/unbind/bindings" {
-        $script:peonHookContent | Should -Match '--packs bind'
-        $script:peonHookContent | Should -Match '--packs unbind'
-        $script:peonHookContent | Should -Match '--packs bindings'
+        $script:peonHookContent | Should -Match 'peon packs bind'
+        $script:peonHookContent | Should -Match 'peon packs unbind'
+        $script:peonHookContent | Should -Match 'peon packs bindings'
     }
 }
 
@@ -2112,9 +2184,9 @@ Describe "path_rules: CLI Commands - Structural" {
     }
 
     It "help text includes bind/unbind/bindings" {
-        $script:peonHookContent | Should -Match '--packs bind'
-        $script:peonHookContent | Should -Match '--packs unbind'
-        $script:peonHookContent | Should -Match '--packs bindings'
+        $script:peonHookContent | Should -Match 'peon packs bind'
+        $script:peonHookContent | Should -Match 'peon packs unbind'
+        $script:peonHookContent | Should -Match 'peon packs bindings'
     }
 }
 
@@ -2271,10 +2343,10 @@ Describe "Windows IDE rules and exclude_dirs parity" {
     }
 
     It "help text includes IDE and exclude pack commands" {
-        $script:installContent | Should -Match '--packs ide-bind'
-        $script:installContent | Should -Match '--packs ide-unbind'
-        $script:installContent | Should -Match '--packs ide-bindings'
-        $script:installContent | Should -Match '--packs exclude'
+        $script:installContent | Should -Match 'peon packs ide-bind'
+        $script:installContent | Should -Match 'peon packs ide-unbind'
+        $script:installContent | Should -Match 'peon packs ide-bindings'
+        $script:installContent | Should -Match 'peon packs exclude'
     }
 
     It "embedded hook defines IDE/path helper functions" {
@@ -2617,9 +2689,9 @@ Describe "path_rules: CLI Commands - Structural" {
     }
 
     It "help text includes bind/unbind/bindings" {
-        $script:peonHookContent | Should -Match '--packs bind'
-        $script:peonHookContent | Should -Match '--packs unbind'
-        $script:peonHookContent | Should -Match '--packs bindings'
+        $script:peonHookContent | Should -Match 'peon packs bind'
+        $script:peonHookContent | Should -Match 'peon packs unbind'
+        $script:peonHookContent | Should -Match 'peon packs bindings'
     }
 }
 

--- a/tests/adapters-windows.Tests.ps1
+++ b/tests/adapters-windows.Tests.ps1
@@ -1819,8 +1819,8 @@ Describe "install.ps1 Default Config" {
         # Get-ExecutionPolicy. If pwsh is installed, prefer it; else use
         # powershell.exe. Structural test on the install.ps1 here-string.
         $script:installContent | Should -Match 'where pwsh'
-        $script:installContent | Should -Match 'pwsh -NoProfile -NonInteractive -Command "& ''%USERPROFILE%\\.claude\\hooks\\peon-ping\\peon\.ps1'''
-        $script:installContent | Should -Match 'powershell -NoProfile -NonInteractive -Command "& ''%USERPROFILE%\\.claude\\hooks\\peon-ping\\peon\.ps1'''
+        $script:installContent | Should -Match ([regex]::Escape('pwsh -NoProfile -NonInteractive -Command "& ''$peonPs1Path'' %*"'))
+        $script:installContent | Should -Match ([regex]::Escape('powershell -NoProfile -NonInteractive -Command "& ''$peonPs1Path'' %*"'))
     }
 
     It "peon bash shim probes for pwsh before falling back to powershell" {
@@ -1830,6 +1830,7 @@ Describe "install.ps1 Default Config" {
         $script:installContent | Should -Match 'command -v pwsh'
         $script:installContent | Should -Match 'PS_EXE=pwsh'
         $script:installContent | Should -Match 'PS_EXE=powershell\.exe'
+        $script:installContent | Should -Match ([regex]::Escape('"`$PS_EXE" -NoProfile -NonInteractive -Command "& ''$peonPs1Path'' `$*"'))
     }
 
     It "validates pack names with safe charset" {


### PR DESCRIPTION
## Summary
- replace the Windows install docs with a PowerShell download-and-run flow that matches install.ps1
- add Windows installer parameters for local/global/init-local-config flows and safer first-run behavior
- make README-style Windows commands work through the generated CLI shim while preserving legacy flag forms
- extend Windows Pester coverage for install docs, shim routing, packs, volume, notifications, and local install guardrails

## Why
The Windows README and generated CLI had drifted from the actual PowerShell installer behavior. A fresh Windows user could follow the docs and still hit mismatched parameter syntax, broken command routing, or first-run commands that did not work as written.

## Validation
- git diff --check
- git diff --check -- README.md
- Invoke-Pester -Path tests\\adapters-windows.Tests.ps1 (426 passed, 0 failed)