### PR TITLE
fix(pack-download): treat empty source_path as valid (root of repo)

### DIFF
--- a/scripts/pack-download.sh
+++ b/scripts/pack-download.sh
@@ -377,7 +377,9 @@ for p in data.get('packs', []):
     SOURCE_PATH=""
   fi
 
-  if [ -z "$SOURCE_REPO" ] || [ -z "$SOURCE_REF" ] || [ -z "$SOURCE_PATH" ]; then
+  # Note: empty SOURCE_PATH is valid — it means the manifest is at the repo root.
+  # Only fall back when repo or ref are missing.
+  if [ -z "$SOURCE_REPO" ] || [ -z "$SOURCE_REF" ]; then
     SOURCE_REPO="$FALLBACK_REPO"
     SOURCE_REF="$FALLBACK_REF"
     SOURCE_PATH="$pack"


### PR DESCRIPTION
## Summary

Fixes #343 — `peon packs install solid_snake` (and any future pack whose manifest lives at the root of its source repo) fails with "Failed downloads (manifest unavailable)".

## Root cause

`scripts/pack-download.sh` line 380 treats an empty `source_path` as missing metadata and triggers the fallback branch:

```bash
if [ -z "$SOURCE_REPO" ] || [ -z "$SOURCE_REF" ] || [ -z "$SOURCE_PATH" ]; then
  SOURCE_REPO="$FALLBACK_REPO"      # PeonPing/og-packs
  SOURCE_REF="$FALLBACK_REF"        # v1.1.0
  SOURCE_PATH="$pack"
fi
```

But `source_path: ""` is a valid value in the registry — it indicates the manifest lives at the repo's root rather than in a subdirectory. The `PACK_BASE` construction immediately below (lines 387–391) already handles both cases:

```bash
if [ -n "$SOURCE_PATH" ]; then
  PACK_BASE=".../$SOURCE_REPO/$SOURCE_REF/$SOURCE_PATH"
else
  PACK_BASE=".../$SOURCE_REPO/$SOURCE_REF"
fi
```

## The Windows installer already gets this right

The PowerShell installer (`install.ps1:515`) explicitly distinguishes `$null` from empty string for `source_path`:

```powershell
if (-not $srcRepo -or -not $srcRef -or ($null -eq $srcPath)) {
```

And there's a dedicated regression test (`tests/adapters-windows.Tests.ps1:1247`):

> **"Install-PackFromRegistry allows empty source_path for repo-root packs"**
> _"Regression: empty source_path (`""`) is valid for packs at repo root. The validation must use `$null` check, not `-not` (which treats `""` as falsy)."_

So the intended behavior is already documented and enforced on Windows. This PR just brings the bash path in line.

## Reproduction

The `solid_snake` pack in the registry has `source_path: ""` pointing to `wsturgiss/openpeon-solid-snake@v1.0.0`:

| URL | Status |
|-----|--------|
| `raw.githubusercontent.com/wsturgiss/openpeon-solid-snake/v1.0.0/openpeon.json` (correct) | 200 |
| `raw.githubusercontent.com/PeonPing/og-packs/v1.1.0/solid_snake/openpeon.json` (current fallback) | 404 |

## Fix

Drop the `-z "$SOURCE_PATH"` check from the guard. Only fall back when `source_repo` or `source_ref` are missing — an empty `source_path` is legitimate and should flow through unchanged.

## Impact analysis

Ran the full `tests/pack-download.bats` suite before and after the change: **31/31 passing** in both.

Scanned the live registry (312 packs):

| Bucket | Count |
|-------|------|
| All three fields populated | 311 |
| Empty `source_path` + repo/ref populated (this fix) | 1 (`solid_snake`) |
| Missing `source_path` field | 0 |
| Empty `source_repo` | 0 |
| Empty `source_ref` | 0 |

So no existing pack changes behavior; the only observable effect is `solid_snake` going from broken to working.

One subtle behavior change worth flagging: if `is_safe_source_path` rejects a malformed path (line 376 clears it to ""), the pack now attempts a download from the declared repo's root instead of silently falling back to `og-packs/$pack`. This is a safer default — the pack's registry entry stays authoritative, and a truly bad `source_path` surfaces as an honest 404 rather than masking it.

## Testing notes

Existing `tests/pack-download.bats` fixtures all use non-empty `source_path` and hit real URLs under `PeonPing/og-packs`, so adding a regression test for the empty-path case would need either (a) a test pack with manifest at the root of `og-packs`, or (b) mocking `curl` in the harness. I kept the PR minimal and didn't include either — happy to follow up with whichever you prefer.
