### PR TITLE
fix: tighten Linux terminal focus detection

### DIFF
--- a/peon.sh
+++ b/peon.sh
@@ -833,11 +833,23 @@ terminal_is_focused() {
     linux)
       # Only use xdotool on X11; fallback to always notify on Wayland or if xdotool is missing
       if [ "${XDG_SESSION_TYPE:-}" = "x11" ] && command -v xdotool &>/dev/null; then
-        local win_name
+        local win_name win_class win_name_lower win_class_lower
         win_name=$(xdotool getactivewindow getwindowname 2>/dev/null || echo "")
-        if [[ "$win_name" =~ (terminal|konsole|alacritty|kitty|wezterm|foot|tilix|gnome-terminal|xterm|xfce4-terminal|sakura|terminator|st|urxvt|ghostty) ]]; then
-          return 0
-        fi
+        win_class=$(xdotool getactivewindow getwindowclassname 2>/dev/null || echo "")
+        win_name_lower=$(printf '%s' "$win_name" | tr '[:upper:]' '[:lower:]')
+        win_class_lower=$(printf '%s' "$win_class" | tr '[:upper:]' '[:lower:]')
+
+        case "$win_class_lower" in
+          alacritty|kitty|org.wezfurlong.wezterm|wezterm|foot|tilix|gnome-terminal|gnome-terminal-server|xterm|xfce4-terminal|sakura|terminator|st|st-256color|urxvt|ghostty|konsole)
+            return 0
+            ;;
+        esac
+
+        case "$win_name_lower" in
+          *terminal*|*konsole*|*alacritty*|*kitty*|*wezterm*|*foot*|*tilix*|*gnome-terminal*|*xterm*|*xfce4-terminal*|*sakura*|*terminator*|*urxvt*|*ghostty*)
+            return 0
+            ;;
+        esac
       fi
       return 1
       ;;

--- a/tests/peon.bats
+++ b/tests/peon.bats
@@ -4264,6 +4264,40 @@ json.dump(c, open('$TEST_DIR/config.json', 'w'))
   afplay_was_called
 }
 
+@test "Linux focus detection uses xdotool window class for zellij in Alacritty" {
+  export PEON_PLATFORM=linux
+  export XDG_SESSION_TYPE=x11
+  /usr/bin/python3 -c "
+import json
+c = json.load(open('$TEST_DIR/config.json'))
+c['suppress_sound_when_tab_focused'] = True
+json.dump(c, open('$TEST_DIR/config.json', 'w'))
+"
+  echo "zellij: dev" > "$TEST_DIR/.mock_xdotool_window_name"
+  echo "Alacritty" > "$TEST_DIR/.mock_xdotool_window_class"
+
+  run_peon '{"hook_event_name":"Stop","cwd":"/tmp/myproject","session_id":"s1","permission_mode":"default"}'
+  [ "$PEON_EXIT" -eq 0 ]
+  ! linux_audio_was_called
+}
+
+@test "Linux focus detection does not treat generic titles like start as st terminal" {
+  export PEON_PLATFORM=linux
+  export XDG_SESSION_TYPE=x11
+  /usr/bin/python3 -c "
+import json
+c = json.load(open('$TEST_DIR/config.json'))
+c['suppress_sound_when_tab_focused'] = True
+json.dump(c, open('$TEST_DIR/config.json', 'w'))
+"
+  echo "start" > "$TEST_DIR/.mock_xdotool_window_name"
+  echo "firefox" > "$TEST_DIR/.mock_xdotool_window_class"
+
+  run_peon '{"hook_event_name":"Stop","cwd":"/tmp/myproject","session_id":"s1","permission_mode":"default"}'
+  [ "$PEON_EXIT" -eq 0 ]
+  linux_audio_was_called
+}
+
 # ============================================================
 # packs bind / unbind / bindings CLI
 # ============================================================

--- a/tests/setup.bash
+++ b/tests/setup.bash
@@ -139,6 +139,24 @@ SCRIPT
     chmod +x "$MOCK_BIN/$player"
   done
 
+  # Mock xdotool for Linux focus detection tests
+  cat > "$MOCK_BIN/xdotool" <<'SCRIPT'
+#!/bin/bash
+if [ -f "${CLAUDE_PEON_DIR}/.disabled_xdotool" ]; then
+  exit 127
+fi
+if [[ "$*" == *"getwindowclassname"* ]]; then
+  cat "${CLAUDE_PEON_DIR}/.mock_xdotool_window_class" 2>/dev/null
+  exit 0
+fi
+if [[ "$*" == *"getwindowname"* ]]; then
+  cat "${CLAUDE_PEON_DIR}/.mock_xdotool_window_name" 2>/dev/null
+  exit 0
+fi
+exit 0
+SCRIPT
+  chmod +x "$MOCK_BIN/xdotool"
+
   # Mock terminal-notifier — log calls instead of sending real notifications
   cat > "$MOCK_BIN/terminal-notifier" <<'SCRIPT'
 #!/bin/bash


### PR DESCRIPTION
Fixes #472

## Summary
- check the active X11 window class as well as the title when deciding whether the terminal is focused
- use stable class-name matches for terminals like Alacritty so zellij-renamed titles still count as focused
- stop treating generic titles like `start` as a match for the `st` terminal by restricting that fallback to class-name detection

## Validation
- `bash -n peon.sh`
- `bash -n tests/setup.bash`
- direct function-level check of `terminal_is_focused()` on Linux/X11:
  - returns focused for `zellij: dev` with window class `Alacritty`
  - returns not focused for window title `start` with window class `firefox`

## Notes
- I added focused BATS coverage for the two Linux regressions, but this host does not currently have `bats` installed to execute the suite locally.
