### PR TITLE
fix(peon.sh): write consolidated python block to tempfile (#488)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+### Fixed
+- **`peon.sh` silently failed on Windows msys2/git-bash because the consolidated Python block exceeded `CreateProcess`'s ~32 KB argv limit.** The block had grown to ~47 KB after the state-helper injection, so `python3 -c "<block>"` returned `E2BIG` and the hook exited 0 with no logs, breaking every event (`Stop`, `Notification`, `PermissionRequest`, etc.) on git-bash. Hook now writes the block to a tempfile and invokes `python3 <path>` instead, with a `trap` for defensive cleanup. Stderr on this path is no longer suppressed so any future exec failure surfaces in `peon debug status`. Linux/macOS were unaffected (argv limits are in the megabytes); native Windows (`peon.ps1`) does not use this path. Closes #488.
+
 ## v2.24.0 (2026-04-25)
 
 ### Fixed

--- a/peon.sh
+++ b/peon.sh
@@ -4356,7 +4356,14 @@ export PEON_ENV_HOOK_TTY="$_PEON_HOOK_TTY"
 # --- Single Python call: config, event parsing, agent detection, category routing, sound picking ---
 # Consolidates 5 separate python3 invocations into one for ~120-200ms faster hook response.
 # Outputs shell variables consumed by the bash play/notify/title logic below.
-_PEON_PYOUT=$(python3 -c "
+#
+# Body is written to a tempfile and invoked by path. Passing this block via
+# `python3 -c` overflows the Windows CreateProcess argv limit (~32 KB) on
+# msys2/git-bash, causing silent E2BIG and a hook that exits 0 with no logs.
+# See https://github.com/PeonPing/peon-ping/issues/488
+_PEON_PY_TMP=$(mktemp 2>/dev/null || echo "${TMPDIR:-/tmp}/peon-py-$$.py")
+trap 'rm -f "$_PEON_PY_TMP"' EXIT
+cat > "$_PEON_PY_TMP" <<PEON_LOCAL_PY_EOF
 import sys, json, os, re, random, time, shlex, tempfile, fnmatch
 q = shlex.quote
 _peon_start = time.monotonic()
@@ -5509,7 +5516,10 @@ print('TAB_COLOR_RGB=' + q(tab_color_rgb))
 _auto_debug = cfg.get('debug', False) or os.environ.get('PEON_DEBUG') == '1'
 if _auto_debug:
     print('PEON_AUTO_PRUNE=' + q(str(cfg.get('debug_retention_days', 7))))
-" <<< "$INPUT" 2>/dev/null)
+PEON_LOCAL_PY_EOF
+# Stderr intentionally NOT suppressed: silent failures here masked issue #488
+# for multiple releases. Any future exec error will surface in `peon debug`.
+_PEON_PYOUT=$(python3 "$_PEON_PY_TMP" <<< "$INPUT")
 eval "$_PEON_PYOUT"
 
 # --- Bash-side debug log function for [play] and [notify] phases ---


### PR DESCRIPTION
## Summary

Fixes #488. On Windows msys2/git-bash, the consolidated python block under `python3 -c \"...\"` (~47 KB after `${_PEON_STATE_PY_HELPERS}` injection) exceeds the `CreateProcess` argv limit of ~32 KB and silently fails with `E2BIG`. The hook exits 0 with no logs and every Claude Code event (`Stop`, `Notification`, `PermissionRequest`, `PreToolUse`, ...) is dropped. CLI paths still work because they don't hit this exec.

Linux `execve` and macOS argv limits are in the megabytes; native Windows uses `peon.ps1` which has no Python dependency. So the fix is scoped to one site in `peon.sh`, but applied unconditionally because the tempfile approach is correct on every platform.

## Changes

1. **Write the block body to a tempfile and invoke `python3 <path>`.** Uses an unquoted heredoc so the existing `${_PEON_STATE_PY_HELPERS}` expansion still happens. The Python source is unchanged — `\\\\` and `\"` escape sequences resolve identically inside `\"...\"` and inside an unquoted heredoc for this body (verified by `py_compile`).
2. **Drop the `2>/dev/null` on the exec.** Per maintainer feedback in #488: silent stderr at this site masked the bug across multiple releases. Future failures will surface in `peon debug status`.
3. **`trap 'rm -f \"\$_PEON_PY_TMP\"' EXIT` for defensive cleanup.** Avoids stranding ~47 KB of Python in `%TEMP%` when a hook is interrupted. There is no other `EXIT` trap in `peon.sh`, so this doesn't clobber anything.

## Verification

- `bash -n peon.sh` — clean.
- `bash scripts/lint-python-quoting.sh peon.sh` — passes (the dangerous `python3 -c \"...\"` quoting pattern is gone at this site).
- `bats tests/lint-python-quoting.bats tests/peon.bats` — same pass/fail set as `main` (the 3 failures on `main` are pre-existing log-fixture flakes on macOS, not caused by this PR; all 382/385 passing tests remain passing).
- Heredoc-expanded body: `py_compile` clean, **47,404 bytes** — confirms the bug still affects v2.23.0, not just v2.22.0 from the original report.

## Test plan

- [ ] Windows + Git Bash + Python 3.x: fresh install, fire any hook event, confirm `logs/` populates and `peon debug status` shows non-zero log files.
- [ ] macOS / Linux: full `bats tests/` should be unchanged from `main`.
- [ ] Native Windows (`peon.ps1`): unchanged path, no regression expected.