### PR TITLE
fix: use Notification media role for pw-play on Linux

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1392,7 +1392,7 @@ except Exception:
       " 2>/dev/null
     elif [ "$PLATFORM" = "linux" ]; then
       if command -v pw-play &>/dev/null; then
-        LC_ALL=C pw-play --volume=0.3 "$TEST_SOUND" 2>/dev/null
+        LC_ALL=C pw-play --media-role=Notification --volume=0.3 "$TEST_SOUND" 2>/dev/null
       elif command -v paplay &>/dev/null; then
         paplay --volume="$(python3 -c "print(int(0.3 * 65536))")" "$TEST_SOUND" 2>/dev/null
       elif command -v ffplay &>/dev/null; then

--- a/peon.sh
+++ b/peon.sh
@@ -301,9 +301,9 @@ play_linux_sound() {
     pw-play)
       # pw-play (PipeWire) expects volume as float 0.0-1.0 (unlike paplay 0-65536, ffplay/mpv 0-100)
       if [ "$use_bg" = true ]; then
-        nohup env LC_ALL=C pw-play --volume "$vol" "$file" >/dev/null 2>&1 &
+        nohup env LC_ALL=C pw-play --media-role=Notification --volume "$vol" "$file" >/dev/null 2>&1 &
       else
-        LC_ALL=C pw-play --volume "$vol" "$file" >/dev/null 2>&1
+        LC_ALL=C pw-play --media-role=Notification --volume "$vol" "$file" >/dev/null 2>&1
       fi
       ;;
     paplay)

--- a/relay.sh
+++ b/relay.sh
@@ -333,7 +333,7 @@ def play_sound_on_host(path, volume):
     elif HOST_PLATFORM == "linux":
         # Try players in priority order (same as peon.sh)
         players = [
-            (["pw-play", "--volume", vol, path], "pw-play"),
+            (["pw-play", "--media-role=Notification", "--volume", vol, path], "pw-play"),
             (["paplay", f"--volume={max(0, min(65536, int(float(vol) * 65536)))}", path], "paplay"),
             (["ffplay", "-nodisp", "-autoexit", "-volume", str(max(0, min(100, int(float(vol) * 100)))), path], "ffplay"),
             (["mpv", "--no-video", f"--volume={max(0, min(100, int(float(vol) * 100)))}", path], "mpv"),

--- a/relay.sh
+++ b/relay.sh
@@ -120,22 +120,24 @@ if [ ! -d "$PEON_DIR/packs" ]; then
   exit 1
 fi
 
-# --- Detect host platform ---
-case "$(uname -s)" in
-  Darwin) HOST_PLATFORM="mac" ;;
-  Linux)
-    # Check for Docker/devcontainer BEFORE checking for WSL
-    # (devcontainers on WSL2 have both indicators)
-    if [ -f /.dockerenv ]; then
-      HOST_PLATFORM="linux"
-    elif grep -qi microsoft /proc/version 2>/dev/null; then
-      HOST_PLATFORM="wsl"
-    else
-      HOST_PLATFORM="linux"
-    fi ;;
-  MINGW*|MSYS*|CYGWIN*) HOST_PLATFORM="windows" ;;
-  *)      HOST_PLATFORM="unknown" ;;
-esac
+# --- Detect host platform (override-friendly for tests) ---
+if [ -z "${HOST_PLATFORM:-}" ]; then
+  case "$(uname -s)" in
+    Darwin) HOST_PLATFORM="mac" ;;
+    Linux)
+      # Check for Docker/devcontainer BEFORE checking for WSL
+      # (devcontainers on WSL2 have both indicators)
+      if [ -f /.dockerenv ]; then
+        HOST_PLATFORM="linux"
+      elif grep -qi microsoft /proc/version 2>/dev/null; then
+        HOST_PLATFORM="wsl"
+      else
+        HOST_PLATFORM="linux"
+      fi ;;
+    MINGW*|MSYS*|CYGWIN*) HOST_PLATFORM="windows" ;;
+    *)      HOST_PLATFORM="unknown" ;;
+  esac
+fi
 
 export RELAY_PORT PEON_DIR BIND_ADDR HOST_PLATFORM
 

--- a/tests/peon.bats
+++ b/tests/peon.bats
@@ -2280,7 +2280,7 @@ PYTHON
 # Linux volume handling per backend
 # ============================================================
 
-@test "Linux pw-play uses --volume with decimal" {
+@test "Linux pw-play uses notification media role and decimal volume" {
   export PEON_PLATFORM=linux
   for player in paplay ffplay mpv play aplay; do
     touch "$TEST_DIR/.disabled_${player}"
@@ -2291,6 +2291,7 @@ JSON
   run_peon '{"hook_event_name":"SessionStart","cwd":"/tmp/myproject","session_id":"s1","permission_mode":"default"}'
   linux_audio_was_called
   cmdline=$(linux_audio_cmdline)
+  [[ "$cmdline" == *"--media-role=Notification"* ]]
   [[ "$cmdline" == *"--volume 0.3"* ]]
 }
 

--- a/tests/relay.bats
+++ b/tests/relay.bats
@@ -85,6 +85,17 @@ start_relay() {
   [ "$output" = "OK" ]
 }
 
+@test "relay /play uses notification media role with pw-play on Linux" {
+  start_relay
+  run "$REAL_CURL" -sf "http://127.0.0.1:$RELAY_PORT/play?file=packs/peon/sounds/Hello1.wav" \
+    -H "X-Volume: 0.7"
+  [ "$status" -eq 0 ]
+  [ "$output" = "OK" ]
+  sleep 0.2
+  [ -f "$TEST_DIR/linux_audio.log" ]
+  [[ "$(linux_audio_cmdline)" == *"--media-role=Notification"* ]]
+}
+
 @test "relay /play returns 400 without file parameter" {
   start_relay
   run "$REAL_CURL" -s -o /dev/null -w "%{http_code}" "http://127.0.0.1:$RELAY_PORT/play"

--- a/tests/relay.bats
+++ b/tests/relay.bats
@@ -92,8 +92,9 @@ start_relay() {
   [ "$status" -eq 0 ]
   [ "$output" = "OK" ]
   sleep 0.2
-  [ -f "$TEST_DIR/linux_audio.log" ]
-  [[ "$(linux_audio_cmdline)" == *"--media-role=Notification"* ]]
+  linux_audio_was_called
+  cmdline=$(linux_audio_cmdline)
+  [[ "$cmdline" == *"--media-role=Notification"* ]]
 }
 
 @test "relay /play returns 400 without file parameter" {

--- a/tests/relay.bats
+++ b/tests/relay.bats
@@ -86,7 +86,8 @@ start_relay() {
 }
 
 @test "relay /play uses notification media role with pw-play on Linux" {
-  start_relay
+  # Override platform detection in relay.sh so the Linux audio branch fires on macOS CI runners.
+  HOST_PLATFORM=linux start_relay
   run "$REAL_CURL" -sf "http://127.0.0.1:$RELAY_PORT/play?file=packs/peon/sounds/Hello1.wav" \
     -H "X-Volume: 0.7"
   [ "$status" -eq 0 ]


### PR DESCRIPTION
## Summary
- pass `--media-role=Notification` to `pw-play` so peon-ping sounds follow notification routing instead of PipeWire's default music role
- apply the same behavior to relay playback and the Linux installer sound test for consistent `pw-play` usage
- add regression coverage for both direct Linux playback and relay playback

Closes #499.

Disclaimer: This PR was assisted by AI