### PR TITLE
feat(sounds): add per-sound disable toggles within a pack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+### Added
+- **Per-sound disable toggles.** New `disabled_sounds` config key (keyed by pack → category → array of filenames) lets you silence individual sounds within a pack without removing the file or disabling the whole category. If every sound in a category is disabled, the category stays silent for that pack. Three new CLI commands drive it: `peon sounds list [pack]` lists sounds with a `<-- disabled` marker, `peon sounds disable <category> <file> [--pack=<name>]` mutes a single sound, and `peon sounds enable ...` re-enables it. Applies across `peon.sh`, the Windows `peon.ps1` runtime, and the SSH/devcontainer relay.
+
 ## v2.25.0 (2026-04-28)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -266,6 +266,9 @@ peon packs ide-bindings   # List all IDE-based bindings
 peon packs exclude add <path> # Silence sounds & notifications for a glob or directory
 peon packs exclude remove <path> # Stop silencing the given path
 peon packs exclude list   # List silenced paths
+peon sounds list [pack]   # List sounds in a pack, marking disabled ones
+peon sounds disable <category> <file> [--pack=<name>]  # Mute a single sound within a pack
+peon sounds enable <category> <file> [--pack=<name>]   # Re-enable a previously disabled sound
 peon notifications on     # Enable desktop notifications
 peon notifications off    # Disable desktop notifications
 peon notifications overlay   # Use large overlay banners (default)

--- a/README_zh.md
+++ b/README_zh.md
@@ -263,6 +263,9 @@ peon packs ide-bindings   # 列出所有 IDE 绑定
 peon packs exclude add <path> # 为 glob 或目录跳过 path_rules
 peon packs exclude remove <path> # 移除排除路径
 peon packs exclude list   # 列出排除路径
+peon sounds list [pack]   # 列出语音包中的所有声音，并标记已禁用项
+peon sounds disable <category> <file> [--pack=<name>]  # 禁用语音包中的单个声音
+peon sounds enable <category> <file> [--pack=<name>]   # 重新启用之前禁用的声音
 peon notifications on     # 启用桌面通知
 peon notifications off    # 禁用桌面通知
 peon notifications overlay   # 使用大型覆盖横幅（默认）

--- a/completions.bash
+++ b/completions.bash
@@ -88,6 +88,11 @@ _peon_completions() {
           COMPREPLY=( $(compgen -W "ntfy pushover telegram on off status test" -- "$cur") )
         fi
         return 0 ;;
+      sounds)
+        if [ "$cword" -eq 2 ]; then
+          COMPREPLY=( $(compgen -W "list disable enable" -- "$cur") )
+        fi
+        return 0 ;;
       debug)
         if [ "$cword" -eq 2 ]; then
           COMPREPLY=( $(compgen -W "on off status" -- "$cur") )
@@ -114,7 +119,7 @@ _peon_completions() {
   fi
 
   # Top-level commands
-  COMPREPLY=( $(compgen -W "pause resume mute unmute toggle status volume rotation packs notifications mobile relay debug logs trainer update help" -- "$cur") )
+  COMPREPLY=( $(compgen -W "pause resume mute unmute toggle status volume rotation packs sounds notifications mobile relay debug logs trainer update help" -- "$cur") )
   return 0
 }
 

--- a/completions.fish
+++ b/completions.fish
@@ -32,6 +32,7 @@ complete -c peon -n "__peon_using_subcommand status" -l verbose -d "Show full de
 complete -c peon -n __peon_no_subcommand -a volume -d "Get or set volume level"
 complete -c peon -n __peon_no_subcommand -a rotation -d "Get or set pack rotation mode"
 complete -c peon -n __peon_no_subcommand -a packs -d "Manage sound packs"
+complete -c peon -n __peon_no_subcommand -a sounds -d "Enable/disable individual sounds in a pack"
 complete -c peon -n __peon_no_subcommand -a notifications -d "Control desktop notifications"
 complete -c peon -n __peon_no_subcommand -a mobile -d "Configure mobile push notifications"
 complete -c peon -n __peon_no_subcommand -a debug -d "Toggle debug logging"
@@ -199,6 +200,11 @@ function __peon_trainer_goal
   set -l cmd (commandline -opc)
   test (count $cmd) -ge 3; and test $cmd[2] = trainer; and test $cmd[3] = goal
 end
+
+# sounds subcommands
+complete -c peon -n "__peon_using_subcommand sounds" -a list -d "List sounds in a pack"
+complete -c peon -n "__peon_using_subcommand sounds" -a disable -d "Disable an individual sound"
+complete -c peon -n "__peon_using_subcommand sounds" -a enable -d "Re-enable an individual sound"
 
 # trainer goal weekday completions (short names)
 complete -c peon -n __peon_trainer_goal -a mon -d "Monday"

--- a/completions.zsh
+++ b/completions.zsh
@@ -15,6 +15,7 @@ _peon() {
     'volume:Get or set volume level'
     'rotation:Get or set pack rotation mode'
     'packs:Manage sound packs'
+    'sounds:Enable/disable individual sounds in a pack'
     'notifications:Control desktop notifications'
     'mobile:Configure mobile push notifications'
     'relay:Start audio relay for devcontainers'
@@ -158,6 +159,13 @@ _peon() {
           _describe 'packs command' packs_cmds
           ;;
       esac
+      ;;
+    sounds)
+      if [[ "$CURRENT" -eq 3 ]]; then
+        compadd -- list disable enable
+      elif [[ "$words[3]" == "list" && "$CURRENT" -eq 4 ]]; then
+        _peon_pack_names
+      fi
       ;;
     notifications)
       case "$words[3]" in

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -140,6 +140,7 @@ peon pause / resume / mute / unmute / status
 peon volume [0.0-1.0]
 peon rotation [random|round-robin|session_override]
 peon packs list / use / install / next / remove / bind / unbind / bindings / community / search
+peon sounds list [pack] / disable <cat> <file> / enable <cat> <file>  (disable or re-enable individual sounds in a pack)
 peon notifications on / off / test
 peon debug on / off / status
 peon logs [--last N] [--session ID] [--clear]

--- a/install.ps1
+++ b/install.ps1
@@ -2742,6 +2742,24 @@ if (-not $catSounds -or $catSounds.Count -eq 0) {
     exit 0
 }
 
+# Filter out individually disabled sounds (config.disabled_sounds[pack][category])
+$disabledList = @()
+try {
+    $_dsPack = $config.disabled_sounds.$activePack
+    if ($_dsPack) {
+        $_dsCat = $_dsPack.$category
+        if ($_dsCat) { $disabledList = @($_dsCat) }
+    }
+} catch {}
+if ($disabledList.Count -gt 0) {
+    $catSounds = @($catSounds | Where-Object { $disabledList -notcontains (Split-Path $_.file -Leaf) })
+    if ($catSounds.Count -eq 0) {
+        & $peonLog 'sound' @{ error = 'all sounds disabled'; pack = $activePack; category = $category; fallback = 'none' }
+        & $peonLog 'exit' @{ duration_ms = [string]$_peonStart.ElapsedMilliseconds; exit = '0' }
+        exit 0
+    }
+}
+
 # Anti-repeat: avoid last played sound
 $lastKey = "last_$category"
 $lastPlayed = ""

--- a/install.ps1
+++ b/install.ps1
@@ -2750,7 +2750,9 @@ try {
         $_dsCat = $_dsPack.$category
         if ($_dsCat) { $disabledList = @($_dsCat) }
     }
-} catch {}
+} catch {
+    # missing or non-object disabled_sounds; treat as no per-sound disables
+}
 if ($disabledList.Count -gt 0) {
     $catSounds = @($catSounds | Where-Object { $disabledList -notcontains (Split-Path $_.file -Leaf) })
     if ($catSounds.Count -eq 0) {

--- a/peon.sh
+++ b/peon.sh
@@ -3065,6 +3065,134 @@ print()
       *)
         echo "Usage: peon packs <list|use|next|install|install-local|remove|rotation|bind|unbind|bindings|community|search>" >&2; exit 1 ;;
     esac ;;
+  sounds)
+    SOUNDS_ACTION="${2:-}"
+    case "$SOUNDS_ACTION" in
+      list)
+        SOUNDS_PACK_ARG="${3:-}"
+        export PEON_ENV_SOUNDS_PACK="$SOUNDS_PACK_ARG"
+        python3 -c "
+import json, os, sys
+no_color = os.environ.get('NO_COLOR', '')
+CYAN = '' if no_color else '\033[36m'
+GREEN = '' if no_color else '\033[32m'
+RED = '' if no_color else '\033[31m'
+DIM = '' if no_color else '\033[90m'
+RST = '' if no_color else '\033[0m'
+config_path = os.environ.get('PEON_ENV_CONFIG', '')
+peon_dir = os.environ.get('PEON_ENV_PEON_DIR', '')
+try:
+    cfg = json.load(open(config_path))
+except Exception:
+    cfg = {}
+pack = os.environ.get('PEON_ENV_SOUNDS_PACK', '') or cfg.get('default_pack', cfg.get('active_pack', 'peon'))
+pack_dir = os.path.join(peon_dir, 'packs', pack)
+manifest = None
+for mname in ('openpeon.json', 'manifest.json'):
+    mpath = os.path.join(pack_dir, mname)
+    if os.path.exists(mpath):
+        manifest = json.load(open(mpath))
+        break
+if not manifest:
+    print(f'Error: pack \"{pack}\" not found.', file=sys.stderr)
+    sys.exit(1)
+disabled_map = cfg.get('disabled_sounds', {}).get(pack, {})
+categories = manifest.get('categories', {})
+total = sum(len(c.get('sounds', [])) for c in categories.values())
+print()
+print(f'  {CYAN}Sounds in \"{pack}\" ({total} total){RST}')
+for cat in sorted(categories.keys()):
+    sounds = categories[cat].get('sounds', [])
+    if not sounds:
+        continue
+    disabled = set(disabled_map.get(cat, []) or [])
+    print()
+    print(f'  {CYAN}{cat}{RST}')
+    max_w = max(len(os.path.basename(str(s.get('file', '')))) for s in sounds) + 2
+    name_w = max(max_w, 28)
+    for s in sounds:
+        fname = os.path.basename(str(s.get('file', '')))
+        label = str(s.get('label', ''))
+        is_disabled = fname in disabled
+        marker = f'  {RED}<-- disabled{RST}' if is_disabled else ''
+        label_str = f'{DIM}{label}{RST}' if label else ''
+        print(f'    {fname:<{name_w}}{label_str}{marker}')
+print()
+"
+        exit $? ;;
+      disable|enable)
+        SOUNDS_CAT="${3:-}"
+        SOUNDS_FILE="${4:-}"
+        SOUNDS_PACK=""
+        for _a in "${@:5}"; do
+          case "$_a" in
+            --pack=*) SOUNDS_PACK="${_a#--pack=}" ;;
+          esac
+        done
+        if [ -z "$SOUNDS_CAT" ] || [ -z "$SOUNDS_FILE" ]; then
+          echo "Usage: peon sounds $SOUNDS_ACTION <category> <file> [--pack=<name>]" >&2; exit 1
+        fi
+        export PEON_ENV_SOUNDS_ACTION="$SOUNDS_ACTION"
+        export PEON_ENV_SOUNDS_CAT="$SOUNDS_CAT"
+        export PEON_ENV_SOUNDS_FILE="$SOUNDS_FILE"
+        export PEON_ENV_SOUNDS_PACK="$SOUNDS_PACK"
+        python3 -c "
+import json, os, sys
+config_path = os.environ.get('PEON_ENV_CONFIG', '')
+peon_dir = os.environ.get('PEON_ENV_PEON_DIR', '')
+action = os.environ.get('PEON_ENV_SOUNDS_ACTION', '')
+category = os.environ.get('PEON_ENV_SOUNDS_CAT', '')
+fname = os.path.basename(os.environ.get('PEON_ENV_SOUNDS_FILE', ''))
+try:
+    cfg = json.load(open(config_path))
+except Exception:
+    cfg = {}
+pack = os.environ.get('PEON_ENV_SOUNDS_PACK', '') or cfg.get('default_pack', cfg.get('active_pack', 'peon'))
+pack_dir = os.path.join(peon_dir, 'packs', pack)
+manifest = None
+for mname in ('openpeon.json', 'manifest.json'):
+    mpath = os.path.join(pack_dir, mname)
+    if os.path.exists(mpath):
+        manifest = json.load(open(mpath))
+        break
+if not manifest:
+    print(f'Error: pack \"{pack}\" not found.', file=sys.stderr)
+    sys.exit(1)
+cat_sounds = manifest.get('categories', {}).get(category, {}).get('sounds', [])
+if not cat_sounds:
+    print(f'Error: category \"{category}\" has no sounds in pack \"{pack}\".', file=sys.stderr)
+    sys.exit(1)
+valid = {os.path.basename(str(s.get('file', ''))) for s in cat_sounds}
+if fname not in valid:
+    print(f'Error: sound \"{fname}\" not found in {pack}/{category}.', file=sys.stderr)
+    print(f'Available: {\", \".join(sorted(valid))}', file=sys.stderr)
+    sys.exit(1)
+ds = cfg.setdefault('disabled_sounds', {})
+pack_map = ds.setdefault(pack, {})
+cur = list(pack_map.get(category, []) or [])
+if action == 'disable':
+    if fname not in cur:
+        cur.append(fname)
+    pack_map[category] = sorted(cur)
+    msg = f'peon-ping: disabled {fname} in {pack}/{category}'
+else:
+    cur = [f for f in cur if f != fname]
+    if cur:
+        pack_map[category] = sorted(cur)
+    else:
+        pack_map.pop(category, None)
+    if not pack_map:
+        ds.pop(pack, None)
+    if not ds:
+        cfg.pop('disabled_sounds', None)
+    msg = f'peon-ping: enabled {fname} in {pack}/{category}'
+json.dump(cfg, open(config_path, 'w'), indent=2)
+print(msg)
+"
+        _rc=$?; [ $_rc -eq 0 ] && sync_adapter_configs; exit $_rc ;;
+      *)
+        echo "Usage: peon sounds <list|disable|enable> [args]" >&2; exit 1 ;;
+    esac ;;
   mobile)
     case "${2:-}" in
       ntfy)
@@ -3728,6 +3856,11 @@ Pack management:
   packs rotation add --install <p>  Add to rotation, installing from registry if needed
   packs rotation remove <p> Remove pack(s) from rotation
   packs rotation clear    Clear all packs from rotation
+
+Sound management (per-sound toggles within a pack):
+  sounds list [pack]                      List sounds in a pack, marking disabled ones
+  sounds disable <cat> <file> [--pack=<p>] Disable a specific sound within a category
+  sounds enable <cat> <file> [--pack=<p>]  Re-enable a previously disabled sound
 
 Mobile notifications:
   mobile ntfy <topic>      Set up ntfy.sh push notifications
@@ -5298,6 +5431,9 @@ if category and not paused:
         if not manifest:
             manifest = {}
         sounds = manifest.get('categories', {}).get(category, {}).get('sounds', [])
+        disabled_list = cfg.get('disabled_sounds', {}).get(active_pack, {}).get(category, []) or []
+        if disabled_list:
+            sounds = [s for s in sounds if os.path.basename(str(s.get('file', ''))) not in disabled_list]
         if sounds:
             last_played = state.get('last_played', {})
             last_file = last_played.get(category, '')

--- a/relay.sh
+++ b/relay.sh
@@ -281,6 +281,13 @@ def pick_sound_for_category(category):
     if not sounds:
         return None, None
 
+    # Filter out individually disabled sounds (by basename)
+    disabled_list = config.get("disabled_sounds", {}).get(active_pack, {}).get(category, []) or []
+    if disabled_list:
+        sounds = [s for s in sounds if os.path.basename(str(s.get("file", ""))) not in disabled_list]
+        if not sounds:
+            return None, None
+
     # Load state to avoid repeats
     state = load_state()
     last_played = state.get("last_played", {})

--- a/skills/peon-ping-config/SKILL.md
+++ b/skills/peon-ping-config/SKILL.md
@@ -21,6 +21,18 @@ The config file is at `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/peon-ping/confi
 - **pack_rotation_mode** (string): `"random"` (default) picks a random pack each session. `"round-robin"` cycles through in order. `"session_override"` uses explicit per-session assignments from `/peon-ping-use`; invalid or missing packs fall back to `default_pack` and the stale assignment is removed. Legacy value `"agentskill"` is accepted as an alias.
 - **categories** (object): Toggle individual CESP sound categories:
   - `session.start`, `task.acknowledge`, `task.complete`, `task.error`, `input.required`, `resource.limit`, `user.spam` — each a boolean
+- **disabled_sounds** (object): Disable specific sound files within a pack, keyed by pack name → category → array of filenames (basenames). Example:
+  ```json
+  "disabled_sounds": {
+    "peon": { "session.start": ["Hello1.wav"] }
+  }
+  ```
+  If every sound in a category is listed, that category stays silent. Prefer the CLI:
+  ```bash
+  peon sounds list [pack]
+  peon sounds disable <category> <file> [--pack=<name>]
+  peon sounds enable  <category> <file> [--pack=<name>]
+  ```
 - **annoyed_threshold** (number): How many rapid prompts trigger user.spam sounds
 - **annoyed_window_seconds** (number): Time window for the annoyed threshold
 - **silent_window_seconds** (number): Suppress task.complete sounds for tasks shorter than this many seconds

--- a/tests/peon.bats
+++ b/tests/peon.bats
@@ -5866,3 +5866,125 @@ json.dump(c, open('$TEST_DIR/config.json', 'w'), indent=2)
   [ "$status" -eq 0 ]
   [[ "$output" == *"logs"* ]]
 }
+
+# ============================================================
+# Per-sound disable (disabled_sounds)
+# ============================================================
+
+@test "disabled_sounds filters out a sound from random selection" {
+  # Disable Hello1.wav — only Hello2.wav remains for session.start
+  "$PEON_PY" -c "
+import json
+cfg = json.load(open('$TEST_DIR/config.json'))
+cfg['disabled_sounds'] = {'peon': {'session.start': ['Hello1.wav']}}
+json.dump(cfg, open('$TEST_DIR/config.json', 'w'))
+"
+  for i in 1 2 3 4 5; do
+    run_peon "{\"hook_event_name\":\"SessionStart\",\"cwd\":\"/tmp/p\",\"session_id\":\"s$i\",\"permission_mode\":\"default\"}"
+  done
+  [ -f "$TEST_DIR/afplay.log" ]
+  ! grep -q "Hello1.wav" "$TEST_DIR/afplay.log"
+  grep -q "Hello2.wav" "$TEST_DIR/afplay.log"
+}
+
+@test "disabled_sounds: all sounds disabled => no sound played" {
+  "$PEON_PY" -c "
+import json
+cfg = json.load(open('$TEST_DIR/config.json'))
+cfg['disabled_sounds'] = {'peon': {'session.start': ['Hello1.wav', 'Hello2.wav']}}
+json.dump(cfg, open('$TEST_DIR/config.json', 'w'))
+"
+  run_peon '{"hook_event_name":"SessionStart","cwd":"/tmp/p","session_id":"s1","permission_mode":"default"}'
+  [ "$PEON_EXIT" -eq 0 ]
+  ! afplay_was_called
+}
+
+@test "disabled_sounds applies only to the named pack" {
+  # Disabled in sc_kerrigan, not peon — peon sound should still play
+  "$PEON_PY" -c "
+import json
+cfg = json.load(open('$TEST_DIR/config.json'))
+cfg['disabled_sounds'] = {'sc_kerrigan': {'session.start': ['Hello1.wav']}}
+json.dump(cfg, open('$TEST_DIR/config.json', 'w'))
+"
+  run_peon '{"hook_event_name":"SessionStart","cwd":"/tmp/p","session_id":"s1","permission_mode":"default"}'
+  [ "$PEON_EXIT" -eq 0 ]
+  afplay_was_called
+}
+
+# ============================================================
+# sounds CLI (list/disable/enable)
+# ============================================================
+
+@test "sounds list prints categories and sounds from active pack" {
+  run bash "$PEON_SH" sounds list
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"session.start"* ]]
+  [[ "$output" == *"Hello1.wav"* ]]
+  [[ "$output" == *"Hello2.wav"* ]]
+}
+
+@test "sounds list marks disabled sounds" {
+  "$PEON_PY" -c "
+import json
+cfg = json.load(open('$TEST_DIR/config.json'))
+cfg['disabled_sounds'] = {'peon': {'session.start': ['Hello1.wav']}}
+json.dump(cfg, open('$TEST_DIR/config.json', 'w'))
+"
+  run bash "$PEON_SH" sounds list
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Hello1.wav"*"disabled"* ]]
+}
+
+@test "sounds list accepts explicit pack arg" {
+  run bash "$PEON_SH" sounds list sc_kerrigan
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"sc_kerrigan"* ]]
+}
+
+@test "sounds disable writes config entry" {
+  run bash "$PEON_SH" sounds disable session.start Hello1.wav
+  [ "$status" -eq 0 ]
+  disabled=$("$PEON_PY" -c "import json; print(','.join(json.load(open('$TEST_DIR/config.json')).get('disabled_sounds', {}).get('peon', {}).get('session.start', [])))")
+  [ "$disabled" = "Hello1.wav" ]
+}
+
+@test "sounds disable rejects unknown file" {
+  run bash "$PEON_SH" sounds disable session.start NoSuch.wav
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"not found"* ]]
+}
+
+@test "sounds disable rejects unknown category" {
+  run bash "$PEON_SH" sounds disable no.such Hello1.wav
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"no sounds"* ]]
+}
+
+@test "sounds enable removes entry and cleans empty structure" {
+  "$PEON_PY" -c "
+import json
+cfg = json.load(open('$TEST_DIR/config.json'))
+cfg['disabled_sounds'] = {'peon': {'session.start': ['Hello1.wav']}}
+json.dump(cfg, open('$TEST_DIR/config.json', 'w'))
+"
+  run bash "$PEON_SH" sounds enable session.start Hello1.wav
+  [ "$status" -eq 0 ]
+  has=$("$PEON_PY" -c "import json; print('disabled_sounds' in json.load(open('$TEST_DIR/config.json')))")
+  [ "$has" = "False" ]
+}
+
+@test "sounds --pack=<name> targets a non-default pack" {
+  run bash "$PEON_SH" sounds disable session.start Hello1.wav --pack=sc_kerrigan
+  [ "$status" -eq 0 ]
+  disabled=$("$PEON_PY" -c "import json; print(','.join(json.load(open('$TEST_DIR/config.json')).get('disabled_sounds', {}).get('sc_kerrigan', {}).get('session.start', [])))")
+  [ "$disabled" = "Hello1.wav" ]
+}
+
+@test "help lists sounds subcommand" {
+  run bash "$PEON_SH" help
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"sounds list"* ]]
+  [[ "$output" == *"sounds disable"* ]]
+  [[ "$output" == *"sounds enable"* ]]
+}


### PR DESCRIPTION
## Summary
- New `disabled_sounds` config key (pack → category → filenames) silences individual sounds without removing files or muting whole categories. If every sound in a category is listed, the category stays silent for that pack.
- New CLI: `peon sounds list [pack]`, `peon sounds disable <category> <file> [--pack=<name>]`, `peon sounds enable ...`. `sounds list` marks disabled entries with `<-- disabled`.
- Filter applied in `peon.sh`, the Windows `peon.ps1` runtime (in `install.ps1`), and `relay.sh` so SSH/devcontainer sessions honor the same config.

## Test plan
- [x] `bash -n peon.sh relay.sh` — syntax clean
- [x] Manual smoke: `peon sounds list|disable|enable` round-trips config; unknown file/category rejected
- [x] Manual runtime: disabled sound skipped across 6 SessionStart invocations; all-disabled category emits no sound
- [ ] `bats tests/` — 10 new BATS cases added in `tests/peon.bats` under "Per-sound disable" and "sounds CLI" (bats not available locally; please run in CI)
- [ ] Verify Windows Pester CI still passes with the new `peon.ps1` filter