### PR TITLE
WSL2 play_sound() method switching

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,11 +54,20 @@ Then run `peon-ping-setup` to register hooks and download sound packs. macOS and
 curl -fsSL https://raw.githubusercontent.com/PeonPing/peon-ping/main/install.sh | bash
 ```
 
-⚠️ In WSL2, **ffmpeg** must be installed to use sound packs that use formats other than **WAV**. In Debian distros, install with
+⚠️ **WSL2 audio notes.** peon-ping plays audio on the Windows side. On first run it probes your Windows host once (cached per Windows build) to pick the best playback path:
 
-```sh
-sudo apt update; sudo apt install -y ffmpeg
-```
+- On **Windows 10 / Windows 11 pre-24H2**, WPF MediaPlayer is used directly — native MP3 + WAV, no extra dependencies.
+- On **Windows 11 24H2+** (build 26100+), Microsoft removed legacy Windows Media Player from the OS and WPF MediaPlayer fails (`MILAVERR_INVALIDWMPVERSION`). peon-ping falls back to `System.Media.SoundPlayer`, which uses the Win32 `PlaySound` API and works everywhere — but it's WAV-only, so MP3 packs require **ffmpeg** to transcode on the fly:
+
+  ```sh
+  sudo apt update; sudo apt install -y ffmpeg
+  ```
+
+You can override the auto-detection with `PEON_WSL_AUDIO_BACKEND=auto|mediaplayer|soundplayer`:
+
+- `auto` (default) — probe + cache as described above
+- `mediaplayer` — force WPF MediaPlayer over the WSL UNC path (fails silently on 24H2+)
+- `soundplayer` — force tmpfile copy + `SoundPlayer` (universal, requires ffmpeg for non-WAV files)
 
 ### Option 3: Installer for Windows
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -52,11 +52,20 @@ brew install PeonPing/tap/peon-ping
 curl -fsSL https://raw.githubusercontent.com/PeonPing/peon-ping/main/install.sh | bash
 ```
 
-⚠️ 在 WSL2 中，若要使用 **WAV** 以外格式的语音包，必须安装 **ffmpeg**。在 Debian 发行版中可使用以下命令安装：
+⚠️ **WSL2 音频说明。** peon-ping 在 Windows 端播放音频。首次运行时会探测一次 Windows 主机（按 Windows 构建号缓存），自动选择最佳播放方式：
 
-```sh
-sudo apt update; sudo apt install -y ffmpeg
-```
+- 在 **Windows 10 / Windows 11 24H2 之前的版本**上，直接使用 WPF MediaPlayer，原生支持 MP3 + WAV，无需额外依赖。
+- 在 **Windows 11 24H2+**（构建号 26100+）上，微软已从系统中移除了旧版 Windows Media Player，WPF MediaPlayer 会失败（`MILAVERR_INVALIDWMPVERSION`）。peon-ping 会回退到 `System.Media.SoundPlayer`，它使用 Win32 `PlaySound` API，到处都能工作 — 但仅支持 WAV，因此 MP3 语音包需要安装 **ffmpeg** 进行实时转码：
+
+  ```sh
+  sudo apt update; sudo apt install -y ffmpeg
+  ```
+
+可通过 `PEON_WSL_AUDIO_BACKEND=auto|mediaplayer|soundplayer` 覆盖自动检测：
+
+- `auto`（默认）— 如上所述探测并缓存
+- `mediaplayer` — 强制通过 WSL UNC 路径使用 WPF MediaPlayer（在 24H2+ 上会静默失败）
+- `soundplayer` — 强制复制临时文件并使用 `SoundPlayer`（通用，非 WAV 文件需要 ffmpeg）
 
 ### 方式三：Windows 安装
 

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -27,6 +27,8 @@ or
 curl -fsSL peonping.com/install | bash
 ```
 
+WSL2 audio note: peon-ping plays audio on the Windows host. On first run it probes WPF MediaPlayer once (cached per Windows build). On Windows 10 / Win11 pre-24H2, MediaPlayer plays MP3+WAV natively. On Windows 11 24H2+ (build 26100+) Microsoft removed legacy WMP, so MediaPlayer fails and peon-ping falls back to System.Media.SoundPlayer (WAV-only — install ffmpeg to play MP3 packs). Override with PEON_WSL_AUDIO_BACKEND=auto|mediaplayer|soundplayer.
+
 ## What it does
 
 When your AI agent finishes a task, asks for permission, or hits an error, peon-ping plays a voice line from a game character. The Warcraft orc peon says "Work, work." when a task completes. GLaDOS says "Oh, it's you." when a session starts. Duke Nukem says "Son of a bitch!" when something breaks.

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -27,8 +27,6 @@ or
 curl -fsSL peonping.com/install | bash
 ```
 
-WSL2 audio note: peon-ping plays audio on the Windows host. On first run it probes WPF MediaPlayer once (cached per Windows build). On Windows 10 / Win11 pre-24H2, MediaPlayer plays MP3+WAV natively. On Windows 11 24H2+ (build 26100+) Microsoft removed legacy WMP, so MediaPlayer fails and peon-ping falls back to System.Media.SoundPlayer (WAV-only — install ffmpeg to play MP3 packs). Override with PEON_WSL_AUDIO_BACKEND=auto|mediaplayer|soundplayer.
-
 ## What it does
 
 When your AI agent finishes a task, asks for permission, or hits an error, peon-ping plays a voice line from a game character. The Warcraft orc peon says "Work, work." when a task completes. GLaDOS says "Oh, it's you." when a session starts. Duke Nukem says "Son of a bitch!" when something breaks.

--- a/peon.sh
+++ b/peon.sh
@@ -498,22 +498,95 @@ play_sound() {
       fi
       ;;
     wsl)
-      local wpath
-      wpath=$(wslpath -w "$file" 2>/dev/null) || { _peon_log play "error=\"wslpath failed\" file=$(basename "$file")"; return 0; }
-      wpath="${wpath//\\/\/}"
-      powershell.exe -NoProfile -NonInteractive -Command "
-        Add-Type -AssemblyName PresentationCore
-        \$p = New-Object System.Windows.Media.MediaPlayer
-        \$p.Volume = $vol
-        \$p.Open([Uri]::new('file:///$wpath'))
-        Start-Sleep -Milliseconds 500
-        \$p.Play()
-        while (\$p.Position -lt \$p.NaturalDuration.TimeSpan -and \$p.Position.TotalSeconds -lt 10) {
-          Start-Sleep -Milliseconds 100
-        }
-        \$p.Close()
-      " &>/dev/null &
-      save_sound_pid $!
+      local backend="${PEON_WSL_AUDIO_BACKEND:-auto}"
+      case "$backend" in auto|soundplayer|mediaplayer) ;; *) backend=auto ;; esac
+
+      _wsl_mediaplayer_probe() {
+        local build cache_file probe_wav wpath result
+        build=$(powershell.exe -NoProfile -NonInteractive -Command '[System.Environment]::OSVersion.Version.Build' 2>/dev/null | tr -d '\r\n ')
+        [ -z "$build" ] && { echo no; return; }
+        cache_file="$PEON_DIR/.wsl-mediaplayer-probe-$build"
+        if [ -f "$cache_file" ]; then
+          cat "$cache_file"
+          return
+        fi
+        probe_wav=$(find "$PEON_DIR/packs" -name '*.wav' -type f 2>/dev/null | head -1)
+        [ -z "$probe_wav" ] && { echo no; return; }
+        wpath=$(wslpath -w "$probe_wav" 2>/dev/null) || { echo no; return; }
+        result=$(powershell.exe -NoProfile -NonInteractive -Command "
+          Add-Type -AssemblyName PresentationCore,WindowsBase
+          \$disp = [System.Windows.Threading.Dispatcher]::CurrentDispatcher
+          \$p = New-Object System.Windows.Media.MediaPlayer
+          \$script:opened = \$false
+          \$p.add_MediaOpened({ \$script:opened = \$true; \$disp.InvokeShutdown() })
+          \$p.add_MediaFailed({ \$disp.InvokeShutdown() })
+          \$timer = New-Object System.Windows.Threading.DispatcherTimer
+          \$timer.Interval = [TimeSpan]::FromSeconds(2)
+          \$timer.add_Tick({ \$disp.InvokeShutdown() })
+          \$timer.Start()
+          \$p.Open([Uri]'$wpath')
+          [System.Windows.Threading.Dispatcher]::Run()
+          \$p.Close()
+          if (\$script:opened) { 'yes' } else { 'no' }
+        " 2>/dev/null | tr -d '\r\n ' | tail -c 3)
+        [ "$result" != "yes" ] && result=no
+        echo "$result" > "$cache_file" 2>/dev/null
+        _peon_log play "wsl_mediaplayer_probe build=$build result=$result"
+        echo "$result"
+      }
+
+      _wsl_play_mediaplayer() {
+        local wpath
+        wpath=$(wslpath -w "$file" 2>/dev/null) || { _peon_log play "error=\"wslpath failed\" file=$(basename "$file")"; return 1; }
+        powershell.exe -NoProfile -NonInteractive -Command "
+          Add-Type -AssemblyName PresentationCore
+          \$p = New-Object System.Windows.Media.MediaPlayer
+          \$p.Volume = $vol
+          \$p.Open([Uri]'$wpath')
+          Start-Sleep -Milliseconds 500
+          \$p.Play()
+          while (\$p.Position -lt \$p.NaturalDuration.TimeSpan -and \$p.Position.TotalSeconds -lt 10) {
+            Start-Sleep -Milliseconds 100
+          }
+          \$p.Close()
+        " &>/dev/null &
+        save_sound_pid $!
+      }
+
+      _wsl_play_soundplayer() {
+        local tmpdir tmpwin tmplinux
+        tmpdir=$(powershell.exe -NoProfile -NonInteractive -Command '[System.IO.Path]::GetTempPath()' 2>/dev/null | tr -d '\r')
+        [ -z "$tmpdir" ] && { _peon_log play "error=\"could not resolve windows temp dir\""; return 1; }
+        tmpwin="${tmpdir}peon-ping-sound.wav"
+        tmplinux="$(wslpath -u "$tmpwin")" || return 1
+        if command -v ffmpeg &>/dev/null; then
+          ffmpeg -y -i "$file" -filter:a "volume=$vol" "$tmplinux" 2>/dev/null || return 1
+        elif [[ "$file" == *.wav ]]; then
+          cp "$file" "$tmplinux" || return 1
+        else
+          return 1
+        fi
+        powershell.exe -NoProfile -NonInteractive -Command "
+          (New-Object System.Media.SoundPlayer '$tmpwin').PlaySync()
+        " &>/dev/null &
+        save_sound_pid $!
+      }
+
+      case "$backend" in
+        mediaplayer)
+          _wsl_play_mediaplayer
+          ;;
+        soundplayer)
+          _wsl_play_soundplayer || _peon_log play "error=\"soundplayer backend failed\" file=$(basename "$file")"
+          ;;
+        auto)
+          if [ "$(_wsl_mediaplayer_probe)" = "yes" ]; then
+            _wsl_play_mediaplayer
+          else
+            _wsl_play_soundplayer || _wsl_play_mediaplayer
+          fi
+          ;;
+      esac
       ;;
     devcontainer|ssh)
       local relay_host_default="host.docker.internal"

--- a/tests/wsl-audio.bats
+++ b/tests/wsl-audio.bats
@@ -47,6 +47,27 @@ SCRIPT
 SCRIPT
   chmod +x "$MOCK_BIN/setsid"
 
+  # Mock ffmpeg — _wsl_play_soundplayer pipes test fixture WAVs through
+  # ffmpeg for volume baking, but the fixture WAVs are empty placeholders
+  # so a real ffmpeg invocation would fail and the function would return
+  # before reaching the PowerShell SoundPlayer call. Replace with a
+  # passthrough that just copies the input to the output path.
+  cat > "$MOCK_BIN/ffmpeg" <<'SCRIPT'
+#!/bin/bash
+input=""
+output=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -i) input="$2"; shift 2 ;;
+    -*) shift ;;
+    *) output="$1"; shift ;;
+  esac
+done
+[ -n "$input" ] && [ -n "$output" ] && cp "$input" "$output"
+exit 0
+SCRIPT
+  chmod +x "$MOCK_BIN/ffmpeg"
+
   mkdir -p "$TEST_DIR/wsl_tmp"
 }
 

--- a/tests/wsl-audio.bats
+++ b/tests/wsl-audio.bats
@@ -1,0 +1,130 @@
+#!/usr/bin/env bats
+#
+# Tests for the WSL audio backend selector (PEON_WSL_AUDIO_BACKEND).
+#
+# Strategy: mock powershell.exe to log every invocation to a file, mock
+# wslpath, set PEON_PLATFORM=wsl, drive a hook event through run_peon,
+# then grep the powershell.exe log for "MediaPlayer" vs "SoundPlayer" to
+# verify which playback path was taken.
+
+load setup.bash
+
+setup() {
+  setup_test_env
+  export PEON_PLATFORM=wsl
+
+  # Mock powershell.exe — logs every invocation, responds to GetTempPath
+  cat > "$MOCK_BIN/powershell.exe" <<SCRIPT
+#!/bin/bash
+echo "POWERSHELL_CALL: \$*" >> "${TEST_DIR}/powershell.log"
+if [[ "\$*" == *"GetTempPath"* ]]; then
+  echo "C:\\\\Users\\\\test\\\\AppData\\\\Local\\\\Temp\\\\"
+  exit 0
+fi
+if [[ "\$*" == *"OSVersion.Version.Build"* ]]; then
+  echo "26200"
+  exit 0
+fi
+exit 0
+SCRIPT
+  chmod +x "$MOCK_BIN/powershell.exe"
+
+  # Mock wslpath — converts both directions to test paths
+  cat > "$MOCK_BIN/wslpath" <<SCRIPT
+#!/bin/bash
+if [[ "\$1" == "-u" ]]; then
+  echo "${TEST_DIR}/wsl_tmp/peon-ping-sound.wav"
+elif [[ "\$1" == "-w" ]]; then
+  echo "C:\\\\fake\\\\path.wav"
+fi
+SCRIPT
+  chmod +x "$MOCK_BIN/wslpath"
+
+  # Mock setsid — run inline (no session separation in tests)
+  cat > "$MOCK_BIN/setsid" <<'SCRIPT'
+#!/bin/bash
+"$@"
+SCRIPT
+  chmod +x "$MOCK_BIN/setsid"
+
+  mkdir -p "$TEST_DIR/wsl_tmp"
+}
+
+teardown() {
+  teardown_test_env
+}
+
+# Helper: grep the powershell command log for a substring
+ps_log_contains() {
+  grep -q "$1" "$TEST_DIR/powershell.log" 2>/dev/null
+}
+
+# Default config used by all tests
+write_default_config() {
+  cat > "$TEST_DIR/config.json" <<'JSON'
+{ "default_pack": "peon", "volume": 0.5, "enabled": true, "notification_style": "silent", "categories": { "session.start": true, "task.complete": true, "task.error": true, "input.required": true, "resource.limit": true, "user.spam": true }, "annoyed_threshold": 3, "annoyed_window_seconds": 10 }
+JSON
+}
+
+# ============================================================
+# Backend env var routing
+# ============================================================
+
+@test "PEON_WSL_AUDIO_BACKEND=mediaplayer routes to WPF MediaPlayer (no probe, no copy)" {
+  write_default_config
+  export PEON_WSL_AUDIO_BACKEND=mediaplayer
+  run_peon '{"hook_event_name":"SessionStart","cwd":"/tmp/p","session_id":"s1"}'
+  [ "$PEON_EXIT" -eq 0 ]
+  ps_log_contains "MediaPlayer"
+  ! ps_log_contains "SoundPlayer"
+  # No probe cache should be written when backend is forced
+  [ ! -f "$TEST_DIR/.wsl-mediaplayer-probe-26200" ]
+}
+
+@test "PEON_WSL_AUDIO_BACKEND=soundplayer routes to System.Media.SoundPlayer" {
+  write_default_config
+  export PEON_WSL_AUDIO_BACKEND=soundplayer
+  run_peon '{"hook_event_name":"SessionStart","cwd":"/tmp/p","session_id":"s1"}'
+  [ "$PEON_EXIT" -eq 0 ]
+  ps_log_contains "SoundPlayer"
+  ! ps_log_contains "MediaPlayer"
+}
+
+@test "PEON_WSL_AUDIO_BACKEND=auto with cached probe=yes uses MediaPlayer" {
+  write_default_config
+  # Pre-seed the probe cache so no probe runs
+  echo yes > "$TEST_DIR/.wsl-mediaplayer-probe-26200"
+  export PEON_WSL_AUDIO_BACKEND=auto
+  run_peon '{"hook_event_name":"SessionStart","cwd":"/tmp/p","session_id":"s1"}'
+  [ "$PEON_EXIT" -eq 0 ]
+  ps_log_contains "MediaPlayer"
+  ! ps_log_contains "SoundPlayer"
+}
+
+@test "PEON_WSL_AUDIO_BACKEND=auto with cached probe=no uses SoundPlayer" {
+  write_default_config
+  echo no > "$TEST_DIR/.wsl-mediaplayer-probe-26200"
+  export PEON_WSL_AUDIO_BACKEND=auto
+  run_peon '{"hook_event_name":"SessionStart","cwd":"/tmp/p","session_id":"s1"}'
+  [ "$PEON_EXIT" -eq 0 ]
+  ps_log_contains "SoundPlayer"
+  ! ps_log_contains "MediaPlayer"
+}
+
+@test "PEON_WSL_AUDIO_BACKEND default (unset) is auto" {
+  write_default_config
+  echo no > "$TEST_DIR/.wsl-mediaplayer-probe-26200"
+  unset PEON_WSL_AUDIO_BACKEND
+  run_peon '{"hook_event_name":"SessionStart","cwd":"/tmp/p","session_id":"s1"}'
+  [ "$PEON_EXIT" -eq 0 ]
+  ps_log_contains "SoundPlayer"
+}
+
+@test "PEON_WSL_AUDIO_BACKEND with invalid value falls back to auto" {
+  write_default_config
+  echo yes > "$TEST_DIR/.wsl-mediaplayer-probe-26200"
+  export PEON_WSL_AUDIO_BACKEND=garbage
+  run_peon '{"hook_event_name":"SessionStart","cwd":"/tmp/p","session_id":"s1"}'
+  [ "$PEON_EXIT" -eq 0 ]
+  ps_log_contains "MediaPlayer"
+}


### PR DESCRIPTION
## Summary

addresses #503 

Fixes silent audio failure on Windows 11 24H2 (build 26100+) WSL2 setups.

WPF `MediaPlayer` (the current WSL2 backend in `peon.sh`) has a hard dependency on legacy Windows Media Player and throws `MILAVERR_INVALIDWMPVERSION` when WMP isn't present. Microsoft removed legacy WMP from Windows 11 24H2 — the "Windows Media Player Legacy" optional feature on 24H2 installs the new WinUI app, **not** the legacy WMP that WPF requires. The previous polling loop (`while $p.Position -lt ...`) never subscribed to `MediaFailed`, so this exception was completely silent; 24H2 users got no audio at all and no error log to diagnose with.

## What changed

- **One-time dispatcher-pumped probe**, cached per Windows build at `$PEON_DIR/.wsl-mediaplayer-probe-<build>`. Opens a WAV with `MediaOpened`/`MediaFailed` handlers and a 2s `DispatcherTimer` timeout. ~1-2s on first invocation, then cached. A Windows build update invalidates the cache automatically (different filename).
- **Two-backend dispatch in the `wsl)` branch:**
  - Probe = `yes` → WPF `MediaPlayer` over the WSL UNC path (native MP3, no copy, volume control). This is the existing path; no behavioral change for users where it works.
  - Probe = `no` → `System.Media.SoundPlayer` with ffmpeg/copy to Windows temp. Win32 `PlaySound` API, no Media Foundation dependency, works on 24H2. WAV-only at the API level, but ffmpeg transcodes MP3 packs on the fly with volume baked in; falls back to a plain WAV copy when ffmpeg is absent.
- **`PEON_WSL_AUDIO_BACKEND` env var** for manual override: `auto` (default), `mediaplayer`, `soundplayer`.

## Why a probe vs. a heuristic

I originally tried two cheaper signals — neither held up:

1. **`command -v ffmpeg`** as a proxy — wrong axis. ffmpeg presence describes format-conversion capability, not whether MediaPlayer is functional.
2. **`WMPlayer.OCX.7` COM registration** as a proxy for "legacy media stack present" — also wrong. On 24H2, `WMPlayer.OCX.7` reports "Class not registered" *both* with and without "Windows Media Player Legacy" installed. The optional feature ships the new WinUI app while the legacy ActiveX/COM control is gone for good.

The dispatcher-pumped probe tests the actual API path we care about, so there's no proxy mismatch.

## Files changed

- `peon.sh` — `wsl)` branch: probe function + backend dispatcher
- `README.md` / `README_zh.md` — documents the env var + 24H2 ffmpeg requirement
- `docs/public/llms.txt` — short summary for LLM context
- `tests/wsl-audio.bats` — BATS coverage for env-var dispatch and cached-probe routing

Did **not** touch `VERSION` or `CHANGELOG.md` — leaving the version bump to your release flow.

## Test plan

- [ ] CI: BATS suite passes on macOS (`tests/wsl-audio.bats` is new).
- [ ] Manual on Win11 24H2 + WSL2: confirmed end-to-end via the actual hook — probe correctly caches `no`, audio plays via SoundPlayer fallback. Subsequent runs are fast (~1.2s total, no probe overhead).
- [ ] Manual on a pre-24H2 Windows / Windows 10 box: confirm probe caches `yes` and MediaPlayer path remains the default. *(I don't have a non-24H2 box to test against — would appreciate a second pair of ears here.)*
- [ ] Override paths: `PEON_WSL_AUDIO_BACKEND=mediaplayer` and `=soundplayer` route correctly (covered by BATS).

## Notes

- The probe test file is the first WAV found under `$PEON_DIR/packs`. If no WAV is installed, the probe returns `no` (safe default) without falsely caching.
- Probe exit conditions: `MediaOpened` → `yes`, `MediaFailed` or 2s timeout → `no`. No `Play()` is invoked, so the probe is silent.

