### PR TITLE
[codex] fix Home Manager home.file definitions

### DIFF
--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -131,31 +131,69 @@ in
   };
 
   config = mkIf cfg.enable {
-    # Install base files from share into ~/.openpeon, excluding peon.sh which is wrapped by bin/peon.sh
-    home.file.".openpeon" = {
-      source = pkgs.runCommand "peon-home-files" {} ''
-        cp -r ${cfg.package}/share/peon-ping $out
-        chmod -R u+w $out
-        rm -f $out/peon.sh
-      '';
-      recursive = true;
-    };
-
     # PEON_DIR points at ~/.openpeon where all runtime files live.
     home.sessionVariables.PEON_DIR = "${config.home.homeDirectory}/.openpeon";
 
-    # peon.sh in ~/.openpeon is the bin/peon wrapper (has runtime PATH baked in).
-    home.file.".openpeon/peon.sh".source = "${cfg.package}/bin/peon";
+    home.file = mkMerge [
+      {
+        # Install base files from share into ~/.openpeon, excluding peon.sh which is wrapped by bin/peon.sh
+        ".openpeon" = {
+          source = pkgs.runCommand "peon-home-files" {} ''
+            cp -r ${cfg.package}/share/peon-ping $out
+            chmod -R u+w $out
+            rm -f $out/peon.sh
+          '';
+          recursive = true;
+        };
 
-    # Create the config file at the location peon-ping expects.
-    # Overrides any config.json that may be present in the package.
-    home.file.".openpeon/config.json".source = jsonFormat.generate "peon-ping-config" cfg.settings;
+        # peon.sh in ~/.openpeon is the bin/peon wrapper (has runtime PATH baked in).
+        ".openpeon/peon.sh".source = "${cfg.package}/bin/peon";
 
-    home.file = mkIf cfg.claudeCodeIntegration {
-      ".claude/hooks/peon-ping/peon.sh".source = "${cfg.package}/bin/peon";
-      ".claude/hooks/peon-ping/scripts/hook-handle-use.sh".source = "${cfg.package}/share/peon-ping/scripts/hook-handle-use.sh";
-      ".claude/hooks/peon-ping/scripts/hook-handle-rename.sh".source = "${cfg.package}/share/peon-ping/scripts/hook-handle-rename.sh";
-    };
+        # Create the config file at the location peon-ping expects.
+        # Overrides any config.json that may be present in the package.
+        ".openpeon/config.json".source = jsonFormat.generate "peon-ping-config" cfg.settings;
+      }
+
+      (mkIf cfg.claudeCodeIntegration {
+        ".claude/hooks/peon-ping/peon.sh".source = "${cfg.package}/bin/peon";
+        ".claude/hooks/peon-ping/scripts/hook-handle-use.sh".source = "${cfg.package}/share/peon-ping/scripts/hook-handle-use.sh";
+        ".claude/hooks/peon-ping/scripts/hook-handle-rename.sh".source = "${cfg.package}/share/peon-ping/scripts/hook-handle-rename.sh";
+      })
+
+      (mkIf (cfg.installPacks != [ ]) (let
+        # Separate string pack names (og-packs) from custom pack specs
+        ogPacks = lib.filter (p: lib.isString p) cfg.installPacks;
+        customPacks = lib.filter (p: lib.isAttrs p) cfg.installPacks;
+      in {
+        # Install sound packs from og-packs and/or custom sources
+        ".openpeon/packs" = {
+          source = pkgs.runCommand "peon-packs" { } ''
+            set -euo pipefail
+            mkdir -p $out
+
+            # Install packs from og-packs
+            ${lib.concatMapStringsSep "\n" (packName: ''
+              if [ -d "${ogPacksSrc}/og-packs-${ogPacksVersion}/${packName}" ]; then
+                cp -r "${ogPacksSrc}/og-packs-${ogPacksVersion}/${packName}" $out/
+              else
+                echo "Error: Pack '${packName}' not found in og-packs" >&2
+                exit 1
+              fi
+            '') ogPacks}
+
+            # Install custom packs
+            ${lib.concatMapStringsSep "\n" (pack: ''
+              if [ -d "${pack.src}" ]; then
+                cp -r "${pack.src}" "$out/${pack.name}"
+              else
+                echo "Error: Custom pack '${pack.name}' source not found" >&2
+                exit 1
+              fi
+            '') customPacks}
+          '';
+        };
+      }))
+    ];
 
     home.activation.peonPingClaudeCodeHooks = mkIf cfg.claudeCodeIntegration (lib.hm.dag.entryAfter [ "writeBoundary" ] ''
       hooks_json='${claudeHooksJsonFormat.generate "peon-claude-hooks" {
@@ -254,38 +292,6 @@ settings["hooks"] = hooks
 settings_path.write_text(json.dumps(settings, indent=2) + "\n")
 PY
     '');
-
-    # Install sound packs from og-packs and/or custom sources
-    home.file.".openpeon/packs" = lib.mkIf (cfg.installPacks != [ ]) (let
-      # Separate string pack names (og-packs) from custom pack specs
-      ogPacks = lib.filter (p: lib.isString p) cfg.installPacks;
-      customPacks = lib.filter (p: lib.isAttrs p) cfg.installPacks;
-    in {
-      source = pkgs.runCommand "peon-packs" { } ''
-        set -euo pipefail
-        mkdir -p $out
-
-        # Install packs from og-packs
-        ${lib.concatMapStringsSep "\n" (packName: ''
-          if [ -d "${ogPacksSrc}/og-packs-${ogPacksVersion}/${packName}" ]; then
-            cp -r "${ogPacksSrc}/og-packs-${ogPacksVersion}/${packName}" $out/
-          else
-            echo "Error: Pack '${packName}' not found in og-packs" >&2
-            exit 1
-          fi
-        '') ogPacks}
-
-        # Install custom packs
-        ${lib.concatMapStringsSep "\n" (pack: ''
-          if [ -d "${pack.src}" ]; then
-            cp -r "${pack.src}" "$out/${pack.name}"
-          else
-            echo "Error: Custom pack '${pack.name}' source not found" >&2
-            exit 1
-          fi
-        '') customPacks}
-      '';
-    });
 
     # Shell completions
     programs.zsh.initContent = mkIf cfg.enableZshIntegration ''

--- a/tests/nix-home-manager.bats
+++ b/tests/nix-home-manager.bats
@@ -5,13 +5,24 @@ setup() {
   MODULE="$REPO_ROOT/nix/hm-module.nix"
 }
 
+@test "home-manager module merges home.file definitions" {
+  grep -q 'home.file = mkMerge' "$MODULE"
+}
+
+@test "home-manager module parses as a Nix expression" {
+  command -v nix-instantiate >/dev/null || skip "nix-instantiate is not available"
+
+  run nix-instantiate --parse "$MODULE"
+  [ "$status" -eq 0 ]
+}
+
 @test "home-manager module exposes Claude Code integration option" {
   grep -q 'claudeCodeIntegration = mkOption' "$MODULE"
 }
 
 @test "home-manager Claude Code integration installs hook files and settings merge" {
-  grep -q '".claude/hooks/peon-ping/peon.sh".source' "$MODULE"
-  grep -q '".claude/hooks/peon-ping/scripts/hook-handle-use.sh".source' "$MODULE"
+  grep -q '".claude/hooks/peon-ping/peon.sh"' "$MODULE"
+  grep -q '".claude/hooks/peon-ping/scripts/hook-handle-use.sh"' "$MODULE"
   grep -q 'settings_path=\"\$HOME/.claude/settings.json\"' "$MODULE"
   grep -q 'hooks.pop("beforeSubmitPrompt", None)' "$MODULE"
 }


### PR DESCRIPTION
## Summary
- wrap Home Manager `home.file` definitions in `mkMerge`, with the Claude Code hook files in a `claudeCodeIntegration`-gated block
- include the optional pack install file entry in the same `home.file` merge to avoid any top-level redefinition
- add regression coverage for `mkMerge` usage and Nix parsing

## Root cause
`nix/hm-module.nix` mixed dotted `home.file.*` definitions with a later whole-attr `home.file = ...` assignment in the same attrset. Nix rejects that before the module system can merge anything.

## Validation
- `nix develop -c bats tests/nix-home-manager.bats`
- `nix-instantiate --parse nix/hm-module.nix`
- `nix flake check --no-build`

Fixes #496