### PR TITLE
fix: replace Bun.spawn with node:child_process in OpenCode adapter

### DIFF
--- a/adapters/opencode/peon-ping.ts
+++ b/adapters/opencode/peon-ping.ts
@@ -27,6 +27,7 @@
 import * as fs from "node:fs"
 import * as path from "node:path"
 import * as os from "node:os"
+import { spawn } from "node:child_process"
 import type { Plugin } from "@opencode-ai/plugin"
 
 const PEON_SH_PATHS = [
@@ -73,10 +74,8 @@ export const PeonPingPlugin: Plugin = async ({ directory }) => {
     })
 
     try {
-      const proc = Bun.spawn(["bash", peonSh], {
-        stdin: "pipe",
-        stdout: "ignore",
-        stderr: "ignore",
+      const proc = spawn("bash", [peonSh], {
+        stdio: ["pipe", "ignore", "ignore"],
       })
       proc.stdin.write(payload)
       proc.stdin.end()


### PR DESCRIPTION
## Problem

OpenCode plugins run in a **Node.js sandbox**, not Bun. Even though OpenCode itself is a Bun binary, the plugin execution context does not expose the `Bun` global.

This caused every `firePeon()` call to throw:
```
ReferenceError: Bun is not defined
```

The error was silently swallowed by the `catch {}` block, so no sounds ever played and there was no visible feedback to the user.

## Fix

Replace `Bun.spawn` with `spawn` from `node:child_process`. The API is equivalent for this use case — both spawn a subprocess, pipe stdin, and support `unref()`.

```ts
// Before
const proc = Bun.spawn(["bash", peonSh], {
  stdin: "pipe",
  stdout: "ignore",
  stderr: "ignore",
})
proc.stdin.write(payload)
proc.stdin.end()
proc.unref()

// After
const proc = spawn("bash", [peonSh], {
  stdio: ["pipe", "ignore", "ignore"],
})
proc.stdin.write(payload)
proc.stdin.end()
proc.unref()
```

## Tested

Verified on OpenCode 1.14.37 (macOS arm64) — sounds now fire correctly on `SessionStart`, `UserPromptSubmit`, `Stop`, and `PermissionRequest` events.