### PR TITLE
feat(rovodev): handle stdin hook payloads and permission summaries

### DIFF
--- a/adapters/rovodev.sh
+++ b/adapters/rovodev.sh
@@ -4,13 +4,22 @@
 # Translates Rovo Dev event hook names into peon.sh stdin JSON
 #
 # Rovo Dev CLI fires shell commands on agent lifecycle events.
-# Unlike Claude Code / Kiro, events are not piped via stdin —
-# the event name is passed as a CLI argument.
+# The event name is passed as a CLI argument ($1), and the full JSON payload
+# is piped to stdin (same pattern as Claude Code / Kiro hooks).
 #
 # Setup: Add to ~/.rovodev/config.yml:
 #
 #   eventHooks:
 #     events:
+#       - name: on_user_prompt
+#         commands:
+#           - command: bash ~/.claude/hooks/peon-ping/adapters/rovodev.sh on_user_prompt
+#       - name: on_tool_start
+#         commands:
+#           - command: bash ~/.claude/hooks/peon-ping/adapters/rovodev.sh on_tool_start
+#       - name: on_tool_end
+#         commands:
+#           - command: bash ~/.claude/hooks/peon-ping/adapters/rovodev.sh on_tool_end
 #       - name: on_complete
 #         commands:
 #           - command: bash ~/.claude/hooks/peon-ping/adapters/rovodev.sh on_complete
@@ -20,6 +29,12 @@
 #       - name: on_tool_permission
 #         commands:
 #           - command: bash ~/.claude/hooks/peon-ping/adapters/rovodev.sh on_tool_permission
+#       - name: on_session_start
+#         commands:
+#           - command: bash ~/.claude/hooks/peon-ping/adapters/rovodev.sh on_session_start
+#       - name: on_session_end
+#         commands:
+#           - command: bash ~/.claude/hooks/peon-ping/adapters/rovodev.sh on_session_end
 #
 # Note: Use absolute paths if ~ is not expanded in your environment.
 
@@ -33,10 +48,61 @@ if [ ! -f "$PEON_DIR/peon.sh" ]; then
   exit 1
 fi
 
+# Read the JSON payload from stdin (provided by Rovo Dev CLI for all events).
+# Note: contrary to the original adapter comment above, Rovo Dev DOES pipe the
+# JSON payload to the hook command's stdin (confirmed by the on_complete payload shape).
+[ "${PEON_DEBUG:-0}" = "1" ] && echo "[rovodev] script started event=${1:-?}" >&2
+if command -v timeout >/dev/null 2>&1; then
+  input=$(timeout 2 cat 2>/dev/null) || input=""
+elif command -v gtimeout >/dev/null 2>&1; then
+  input=$(gtimeout 2 cat 2>/dev/null) || input=""
+else
+  input=$(cat)
+fi
+[ "${PEON_DEBUG:-0}" = "1" ] && echo "[rovodev] input=${input:0:200}" >&2
+# Dump hook payloads to timestamped files for debugging/replay.
+# Enable by setting PEON_DUMP=1 in the hook command or environment.
+# Files are written to PEON_DUMP_DIR (default: /tmp/rovodev-dumps).
+if [ "${PEON_DUMP:-0}" = "1" ]; then
+  _dump_dir="${PEON_DUMP_DIR:-/tmp/rovodev-dumps}"
+  mkdir -p "$_dump_dir"
+  _dump_ts="$(date +%Y%m%d-%H%M%S)-${1:-event}"
+  printf '%s\n' "$input" > "$_dump_dir/$_dump_ts.json"
+fi
+
+# Eagerly read the transcript file before any other processing.
+# Rovo Dev runs hooks in a fire-and-forget async process and deletes the
+# transcript file as soon as the hook command exits — so we must read it
+# immediately while it still exists, before doing event mapping or anything else.
+_transcript_content=""
+if command -v jq &>/dev/null; then
+  _tp=$(echo "$input" | jq -r '.transcript_path // .attributes.transcript_path // empty' 2>/dev/null || true)
+  [ "${PEON_DEBUG:-0}" = "1" ] && echo "[rovodev] transcript_path='$_tp' file_exists=$([ -f "$_tp" ] && echo yes || echo no)" >&2
+  if [ -n "$_tp" ] && [ -f "$_tp" ]; then
+    _transcript_content=$(cat "$_tp" 2>/dev/null || true)
+    [ "${PEON_DEBUG:-0}" = "1" ] && echo "[rovodev] transcript read: ${#_transcript_content} bytes" >&2
+    # Dump transcript content while it's still in memory
+    if [ "${PEON_DUMP:-0}" = "1" ] && [ -n "$_transcript_content" ]; then
+      _dump_dir="${PEON_DUMP_DIR:-/tmp/rovodev-dumps}"
+      _dump_ts_t="$(date +%Y%m%d-%H%M%S)-${1:-event}"
+      printf '%s\n' "$_transcript_content" > "$_dump_dir/$_dump_ts_t.transcript.json"
+    fi
+  fi
+fi
+
 RD_EVENT="${1:-on_complete}"
 
 # Map Rovo Dev CLI event names to peon.sh hook events
 case "$RD_EVENT" in
+  on_user_prompt)
+    EVENT="UserPromptSubmit"
+    ;;
+  on_tool_start)
+    EVENT="PreToolUse"
+    ;;
+  on_tool_end)
+    EVENT="PostToolUse"
+    ;;
   on_complete)
     EVENT="Stop"
     ;;
@@ -45,6 +111,12 @@ case "$RD_EVENT" in
     ;;
   on_tool_permission|on_permission_request)
     EVENT="PermissionRequest"
+    ;;
+  on_session_start)
+    EVENT="SessionStart"
+    ;;
+  on_session_end)
+    EVENT="SessionEnd"
     ;;
   *)
     # Unknown event — exit silently
@@ -58,7 +130,90 @@ SESSION_ID="rovodev-${ROVODEV_SESSION_ID:-$$}"
 # peon.sh reads tool_name/error at the top level, so they must not be nested
 TOOL_NAME=""
 ERROR_MSG=""
+TRANSCRIPT_SUMMARY=""
 [ "$EVENT" = "PostToolUseFailure" ] && TOOL_NAME="Bash" && ERROR_MSG="Agent error"
+
+# For permission requests, extract tool_name and args from the stdin payload.
+# Rovo Dev nests them under attributes.tool_input.
+# Build a short description from the args to use as transcript_summary so the
+# notification body shows something useful (e.g. "command: ls -la") rather than
+# the generic "Requires permissions" fallback.
+# For permission requests, use Python (not jq) to parse the payload since bash
+# commands may contain raw newlines that make the JSON invalid for jq.
+# Extracts tool_name + builds a human-readable summary from the args.
+if [ "$EVENT" = "PermissionRequest" ] && command -v python3 &>/dev/null; then
+  _perm_result=$(echo "$input" | python3 -c "
+import json, sys
+try:
+    d = json.load(sys.stdin)
+    ti = d.get('attributes', {}).get('tool_input', {}) or {}
+    tool = ti.get('tool_name') or 'bash'
+    args = ti.get('args', {}) or {}
+    if tool.lower() == 'bash':
+        cmd = (args.get('command') or args.get('cmd') or args.get('input') or '').replace('\n', '; ').strip()
+        if cmd:
+            detail = 'Permission requested (' + cmd + ')'
+        else:
+            intent = args.get('_intent', '')
+            detail = 'Permission requested (bash)' + (' \u2014 ' + intent if intent else '')
+    else:
+        intent = args.get('_intent', '')
+        detail = 'Permission requested (' + tool + ')'
+        if intent:
+            detail += ' \u2014 ' + intent
+    # Output tool_name on first line, detail on second line
+    print(tool)
+    print(detail)
+except Exception:
+    pass
+" 2>/dev/null || true)
+  if [ -n "$_perm_result" ]; then
+    _perm_tool=$(printf '%s' "$_perm_result" | head -1)
+    _perm_detail=$(printf '%s' "$_perm_result" | tail -n +2)
+    [ -n "$_perm_tool" ] && TOOL_NAME="$_perm_tool"
+    if [ -n "$_perm_detail" ]; then
+      TRANSCRIPT_SUMMARY=$(printf '%s' "$_perm_detail" | tr -s ' \n' ' ' | cut -c1-120)
+      TRANSCRIPT_SUMMARY="${TRANSCRIPT_SUMMARY%"${TRANSCRIPT_SUMMARY##*[![:space:]]}"}"
+    fi
+  fi
+fi
+
+# For on_complete, extract the last agent response text from the in-memory
+# transcript content (eagerly read above before the file could be deleted),
+# strip markdown, and truncate to 120 chars. Permission requests keep their
+# permission-specific summary so notifications show the requested action.
+if [ "$EVENT" = "Stop" ] && [ -n "$_transcript_content" ] && command -v jq &>/dev/null; then
+  raw_response=$(echo "$_transcript_content" | jq -r '
+    .message_history
+    | map(select(.kind == "response"))
+    | last
+    | .parts
+    | map(select(.part_kind == "text"))
+    | last
+    | .content
+  ' 2>/dev/null || true)
+  # Treat jq "null" output as empty
+  [ "$raw_response" = "null" ] && raw_response=""
+  [ "${PEON_DEBUG:-0}" = "1" ] && echo "[rovodev] raw_response='${raw_response:0:80}'" >&2
+  if [ -n "$raw_response" ]; then
+    # Strip common markdown: headers, bold/italic, inline code, links, images
+    TRANSCRIPT_SUMMARY=$(printf '%s' "$raw_response" \
+      | sed -E \
+          -e 's/^[[:space:]]*#{1,6}[[:space:]]*//' \
+          -e 's/!\[[^]]*\]\([^)]*\)//g' \
+          -e 's/\[[^]]*\]\([^)]*\)//g' \
+          -e 's/`([^`]*)`/\1/g' \
+          -e 's/\*\*([^*]*)\*\*/\1/g' \
+          -e 's/__([^_]*)__/\1/g' \
+          -e 's/\*([^*]*)\*/\1/g' \
+          -e 's/_([^_]*)_/\1/g' \
+          -e 's/^[[:space:]]*[-*+][[:space:]]*//' \
+          -e 's/^[[:space:]]*//' \
+      | tr -s ' \n' ' ' \
+      | cut -c1-120)
+    TRANSCRIPT_SUMMARY="${TRANSCRIPT_SUMMARY%"${TRANSCRIPT_SUMMARY##*[![:space:]]}"}"
+  fi
+fi
 
 if command -v jq &>/dev/null; then
   jq -nc \
@@ -67,8 +222,9 @@ if command -v jq &>/dev/null; then
     --arg sid "$SESSION_ID" \
     --arg tn "$TOOL_NAME" \
     --arg err "$ERROR_MSG" \
-    '{hook_event_name:$hook, cwd:$cwd, session_id:$sid, permission_mode:"", source:"rovodev", tool_name:$tn, error:$err}'
+    --arg summary "$TRANSCRIPT_SUMMARY" \
+    '{hook_event_name:$hook, cwd:$cwd, session_id:$sid, permission_mode:"", source:"rovodev", tool_name:$tn, error:$err, transcript_summary:$summary}'
 else
-  printf '{"hook_event_name":"%s","cwd":"%s","session_id":"%s","permission_mode":"","source":"rovodev","tool_name":"%s","error":"%s"}\n' \
-    "$EVENT" "$PWD" "$SESSION_ID" "$TOOL_NAME" "$ERROR_MSG"
+  printf '{"hook_event_name":"%s","cwd":"%s","session_id":"%s","permission_mode":"","source":"rovodev","tool_name":"%s","error":"%s","transcript_summary":"%s"}\n' \
+    "$EVENT" "$PWD" "$SESSION_ID" "$TOOL_NAME" "$ERROR_MSG" "$TRANSCRIPT_SUMMARY"
 fi | bash "$PEON_DIR/peon.sh"

--- a/install.sh
+++ b/install.sh
@@ -79,11 +79,6 @@ adapter_path = '$ROVODEV_ADAPTER'
 with open(config_path, 'r') as f:
     content = f.read()
 
-# Skip if peon-ping adapter is already referenced
-if 'rovodev.sh' in content:
-    print('peon-ping hooks already present in Rovo Dev CLI config — skipping')
-    sys.exit(0)
-
 peon_events = '''    - name: on_complete
       commands:
         - command: bash {adapter} on_complete
@@ -93,6 +88,21 @@ peon_events = '''    - name: on_complete
     - name: on_tool_permission
       commands:
         - command: bash {adapter} on_tool_permission
+    - name: on_user_prompt
+      commands:
+        - command: bash {adapter} on_user_prompt
+    - name: on_tool_start
+      commands:
+        - command: bash {adapter} on_tool_start
+    - name: on_tool_end
+      commands:
+        - command: bash {adapter} on_tool_end
+    - name: on_session_start
+      commands:
+        - command: bash {adapter} on_session_start
+    - name: on_session_end
+      commands:
+        - command: bash {adapter} on_session_end
 '''.format(adapter=adapter_path)
 
 if 'eventHooks:' not in content and 'eventHooks :' not in content:
@@ -132,7 +142,7 @@ else:
             if name_indent is None:
                 name_indent = len(line) - len(stripped)
             current_event = stripped.split('- name:')[1].strip()
-            event_map[current_event] = {'name_idx': i, 'commands_idx': None, 'last_cmd_idx': None}
+            event_map[current_event] = {'name_idx': i, 'commands_idx': None, 'last_cmd_idx': None, 'has_peon_cmd': False}
         elif in_events and current_event and stripped.startswith('commands:'):
             event_map[current_event]['commands_idx'] = i
         elif in_events and current_event and stripped.startswith('- command:'):
@@ -153,6 +163,8 @@ else:
                     break
                 end = j
             event_map[current_event]['last_cmd_idx'] = end
+            if 'rovodev.sh' in stripped:
+                event_map[current_event]['has_peon_cmd'] = True
         elif in_events and line and not line.startswith(' ') and not line.startswith('\t'):
             break
 
@@ -166,19 +178,29 @@ else:
         'on_complete': 'on_complete',
         'on_error': 'on_error',
         'on_tool_permission': 'on_tool_permission',
+        'on_user_prompt': 'on_user_prompt',
+        'on_tool_start': 'on_tool_start',
+        'on_tool_end': 'on_tool_end',
+        'on_session_start': 'on_session_start',
+        'on_session_end': 'on_session_end',
     }
 
     pad_cmd = ' ' * cmd_indent
     new_cmd_template = pad_cmd + '- command: bash {adapter} {event}\n'
 
     # Process in reverse order so line indices stay valid after insertions
+    changed = False
     inserted_events = set()
     for event_name, rovodev_arg in sorted(rovodev_events.items(), key=lambda x: event_map.get(x[0], {}).get('last_cmd_idx', 99999), reverse=True):
         if event_name in event_map and event_map[event_name]['last_cmd_idx'] is not None:
+            if event_map[event_name].get('has_peon_cmd'):
+                inserted_events.add(event_name)
+                continue
             # Event exists — append command after the last '- command:' line
             insert_at = event_map[event_name]['last_cmd_idx'] + 1
             new_line = new_cmd_template.format(adapter=adapter_path, event=rovodev_arg).rstrip()
             lines.insert(insert_at, new_line)
+            changed = True
             inserted_events.add(event_name)
 
     # Any events that didn't exist yet — append as new event entries at the end
@@ -202,9 +224,17 @@ else:
             new_entries += '{p}- name: {e}\n{p2}commands:\n{p3}- command: bash {a} {e}\n'.format(
                 p=pad, p2=pad2, p3=pad3, e=ev, a=adapter_path)
         lines.insert(insert_at, new_entries.rstrip())
+        changed = True
+
+    if not changed:
+        print('peon-ping hooks already present in Rovo Dev CLI config — skipping')
+        sys.exit(0)
 
     with open(config_path, 'w') as f:
         f.write('\n'.join(lines))
+    print('Missing Rovo Dev CLI event hooks added to ' + config_path)
+    print('Restart Rovo Dev CLI for hooks to take effect.')
+    sys.exit(0)
 
 print('Rovo Dev CLI event hooks registered in ' + config_path)
 print('Restart Rovo Dev CLI for hooks to take effect.')
@@ -223,6 +253,21 @@ eventHooks:
     - name: on_tool_permission
       commands:
         - command: bash $ROVODEV_ADAPTER on_tool_permission
+    - name: on_user_prompt
+      commands:
+        - command: bash $ROVODEV_ADAPTER on_user_prompt
+    - name: on_tool_start
+      commands:
+        - command: bash $ROVODEV_ADAPTER on_tool_start
+    - name: on_tool_end
+      commands:
+        - command: bash $ROVODEV_ADAPTER on_tool_end
+    - name: on_session_start
+      commands:
+        - command: bash $ROVODEV_ADAPTER on_session_start
+    - name: on_session_end
+      commands:
+        - command: bash $ROVODEV_ADAPTER on_session_end
 ROVOEOF
     echo "Rovo Dev CLI event hooks created at $ROVODEV_CONFIG"
     echo "Restart Rovo Dev CLI for hooks to take effect."

--- a/tests/install.bats
+++ b/tests/install.bats
@@ -811,22 +811,6 @@ EOF
   grep -q "logFile:" "$TEST_HOME/.rovodev/config.yml"
 }
 
-@test "--rovodev-only skips if rovodev.sh already registered" {
-  mkdir -p "$TEST_HOME/.rovodev"
-  mkdir -p "$TEST_HOME/.claude/hooks/peon-ping/adapters"
-  echo '#!/bin/bash' > "$TEST_HOME/.claude/hooks/peon-ping/adapters/rovodev.sh"
-  cat > "$TEST_HOME/.rovodev/config.yml" <<EOF
-eventHooks:
-  events:
-    - name: on_complete
-      commands:
-        - command: bash /some/path/rovodev.sh on_complete
-EOF
-  run bash "$CLONE_DIR/install.sh" --rovodev-only
-  [ "$status" -eq 0 ]
-  [[ "$output" == *"already present"* ]]
-}
-
 @test "--rovodev-only shows in help" {
   run bash "$CLONE_DIR/install.sh" --help
   [ "$status" -eq 0 ]

--- a/tests/rovodev.bats
+++ b/tests/rovodev.bats
@@ -26,6 +26,15 @@ run_rovodev() {
   ROVODEV_STDERR=$(cat "$TEST_DIR/stderr.log" 2>/dev/null)
 }
 
+run_rovodev_with_stdin() {
+  local event="$1"
+  local stdin_json="$2"
+  export PEON_TEST=1
+  printf '%s' "$stdin_json" | bash "$ROVODEV_SH" "$event" 2>"$TEST_DIR/stderr.log"
+  ROVODEV_EXIT=$?
+  ROVODEV_STDERR=$(cat "$TEST_DIR/stderr.log" 2>/dev/null)
+}
+
 # ============================================================
 # Event mapping
 # ============================================================
@@ -46,12 +55,105 @@ run_rovodev() {
   [[ "$sound" == *"/packs/peon/sounds/Error"* ]]
 }
 
+@test "on_session_start maps to SessionStart and plays session.start sound" {
+  run_rovodev "on_session_start"
+  [ "$ROVODEV_EXIT" -eq 0 ]
+  afplay_was_called
+  sound=$(afplay_sound)
+  [[ "$sound" == *"/packs/peon/sounds/Hello"* ]]
+}
+
+@test "on_user_prompt maps to UserPromptSubmit and marks session working without sound" {
+  run_rovodev "on_user_prompt"
+  [ "$ROVODEV_EXIT" -eq 0 ]
+  ! afplay_was_called
+  grep -q ': working' "$TEST_DIR/.tab_title"
+}
+
+@test "on_tool_start maps to PreToolUse and marks session working without sound" {
+  run_rovodev "on_tool_start"
+  [ "$ROVODEV_EXIT" -eq 0 ]
+  ! afplay_was_called
+  grep -q ': working' "$TEST_DIR/.tab_title"
+}
+
+@test "on_tool_end maps to PostToolUse and marks session working without sound" {
+  run_rovodev "on_tool_end"
+  [ "$ROVODEV_EXIT" -eq 0 ]
+  ! afplay_was_called
+  grep -q ': working' "$TEST_DIR/.tab_title"
+}
+
+@test "on_session_end maps to SessionEnd and exits without sound" {
+  run_rovodev "on_session_end"
+  [ "$ROVODEV_EXIT" -eq 0 ]
+  ! afplay_was_called
+}
+
 @test "on_tool_permission maps to PermissionRequest and plays input.required sound" {
   run_rovodev "on_tool_permission"
   [ "$ROVODEV_EXIT" -eq 0 ]
   afplay_was_called
   sound=$(afplay_sound)
   [[ "$sound" == *"/packs/peon/sounds/Perm"* ]]
+}
+
+@test "on_tool_permission without tool_input shows bash in permission notification" {
+  cat > "$TEST_DIR/config.json" <<'JSON'
+{
+  "active_pack": "peon",
+  "volume": 0.5,
+  "enabled": true,
+  "desktop_notifications": true,
+  "notification_style": "standard",
+  "notification_templates": {
+    "permission": "{summary}"
+  },
+  "categories": {}
+}
+JSON
+  payload=$(printf '{"session_id":"s1","cwd":"%s","hook_event_name":"on_tool_permission","attributes":{}}' "$TEST_DIR")
+  run_rovodev_with_stdin "on_tool_permission" "$payload"
+  [ "$ROVODEV_EXIT" -eq 0 ]
+  afplay_was_called
+  grep -q 'Permission requested (bash)' "$TEST_DIR/terminal_notifier.log"
+}
+
+@test "on_tool_permission notification prefers permission text over transcript text" {
+  cat > "$TEST_DIR/config.json" <<'JSON'
+{
+  "active_pack": "peon",
+  "volume": 0.5,
+  "enabled": true,
+  "desktop_notifications": true,
+  "notification_style": "standard",
+  "notification_templates": {
+    "permission": "{summary}"
+  },
+  "categories": {}
+}
+JSON
+  cat > "$TEST_DIR/transcript.json" <<'JSON'
+{
+  "message_history": [
+    {
+      "kind": "response",
+      "parts": [
+        {
+          "part_kind": "text",
+          "content": "This is the transcript response that should not appear"
+        }
+      ]
+    }
+  ]
+}
+JSON
+  payload=$(printf '{"session_id":"s1","cwd":"%s","hook_event_name":"on_tool_permission","transcript_path":"%s/transcript.json","attributes":{"tool_input":{"tool_name":"create_file","args":{"_intent":"Create file for user"}}}}' "$TEST_DIR" "$TEST_DIR")
+  run_rovodev_with_stdin "on_tool_permission" "$payload"
+  [ "$ROVODEV_EXIT" -eq 0 ]
+  afplay_was_called
+  grep -q 'Permission requested (create_file) — Create file for user' "$TEST_DIR/terminal_notifier.log"
+  ! grep -q 'transcript response' "$TEST_DIR/terminal_notifier.log"
 }
 
 @test "on_permission_request is accepted as alias for on_tool_permission" {
@@ -230,7 +332,7 @@ teardown_install_env() {
   teardown_install_env
 }
 
-@test "install: skips when rovodev.sh already in config" {
+@test "install: backfills new hooks into old Rovo Dev config without duplicating old hooks" {
   setup_install_env
   mkdir -p "$INSTALL_HOME/.rovodev"
   cat > "$INSTALL_HOME/.rovodev/config.yml" <<'EOF'
@@ -238,12 +340,62 @@ eventHooks:
   events:
     - name: on_complete
       commands:
-        - command: bash /some/path/rovodev.sh on_complete
+        - command: bash /old/rovodev.sh on_complete
+    - name: on_error
+      commands:
+        - command: bash /old/rovodev.sh on_error
+    - name: on_tool_permission
+      commands:
+        - command: bash /old/rovodev.sh on_tool_permission
 EOF
-  bash "$CLONE_DIR/install.sh"
-  # Should only appear once (not duplicated)
-  count=$(grep -c "rovodev.sh" "$INSTALL_HOME/.rovodev/config.yml")
-  [ "$count" -eq 1 ]
+  bash "$CLONE_DIR/install.sh" > "$TEST_DIR/install.log"
+  [ "$?" -eq 0 ]
+  grep -q "Missing Rovo Dev CLI event hooks added to" "$TEST_DIR/install.log"
+  for hook in on_user_prompt on_tool_start on_tool_end on_session_start on_session_end; do
+    grep -q -- "- name: $hook" "$INSTALL_HOME/.rovodev/config.yml"
+    grep -q "rovodev.sh $hook" "$INSTALL_HOME/.rovodev/config.yml"
+  done
+  [ "$(grep -c "rovodev.sh on_complete" "$INSTALL_HOME/.rovodev/config.yml")" -eq 1 ]
+  [ "$(grep -c "rovodev.sh on_error" "$INSTALL_HOME/.rovodev/config.yml")" -eq 1 ]
+  [ "$(grep -c "rovodev.sh on_tool_permission" "$INSTALL_HOME/.rovodev/config.yml")" -eq 1 ]
+  teardown_install_env
+}
+
+@test "install: skips with message when all Rovo Dev hooks already exist" {
+  setup_install_env
+  mkdir -p "$INSTALL_HOME/.rovodev"
+  cat > "$INSTALL_HOME/.rovodev/config.yml" <<'EOF'
+eventHooks:
+  events:
+    - name: on_complete
+      commands:
+        - command: bash /old/rovodev.sh on_complete
+    - name: on_error
+      commands:
+        - command: bash /old/rovodev.sh on_error
+    - name: on_tool_permission
+      commands:
+        - command: bash /old/rovodev.sh on_tool_permission
+    - name: on_user_prompt
+      commands:
+        - command: bash /old/rovodev.sh on_user_prompt
+    - name: on_tool_start
+      commands:
+        - command: bash /old/rovodev.sh on_tool_start
+    - name: on_tool_end
+      commands:
+        - command: bash /old/rovodev.sh on_tool_end
+    - name: on_session_start
+      commands:
+        - command: bash /old/rovodev.sh on_session_start
+    - name: on_session_end
+      commands:
+        - command: bash /old/rovodev.sh on_session_end
+EOF
+  bash "$CLONE_DIR/install.sh" > "$TEST_DIR/install.log"
+  [ "$?" -eq 0 ]
+  grep -q "peon-ping hooks already present in Rovo Dev CLI config — skipping" "$TEST_DIR/install.log"
+  [ "$(grep -c "rovodev.sh" "$INSTALL_HOME/.rovodev/config.yml")" -eq 8 ]
   teardown_install_env
 }
 


### PR DESCRIPTION
## Summary

Adds support for the newer Rovo Dev hook payload format and expands the Rovo Dev hook coverage installed by peon-ping.

## Changes

- Read the full Rovo Dev hook payload from stdin while still using the hook event argument.
- Add adapter mappings for newer Rovo Dev hooks:
  - `on_user_prompt` → `UserPromptSubmit`
  - `on_tool_start` → `PreToolUse`
  - `on_tool_end` → `PostToolUse`
  - `on_session_start` → `SessionStart`
  - `on_session_end` → `SessionEnd`
- Handle permission request payloads from `attributes.tool_input`.
- Fall back to `bash` for Rovo Dev permission requests that omit `tool_input`.
- Keep permission notifications focused on the permission request text instead of showing the latest transcript message.
- Preserve transcript summaries for `on_complete` by eagerly reading the transient transcript file before Rovo Dev removes it.
- Update installer behavior:
  - new configs get the full Rovo Dev hook set
  - old configs with the original three hooks are backfilled with missing newer hooks
  - fully up-to-date configs keep the existing “already present” skip message
- Cover the new behavior through the real `peon.sh` path using sound, tab-title, and notification mock assertions.

## Testing

```bash
bats --filter 'backfills new hooks|skips with message' tests/rovodev.bats
bats tests/rovodev.bats
```