### PR TITLE
fix(install.ps1): coalesce missing matcher to empty string when preserving sibling hooks

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -3511,8 +3511,15 @@ foreach ($evt in $events) {
                 -not ($_.command -and ($_.command -match "peon\.(ps1|sh)" -or $_.command -match "notify\.sh"))
             })
             if ($keptHooks.Count -gt 0) {
+                # Coalesce a missing matcher property to "" — accessing a missing
+                # property on a PSCustomObject yields $null, which ConvertTo-Json
+                # then serializes as literal JSON null. Claude Code's settings
+                # validator rejects null with "matcher: Expected string, but
+                # received null". An absent or empty-string matcher is the
+                # documented "match all" form.
+                $matcherValue = if ($null -eq $entry.matcher) { "" } else { $entry.matcher }
                 [PSCustomObject]@{
-                    matcher = $entry.matcher
+                    matcher = $matcherValue
                     hooks   = $keptHooks
                 }
             }
@@ -3563,8 +3570,10 @@ if ($settings.hooks | Get-Member -Name "UserPromptSubmit" -MemberType NoteProper
             -not ($_.command -and $_.command -match "hook-handle-use")
         })
         if ($keptHooks.Count -gt 0) {
+            # See matcher-coalesce comment above.
+            $matcherValue = if ($null -eq $entry.matcher) { "" } else { $entry.matcher }
             [PSCustomObject]@{
-                matcher = $entry.matcher
+                matcher = $matcherValue
                 hooks   = $keptHooks
             }
         }

--- a/tests/install-ps1-hook-rewrite.Tests.ps1
+++ b/tests/install-ps1-hook-rewrite.Tests.ps1
@@ -1,0 +1,102 @@
+# Pester 5 regression test for install.ps1 hook re-registration
+# Run: Invoke-Pester -Path tests/install-ps1-hook-rewrite.Tests.ps1
+#
+# Verifies that when install.ps1 preserves a sibling third-party hook entry
+# during update, it does not turn a missing `matcher` property into a literal
+# JSON `null`. Claude Code's settings validator rejects null matchers with
+# "matcher: Expected string, but received null".
+
+BeforeAll {
+    $script:RepoRoot = Split-Path $PSScriptRoot -Parent
+    $script:InstallPs1 = Join-Path $script:RepoRoot "install.ps1"
+}
+
+Describe "install.ps1 hook re-registration" {
+
+    It "extracts the matcher-coalesce pattern unchanged in install.ps1" {
+        # Guard against accidental removal of the fix. The coalesce is the
+        # whole point of this test file, so make sure the source still has it.
+        $content = Get-Content $script:InstallPs1 -Raw
+        $content | Should -Match 'if \(\$null -eq \$entry\.matcher\) \{ "" \} else \{ \$entry\.matcher \}'
+    }
+
+    It "coalesces missing matcher to empty string when preserving sibling hooks" {
+        # Mirror the install.ps1 production code path: read settings.json with
+        # ConvertFrom-Json (yields PSCustomObject), iterate existing entries,
+        # rebuild them with matcher coalesced to "" when absent.
+
+        # Synthetic settings.json with a third-party hook (e.g. omni's broken
+        # async-hook output) that has no matcher property at all.
+        $settingsJson = @'
+{
+  "hooks": {
+    "PostToolUseFailure": [
+      {
+        "hooks": [
+          { "type": "command", "command": "third-party.exe --hook", "async": true }
+        ]
+      }
+    ]
+  }
+}
+'@
+        $settings = $settingsJson | ConvertFrom-Json
+
+        # Same logic as install.ps1: filter peon hooks (none here), rebuild
+        # surviving entries with the coalesce.
+        $rebuilt = @($settings.hooks.PostToolUseFailure | ForEach-Object {
+            $entry = $_
+            $keptHooks = @($entry.hooks | Where-Object {
+                -not ($_.command -and ($_.command -match "peon\.(ps1|sh)" -or $_.command -match "notify\.sh"))
+            })
+            if ($keptHooks.Count -gt 0) {
+                $matcherValue = if ($null -eq $entry.matcher) { "" } else { $entry.matcher }
+                [PSCustomObject]@{
+                    matcher = $matcherValue
+                    hooks   = $keptHooks
+                }
+            }
+        } | Where-Object { $_ -ne $null })
+
+        $output = $rebuilt | ConvertTo-Json -Depth 10
+        $output | Should -Not -Match '"matcher":\s*null'
+        $output | Should -Match '"matcher":\s*""'
+        # Sibling hook command preserved
+        $output | Should -Match 'third-party\.exe --hook'
+    }
+
+    It "preserves a non-empty matcher value (e.g. 'Bash')" {
+        $settingsJson = @'
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          { "type": "command", "command": "third-party.exe --pre-hook" }
+        ]
+      }
+    ]
+  }
+}
+'@
+        $settings = $settingsJson | ConvertFrom-Json
+
+        $rebuilt = @($settings.hooks.PreToolUse | ForEach-Object {
+            $entry = $_
+            $keptHooks = @($entry.hooks | Where-Object {
+                -not ($_.command -and ($_.command -match "peon\.(ps1|sh)" -or $_.command -match "notify\.sh"))
+            })
+            if ($keptHooks.Count -gt 0) {
+                $matcherValue = if ($null -eq $entry.matcher) { "" } else { $entry.matcher }
+                [PSCustomObject]@{
+                    matcher = $matcherValue
+                    hooks   = $keptHooks
+                }
+            }
+        } | Where-Object { $_ -ne $null })
+
+        $output = $rebuilt | ConvertTo-Json -Depth 10
+        $output | Should -Match '"matcher":\s*"Bash"'
+    }
+}


### PR DESCRIPTION
## What

When `install.ps1` updates an existing peon-ping install, it rewrites `settings.json` while preserving any sibling third-party hook entries that share an event with peon's hooks. For each preserved entry it copied `$entry.matcher` directly into the rebuilt object. If the source entry has no `matcher` property, `$entry.matcher` returns `$null`, and `ConvertTo-Json` then serializes the field as literal JSON `null`. Claude Code's settings validator rejects null with:

```
matcher: Expected string, but received null
```

This patch coalesces a missing/null matcher to `""` before rebuilding. An empty matcher is the documented "match all" form, so the rewritten entry behaves the same way while satisfying the schema.

## Scope (only Windows)

`install.sh` already handles this correctly. Python's `dict(h)` clone preserves the missing-key state, so the matcher field stays absent rather than turning into null. PowerShell's `[PSCustomObject]@{ matcher = $entry.matcher }` materializes the property either way: with a string when present, with `null` when absent. The bug only affects users running `install.ps1`.

## Reproduction

I hit this after running the latest peon-ping installer over a `settings.json` that had async-hook entries written by [omni](https://github.com/fajarhide/omni) without a matcher field. Before the rewrite, Claude Code tolerated the missing key. After peon's installer round-tripped the file, the absent key became literal `null`, and Claude Code refused to load the settings. (I reported the upstream omni half in fajarhide/omni#83.)

Minimal repro without omni:

```powershell
$json = '{"hooks":[{"type":"command","command":"third-party.exe --hook","async":true}]}'
$entry = $json | ConvertFrom-Json
[PSCustomObject]@{ matcher = $entry.matcher; hooks = $entry.hooks } | ConvertTo-Json -Compress
# Output: {"matcher":null,"hooks":[...]}    # broken
```

## Test

Added `tests/install-ps1-hook-rewrite.Tests.ps1` (Pester 5):

1. Source-level guard that the coalesce expression remains in `install.ps1` (defends against accidental removal).
2. Behavior test: a third-party hook on `PostToolUseFailure` with no matcher rewrites to `"matcher": ""`, with the sibling command preserved.
3. Behavior test: a non-empty matcher like `"Bash"` passes through unchanged.

All three pass locally with Pester 5.7.1. The CI workflow at `.github/workflows/test.yml` already installs Pester 5.0+ and runs every `*.Tests.ps1` file.

## Related

Issue #484 / PR #485 (sibling hook preservation) is the same codepath, same defensive shape.

The fix is applied symmetrically in install.ps1: the coalesce appears in both the main hook-registration loop (peon.ps1 hooks) and the UserPromptSubmit registration (hook-handle-use.ps1).
