### PR TITLE
fix(windows): quote path arguments in Start-Process -ArgumentList

### DIFF
--- a/adapters/amp.ps1
+++ b/adapters/amp.ps1
@@ -92,7 +92,7 @@ if ($Install) {
     # Fork to background
     $scriptPath = $MyInvocation.MyCommand.Path
     $proc = Start-Process -WindowStyle Hidden -FilePath "powershell" `
-        -ArgumentList "-NoProfile", "-File", $scriptPath `
+        -ArgumentList "-NoProfile", "-File", "`"$scriptPath`"" `
         -PassThru -RedirectStandardOutput $LogFile -RedirectStandardError $LogFile
     Set-Content -Path $PidFile -Value $proc.Id
     Write-Host "peon-ping Amp adapter started (PID $($proc.Id))"

--- a/adapters/antigravity.ps1
+++ b/adapters/antigravity.ps1
@@ -88,7 +88,7 @@ if ($Install) {
 
     $scriptPath = $MyInvocation.MyCommand.Path
     $proc = Start-Process -WindowStyle Hidden -FilePath "powershell" `
-        -ArgumentList "-NoProfile", "-File", $scriptPath `
+        -ArgumentList "-NoProfile", "-File", "`"$scriptPath`"" `
         -PassThru -RedirectStandardOutput $LogFile -RedirectStandardError $LogFile
     Set-Content -Path $PidFile -Value $proc.Id
     Write-Host "peon-ping Antigravity adapter started (PID $($proc.Id))"

--- a/adapters/kimi.ps1
+++ b/adapters/kimi.ps1
@@ -100,7 +100,7 @@ if ($Install) {
 
     $scriptPath = $MyInvocation.MyCommand.Path
     $proc = Start-Process -WindowStyle Hidden -FilePath "powershell" `
-        -ArgumentList "-NoProfile", "-File", $scriptPath `
+        -ArgumentList "-NoProfile", "-File", "`"$scriptPath`"" `
         -PassThru -RedirectStandardOutput $LogFile -RedirectStandardError $LogFile
     Set-Content -Path $PidFile -Value $proc.Id
     Write-Host "peon-ping Kimi adapter started (PID $($proc.Id))"

--- a/install.ps1
+++ b/install.ps1
@@ -3051,7 +3051,7 @@ $winPlayScript = Join-Path $InstallDir "scripts\win-play.ps1"
 function Play-Sound {
     param([string]$SndPath, [double]$Vol)
     if ((Test-Path $winPlayScript) -and (Test-Path $SndPath)) {
-        Start-Process -FilePath "powershell.exe" -ArgumentList "-NoProfile", "-NonInteractive", "-File", $winPlayScript, "-path", $SndPath, "-vol", $Vol -WindowStyle Hidden
+        Start-Process -FilePath "powershell.exe" -ArgumentList "-NoProfile", "-NonInteractive", "-File", "`"$winPlayScript`"", "-path", "`"$SndPath`"", "-vol", $Vol -WindowStyle Hidden
         & $peonLog 'play' @{ backend = 'win-play.ps1'; file = $soundFile; volume = [string]$Vol }
     } else {
         if (-not (Test-Path $winPlayScript)) {
@@ -3221,7 +3221,7 @@ if ($trainerMsg) {
                 if ($proc.Parent) { $parentPid = $proc.Parent.Id }
             } catch { <# PID may not exist; fall through to $parentPid = 0 #> }
             if (-not $parentPid) { $parentPid = 0 }
-            $trainerNotifArgs = @("-NoProfile", "-NonInteractive", "-File", $winNotifyScript,
+            $trainerNotifArgs = @("-NoProfile", "-NonInteractive", "-File", "`"$winNotifyScript`"",
                            "-body", "`"$trainerMsg`"", "-title", "`"$trainerTitle`"", "-dismissSeconds", [string]$dismissSecs,
                            "-parentPid", [string]$parentPid)
             Start-Process -FilePath "powershell.exe" -ArgumentList $trainerNotifArgs -WindowStyle Hidden
@@ -3334,10 +3334,10 @@ $marker = if ($config.notification_title_marker) { $config.notification_title_ma
             if ($proc.Parent) { $parentPid = $proc.Parent.Id }
         } catch { <# PID may not exist; fall through to $parentPid = 0 #> }
         if (-not $parentPid) { $parentPid = 0 }
-        $notifArgs = @("-NoProfile", "-NonInteractive", "-File", $winNotifyScript,
+        $notifArgs = @("-NoProfile", "-NonInteractive", "-File", "`"$winNotifyScript`"",
                        "-body", "`"$notifyMsg`"", "-title", "`"$notifTitle`"", "-dismissSeconds", [string]$dismissSecs,
                        "-parentPid", [string]$parentPid)
-        if ($iconPath) { $notifArgs += @("-iconPath", $iconPath) }
+        if ($iconPath) { $notifArgs += @("-iconPath", "`"$iconPath`"") }
         Start-Process -FilePath "powershell.exe" -ArgumentList $notifArgs -WindowStyle Hidden
     }
 }
@@ -3835,7 +3835,7 @@ if ($testSound) {
     $winPlayScript = Join-Path $scriptsDir "win-play.ps1"
     if (Test-Path $winPlayScript) {
         try {
-            $proc = Start-Process -WindowStyle Hidden -FilePath "powershell.exe" -ArgumentList "-NoProfile","-ExecutionPolicy","Bypass","-File",$winPlayScript,"-path",$testSound.FullName,"-vol",0.3 -PassThru
+            $proc = Start-Process -WindowStyle Hidden -FilePath "powershell.exe" -ArgumentList "-NoProfile","-ExecutionPolicy","Bypass","-File","`"$winPlayScript`"","-path","`"$($testSound.FullName)`"","-vol",0.3 -PassThru
             Start-Sleep -Seconds 3
             Write-Host "  Sound working!" -ForegroundColor Green
         } catch {


### PR DESCRIPTION
## Summary

`Start-Process -ArgumentList @(...)` joins array elements with spaces to build the child's command line — it does **not** auto-quote elements containing spaces. On Windows accounts whose `%USERPROFILE%` contains a space (common when a Microsoft account display name is `Firstname Lastname` — Windows uses the verbatim display name in the profile path), every spawn that passes a path variable verbatim ends up truncating the path in the child process.

The child errors out in ~0.4s with exit code `-196608` and stderr `"Processing -File 'C:\Users\Firstname' failed because the file does not have a '.ps1' extension"`. But the parent's `Start-Process` already returned — no `-Wait`, no `-PassThru` — so the failure is **invisible**: hooks fire, `state.json` updates, exit codes are `0`, but no audio plays and no notification appears.

## Fixed sites

All seven are the same mistake: a path-bearing `$variable` passed unquoted as an element of `-ArgumentList`. Fix is uniform — wrap each in PS-escaped double quotes (`"`"$var`""`).

| File | Function / context | What broke |
|---|---|---|
| `install.ps1` (Play-Sound) | Audio playback on every hook event | All sounds silent |
| `install.ps1` (notification dispatch) | Desktop banner spawn | All banners missing (also `$iconPath`) |
| `install.ps1` (trainer notification) | Trainer reminder banners | All trainer banners missing |
| `install.ps1` ("Testing sound..." check) | Installer's own validation step | Reports "Sound working!" while emitting nothing |
| `adapters/amp.ps1` | Amp watcher background fork | Adapter silently does nothing |
| `adapters/antigravity.ps1` | Antigravity watcher fork | Same |
| `adapters/kimi.ps1` | Kimi watcher fork | Same |

8 lines changed across 4 files.

## How I reproduced & verified

Spawned the exact pre-patch `Start-Process` call via `-PassThru -Wait -RedirectStandardError` to capture what the silent child was doing:

**Before (unquoted, `%USERPROFILE% = C:\Users\Matthew Adel`):**
```
exit=-196608  runtime=0.37s
stderr: Processing -File 'C:\Users\Matthew' failed because the
        file does not have a '.ps1' extension.
audio: silent no-op
```

**After (quoted):**
```
exit=0  runtime=4.56s
stderr: (empty)
audio: plays correctly
```

End-to-end verified by firing a fake `SessionStart` and `Stop` payload through the patched `peon.ps1` — `.state.json` updates as before, and the actual greeting and `task.complete` sounds now reach the speakers.

## Why it slipped through

Three factors compounded:
1. The installer's `"Testing sound..."` check has its own copy of the same bug *and* doesn't wait for the child or check its exit code — so it always prints `"Sound working!"` regardless of whether anything actually played.
2. `Start-Process` calls in production code use neither `-Wait` nor `-PassThru -RedirectStandardError`, so the child's exit/stderr are invisible to the parent.
3. Most contributors' Windows usernames don't contain a space, so the bug never triggers in dev environments.

## Test plan

- [x] Local PowerShell syntax validation (CI's exact tokenizer step) passes on all 12 adapters + `install.ps1`
- [ ] CI's `test-windows` job (Pester 5 + syntax validation) — will run automatically on this PR
- [ ] CI's `test` job (bats on macOS/Linux) — unchanged code paths, should pass
- [x] Manual end-to-end: fresh install on Win 11 24H2 with `%USERPROFILE%` containing a space; verified that `SessionStart`/`Stop`/`Notification` hooks now produce audio + banners

## Notes for the reviewer

- The fix is the smallest possible change: each call goes from `"-File", $var` → `"-File", "`"$var`""`. No restructuring, no new helpers.
- Two other `Start-Process` sites in `install.ps1` (TTS speak at L934, trainer audio at L3199) use `-Command` with single-quoted inline paths (`'$var'`) rather than `-File` with array-passed variables — those handle spaces correctly via PS's literal-string semantics. Left untouched.
- Happy to split this into per-file commits if the maintainer prefers, but the bug is uniform enough that a single commit reads cleaner.

---

Discovered while installing on a Windows 11 box where `%USERPROFILE%` is `C:\Users\Matthew Adel`. All hooks were firing correctly per `.state.json` but no audio reached the speakers — full diagnostic recipe (capture stderr from silent detached spawns) is in the commit message.
