### PR TITLE
fix(nix): home-manager Claude Code integration parity with install.sh

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -50,6 +50,7 @@
             # Bundled helper scripts (find_bundled_script looks here via BASH_SOURCE fallback)
             for f in scripts/pack-download.sh scripts/notify.sh \
                      scripts/remote-hook.sh scripts/hook-handle-use.sh \
+                     scripts/hook-handle-rename.sh \
                      scripts/mac-overlay.js; do
               [ -f "$f" ] && cp "$f" "$share/scripts/"
             done

--- a/flake.nix
+++ b/flake.nix
@@ -56,6 +56,14 @@
             done
             chmod +x "$share/scripts/"*.sh 2>/dev/null || true
 
+            # Wrap hook scripts so they can find python3 (and other runtime deps)
+            # regardless of the PATH Claude Code passes to UserPromptSubmit hooks.
+            for s in "$share/scripts/hook-handle-use.sh" \
+                     "$share/scripts/hook-handle-rename.sh"; do
+              [ -f "$s" ] && wrapProgram "$s" \
+                --prefix PATH : ${pkgs.lib.makeBinPath runtimeDeps}
+            done
+
             # Runtime data
             # Do not copy config.json
             # This is a state (managed by user) or through Home Manager

--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -158,6 +158,15 @@ in
         ".claude/hooks/peon-ping/peon.sh".source = "${cfg.package}/bin/peon";
         ".claude/hooks/peon-ping/scripts/hook-handle-use.sh".source = "${cfg.package}/share/peon-ping/scripts/hook-handle-use.sh";
         ".claude/hooks/peon-ping/scripts/hook-handle-rename.sh".source = "${cfg.package}/share/peon-ping/scripts/hook-handle-rename.sh";
+
+        # Install Claude Code skills (slash commands). Mirrors install.sh's
+        # `install_skill` loop; without these, slash commands like
+        # `/peon-ping-rename` fail with "Unknown command".
+        ".claude/skills/peon-ping-config/SKILL.md".source = "${cfg.package}/share/peon-ping/skills/peon-ping-config/SKILL.md";
+        ".claude/skills/peon-ping-log/SKILL.md".source = "${cfg.package}/share/peon-ping/skills/peon-ping-log/SKILL.md";
+        ".claude/skills/peon-ping-rename/SKILL.md".source = "${cfg.package}/share/peon-ping/skills/peon-ping-rename/SKILL.md";
+        ".claude/skills/peon-ping-toggle/SKILL.md".source = "${cfg.package}/share/peon-ping/skills/peon-ping-toggle/SKILL.md";
+        ".claude/skills/peon-ping-use/SKILL.md".source = "${cfg.package}/share/peon-ping/skills/peon-ping-use/SKILL.md";
       })
 
       (mkIf (cfg.installPacks != [ ]) (let


### PR DESCRIPTION
# Summary

On Nix home-manager installs, every `peon-ping` slash command (`/peon-ping-rename`, `/peon-ping-config`, `/peon-ping-log`, `/peon-ping-toggle`, `/peon-ping-use`) fails with `Unknown command`, and the underlying `UserPromptSubmit` hooks fall through silently. None of these failure modes appear on the `install.sh` path. This PR closes the three independent gaps that, together, prevent the Claude Code integration from working on Nix:

  1. **`fix(nix): ship hook-handle-rename.sh in flake installPhase`** — the installPhase loop in `flake.nix` copies a hardcoded list of helper scripts into `$out/share/peon-ping/scripts/`, and `hook-handle-rename.sh` was missing from that list even though the home-manager module references it. The symlink at `~/.claude/hooks/peon-ping/scripts/hook-handle-rename.sh` dangled and every UserPromptSubmit logged `No such file or directory`.

  2. **`fix(nix): wrap hook scripts so they find python3 at runtime`** — Claude Code launches `UserPromptSubmit` hooks with a minimal PATH that doesn't include `python3`. The hook scripts parse the event JSON via `python3 -c '...'`, the call fails silently (`2>/dev/null || echo ""`), `PROMPT` ends up empty, the regex never matches and every prompt falls through as `not_our_cmd`. `bin/peon` was already `wrapProgram`'d with `runtimeDeps`; this PR does the same for `scripts/hook-handle-use.sh` and `scripts/hook-handle-rename.sh`.

  3. **`feat(nix/hm): install Claude Code skills into ~/.claude/skills`** — `install.sh` installs five skills via the `install_skill` loop (`peon-ping-config`, `peon-ping-log`, `peon-ping-rename`, `peon-ping-toggle`, `peon-ping-use`). The home-manager module never symlinked any of them, so Claude Code's slash-command resolver couldn't find them and short-circuited every `/peon-ping-*` invocation with `Unknown command`. The package already ships the skills tree into `$out/share/peon-ping/skills/` via `installPhase`, so the module just needs five `home.file` entries.

  ## Scope

 All three changes are gated to the Nix path:

 - Changes 1 and 2 are in `flake.nix` (`installPhase`). Non-Nix install paths don't run this code.
- Change 3 is inside `(mkIf cfg.claudeCodeIntegration { ... })` in `nix/hm-module.nix`. Users who only want the CLI on Nix are unaffected.

None of the user-visible behavior of `install.sh`, the standalone `peon` CLI, or the Cursor adapter changes.