### PR TITLE
fix(hooks): align PEON_DIR resolution in hooks with peon.sh

### DIFF
--- a/scripts/hook-handle-rename.sh
+++ b/scripts/hook-handle-rename.sh
@@ -85,7 +85,7 @@ fi
 # (see peon.sh PEON_DIR fallback chain) so .state.json is written to the
 # same path peon.sh reads on subsequent events. On Nix home-manager installs
 # packs live under ~/.openpeon, so the rename state must go there too.
-if [ -n "${CLAUDE_PEON_DIR:-}" ] && [ -d "$CLAUDE_PEON_DIR" ]; then
+if [ -n "${CLAUDE_PEON_DIR:-}" ] && [ -d "$CLAUDE_PEON_DIR/packs" ]; then
   PEON_DIR="$CLAUDE_PEON_DIR"
 elif [ -d "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/peon-ping/packs" ]; then
   PEON_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/peon-ping"

--- a/scripts/hook-handle-rename.sh
+++ b/scripts/hook-handle-rename.sh
@@ -81,12 +81,21 @@ if ! echo "$SESSION_ID" | grep -qE '^[a-zA-Z0-9_-]+$'; then
   SESSION_ID="default"
 fi
 
-# Locate peon-ping installation
-PEON_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/peon-ping"
-if [ ! -d "$PEON_DIR" ]; then
+# Locate peon-ping installation. Must agree with peon.sh's resolution
+# (see peon.sh PEON_DIR fallback chain) so .state.json is written to the
+# same path peon.sh reads on subsequent events. On Nix home-manager installs
+# packs live under ~/.openpeon, so the rename state must go there too.
+if [ -n "${CLAUDE_PEON_DIR:-}" ] && [ -d "$CLAUDE_PEON_DIR" ]; then
+  PEON_DIR="$CLAUDE_PEON_DIR"
+elif [ -d "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/peon-ping/packs" ]; then
+  PEON_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/peon-ping"
+elif [ -d "$HOME/.openpeon/packs" ]; then
+  PEON_DIR="$HOME/.openpeon"
+elif [ -d "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/peon-ping" ]; then
+  PEON_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/peon-ping"
+elif [ -d "$HOME/.cursor/hooks/peon-ping" ]; then
   PEON_DIR="$HOME/.cursor/hooks/peon-ping"
-fi
-if [ ! -d "$PEON_DIR" ]; then
+else
   log "error: peon-ping not installed"
   echo '{"continue": false, "user_message": "[X] peon-ping not installed"}'
   exit 0

--- a/scripts/hook-handle-use.sh
+++ b/scripts/hook-handle-use.sh
@@ -62,7 +62,7 @@ fi
 # read from the same path peon.sh uses on subsequent events. On Nix
 # home-manager installs packs live under ~/.openpeon, so PACKS_DIR
 # must resolve there too.
-if [ -n "${CLAUDE_PEON_DIR:-}" ] && [ -d "$CLAUDE_PEON_DIR" ]; then
+if [ -n "${CLAUDE_PEON_DIR:-}" ] && [ -d "$CLAUDE_PEON_DIR/packs" ]; then
   PEON_DIR="$CLAUDE_PEON_DIR"
 elif [ -d "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/peon-ping/packs" ]; then
   PEON_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/peon-ping"

--- a/scripts/hook-handle-use.sh
+++ b/scripts/hook-handle-use.sh
@@ -57,14 +57,22 @@ if ! echo "$SESSION_ID" | grep -qE '^[a-zA-Z0-9_-]+$'; then
   SESSION_ID="default"
 fi
 
-# Locate peon-ping installation
-PEON_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/peon-ping"
-if [ ! -d "$PEON_DIR" ]; then
-  # Try Cursor location
+# Locate peon-ping installation. Must agree with peon.sh's resolution
+# (see peon.sh PEON_DIR fallback chain) so .state.json and packs/ are
+# read from the same path peon.sh uses on subsequent events. On Nix
+# home-manager installs packs live under ~/.openpeon, so PACKS_DIR
+# must resolve there too.
+if [ -n "${CLAUDE_PEON_DIR:-}" ] && [ -d "$CLAUDE_PEON_DIR" ]; then
+  PEON_DIR="$CLAUDE_PEON_DIR"
+elif [ -d "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/peon-ping/packs" ]; then
+  PEON_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/peon-ping"
+elif [ -d "$HOME/.openpeon/packs" ]; then
+  PEON_DIR="$HOME/.openpeon"
+elif [ -d "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/peon-ping" ]; then
+  PEON_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/peon-ping"
+elif [ -d "$HOME/.cursor/hooks/peon-ping" ]; then
   PEON_DIR="$HOME/.cursor/hooks/peon-ping"
-fi
-
-if [ ! -d "$PEON_DIR" ]; then
+else
   log "error: peon-ping not installed"
   echo "{\"continue\": false, \"user_message\": \"[X] peon-ping not installed\"}"
   exit 0

--- a/tests/hook-handle-use.bats
+++ b/tests/hook-handle-use.bats
@@ -10,7 +10,12 @@ setup() {
   # Derive hook script path from PEON_SH (already resolved by setup_test_env)
   HOOK_SCRIPT="$(dirname "$PEON_SH")/scripts/hook-handle-use.sh"
 
-  # hook-handle-use.sh reads CLAUDE_CONFIG_DIR to find peon install dir
+  # hook-handle-use.sh reads CLAUDE_CONFIG_DIR to find peon install dir.
+  # setup_test_env exports CLAUDE_PEON_DIR=$TEST_DIR globally (with its own
+  # packs/), which now takes precedence in the hook's resolution to match
+  # peon.sh. Unset it here so this test exercises the CLAUDE_CONFIG_DIR path
+  # it intends to, rather than resolving to the harness peon dir.
+  unset CLAUDE_PEON_DIR
   export CLAUDE_CONFIG_DIR="$TEST_DIR"
 
   # Create the hooks/peon-ping layout that hook-handle-use.sh expects


### PR DESCRIPTION
## Summary

  - `hook-handle-rename.sh` and `hook-handle-use.sh` hardcode `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/peon-ping` as `PEON_DIR`, while `peon.sh` picks `PEON_DIR` based on which candidate location actually contains `packs/` (see `peon.sh:116-134`).
  - On install layouts where those two paths disagree, the hooks write `.state.json` to one location and `peon.sh` reads it from another. The user-visible effect: `/peon-ping-rename <name>` accepts the name and updates the tab title once via ANSI escape, but `peon.sh` never sees the saved entry on subsequent events, so the tab reverts to the auto-detected folder name immediately.
  - This is reproducible today on the Nix home-manager install — hooks live under `~/.claude/hooks/peon-ping/` while packs and the runtime state live under `~/.openpeon/` — and would also affect any future layout that follows `peon.sh`'s convention rather than the hooks' hardcoded path.

  ## Fix

  Mirror `peon.sh`'s fallback chain in both hook scripts:

  1. `$CLAUDE_PEON_DIR` if set and exists (already supported by `peon.sh`)
  2. `~/.claude/hooks/peon-ping/` if `packs/` exists there
  3. `~/.openpeon/` if `packs/` exists there
  4. `~/.claude/hooks/peon-ping/` (bare dir, legacy)
  5. `~/.cursor/hooks/peon-ping/` (Cursor)

On standard Claude Code installs (`install.sh` creates `~/.claude/hooks/peon-ping/packs/`) and Cursor installs, the resolved path is unchanged — branch 2 or branch 5 wins, same as the old logic. Only install layouts where the legacy hardcoded path was wrong see a behavior change, and in those cases the new behavior matches `peon.sh`.