### PR TITLE
Fix tab title/color escapes silently dropped under Claude Code (no controlling TTY)

### DIFF
--- a/peon.sh
+++ b/peon.sh
@@ -6264,7 +6264,16 @@ _peon_tty=""
 if [ -n "${TMUX:-}" ]; then
   _peon_tty=$(tmux display-message -p '#{pane_tty}' 2>/dev/null || true)
 fi
-[ -z "$_peon_tty" ] && _peon_tty="/dev/tty"
+if [ -z "$_peon_tty" ]; then
+  # Claude Code (and other agents) run hook commands without a controlling
+  # terminal, so /dev/tty is unavailable and escape writes silently fail.
+  # Fall back to the ancestor-walked session TTY we already resolved.
+  if [ -n "${PEON_ENV_HOOK_TTY:-}" ] && [ -w "/dev/${PEON_ENV_HOOK_TTY}" ]; then
+    _peon_tty="/dev/${PEON_ENV_HOOK_TTY}"
+  else
+    _peon_tty="/dev/tty"
+  fi
+fi
 
 # Helper: emit an escape sequence, wrapping in DCS passthrough when inside tmux
 # so the host terminal (iTerm2, Ghostty, etc.) receives it through the tmux layer.


### PR DESCRIPTION
## Problem

Tab titles and iTerm2 tab colors stop updating when peon-ping runs as a **Claude Code** hook, even though sounds and notifications keep working.

`peon.sh` writes its tab-title (`OSC 0`) and iTerm2 tab-color (`OSC 6`) escapes to `$_peon_tty`, which outside tmux defaults to `/dev/tty`:

```bash
_peon_tty=""
if [ -n "${TMUX:-}" ]; then
  _peon_tty=$(tmux display-message -p '#{pane_tty}' 2>/dev/null || true)
fi
[ -z "$_peon_tty" ] && _peon_tty="/dev/tty"
```

But Claude Code (and other agents) spawn hook commands **without a controlling terminal**. Opening `/dev/tty` then fails with `ENXIO` and the escape is silently dropped, because the write is wrapped in `2>/dev/null || true`:

```
$ tty
not a tty
$ printf '\033]6;...' > /dev/tty
bash: /dev/tty: device not configured
```

Sounds are unaffected (CoreAudio needs no TTY), which is why this presents as "sounds work, colored tabs don't."

## Fix

The script already resolves the session's real TTY by walking the process ancestry into `PEON_ENV_HOOK_TTY` (`_peon_walk_tty`, used today only for notification focus). This makes the non-tmux branch prefer that walked TTY when `/dev/tty` isn't usable, and keeps `/dev/tty` as the fallback when it can't be resolved:

```bash
if [ -z "$_peon_tty" ]; then
  if [ -n "${PEON_ENV_HOOK_TTY:-}" ] && [ -w "/dev/${PEON_ENV_HOOK_TTY}" ]; then
    _peon_tty="/dev/${PEON_ENV_HOOK_TTY}"
  else
    _peon_tty="/dev/tty"
  fi
fi
```

In a normal interactive shell the walked TTY *is* the controlling terminal, so behavior is unchanged there. It only differs in the detached-hook case — exactly where `/dev/tty` was failing.

## Testing

- `bash -n peon.sh` passes.
- Repro before fix: a `Stop` hook piped JSON on stdin with no controlling TTY (`tty` → `not a tty`) silently dropped the escape; tab never changed.
- After fix: the same no-TTY invocation writes to the ancestor-walked pty and the tab title/color update correctly. Verified live in iTerm2 on macOS (Claude Code 2.1.159, peon-ping 2.29.0).
- Existing `tab_title` / `tab_color_rgb` BATS tests assert the *computed* values (written via `PEON_TEST`/`_PEON_SYNC`), which this change does not touch, so they remain green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)