### PR TITLE
fix(codex): stable-hook failure detection + ps1 stdin parity

### DIFF
--- a/adapters/codex.ps1
+++ b/adapters/codex.ps1
@@ -1,14 +1,24 @@
 # peon-ping adapter for OpenAI Codex CLI (Windows)
-# Translates Codex notify events into peon.ps1 stdin JSON
+# Translates Codex events into peon.ps1 stdin JSON.
 #
-# Setup: Add to ~/.codex/config.toml:
-#   notify = ["powershell", "-NoProfile", "-File", "C:\\Users\\YOU\\.claude\\hooks\\peon-ping\\adapters\\codex.ps1"]
+# Codex now ships a stable hook event set (SessionStart, UserPromptSubmit,
+# PreToolUse, PostToolUse, Stop) delivered as JSON on stdin with a
+# `hook_event_name` field. This adapter maps those to CESP, AND preserves the
+# legacy `notify` callback (event name passed as argv, fires on turn-yield)
+# as a non-breaking fallback.
 #
-# Or with CLAUDE_PEON_DIR override:
-#   $env:CLAUDE_PEON_DIR = "C:\path\to\peon-ping"
+# Setup (recommended — stable hooks): add Codex hooks pointing at this script,
+#   e.g. in ~/.codex/config.toml:
+#     [hooks]
+#     SessionStart = "powershell -NoProfile -File C:\\Users\\YOU\\.claude\\hooks\\peon-ping\\adapters\\codex.ps1"
+#     PostToolUse  = "powershell -NoProfile -File C:\\Users\\YOU\\.claude\\hooks\\peon-ping\\adapters\\codex.ps1"
+#     Stop         = "powershell -NoProfile -File C:\\Users\\YOU\\.claude\\hooks\\peon-ping\\adapters\\codex.ps1"
+#   (Consult `codex` docs for the exact hooks config for your version.)
+#
+# Setup (legacy — still supported): notify = ["powershell", "-NoProfile", "-File", "...codex.ps1"]
 
 param(
-    [string]$Event = "agent-turn-complete"
+    [string]$Event = ""
 )
 
 $ErrorActionPreference = "SilentlyContinue"
@@ -20,43 +30,113 @@ $PeonDir = if ($env:CLAUDE_PEON_DIR) { $env:CLAUDE_PEON_DIR }
 $PeonScript = Join-Path $PeonDir "peon.ps1"
 if (-not (Test-Path $PeonScript)) { exit 0 }
 
-# Map Codex event to CESP event name
-$mapped = $null
-$ntype = ""
+# Read stdin JSON only on the stable-hooks path. When an event name is passed
+# as argv (the legacy `notify` callback), we must NOT touch stdin: in that mode
+# the inherited stdin handle can be redirected-but-open (no EOF), and
+# ReadToEnd() would block forever. The argv event alone drives legacy calls.
+$inputJson = $null
+try {
+    if ((-not $Event) -and [Console]::IsInputRedirected) {
+        $stream = [Console]::OpenStandardInput()
+        $reader = New-Object System.IO.StreamReader($stream, [System.Text.Encoding]::UTF8)
+        $raw = $reader.ReadToEnd()
+        $reader.Close()
+        if ($raw) { $inputJson = $raw | ConvertFrom-Json }
+    }
+} catch { if ($env:PEON_DEBUG -eq "1") { Write-Warning "peon-ping: [codex] ConvertFrom-Json failed: $_" } }
 
-switch -Wildcard ($Event) {
-    { $_ -in "agent-turn-complete", "complete", "done" } {
-        $mapped = "Stop"
-    }
-    { $_ -in "start", "session-start" } {
-        $mapped = "SessionStart"
-    }
-    { $_ -in "error" -or $_ -like "fail*" } {
-        $mapped = "Stop"
-    }
-    { $_ -like "permission*" -or $_ -like "approve*" } {
-        $mapped = "Notification"
-        $ntype = "permission_prompt"
-    }
-    default {
-        $mapped = "Stop"
-    }
+function Get-Field($obj, [string]$name) {
+    if ($null -eq $obj) { return $null }
+    return $obj.PSObject.Properties[$name].Value
 }
 
-$sessionId = "codex-$PID"
-if ($env:CODEX_SESSION_ID) { $sessionId = "codex-$($env:CODEX_SESSION_ID)" }
+# Determine the raw event: argv first (legacy notify), then stdin fields.
+$rawEvent = $Event
+if (-not $rawEvent) { $rawEvent = "$(Get-Field $inputJson 'hook_event_name')" }
+if (-not $rawEvent) { $rawEvent = "$(Get-Field $inputJson 'event')" }
+if (-not $rawEvent) { $rawEvent = "$(Get-Field $inputJson 'type')" }
+if (-not $rawEvent) { $rawEvent = "agent-turn-complete" }
 
-# Build CESP JSON payload
+$eventKey = $rawEvent.ToString().Trim().ToLower().Replace("_", "-")
+$notifType = "$(Get-Field $inputJson 'notification_type')".Trim().ToLower()
+
+function Test-ToolFailure {
+    if (Get-Field $inputJson 'error') { return $true }
+    $tr = Get-Field $inputJson 'tool_response'
+    if ($tr) {
+        if ((Get-Field $tr 'error') -or (Get-Field $tr 'is_error') -or (Get-Field $tr 'isError')) { return $true }
+        $ec = Get-Field $tr 'exit_code'; if ($null -eq $ec) { $ec = Get-Field $tr 'exitCode' }
+        if ($null -ne $ec) { try { if ([int]$ec -ne 0) { return $true } } catch {} }
+    }
+    $ec2 = Get-Field $inputJson 'exit_code'; if ($null -eq $ec2) { $ec2 = Get-Field $inputJson 'exitCode' }
+    if ($null -ne $ec2) { try { if ([int]$ec2 -ne 0) { return $true } } catch {} }
+    if ("$(Get-Field $inputJson 'success')".ToLower() -eq "false") { return $true }
+    return $false
+}
+
+$mapped = $null
+$ntype = $notifType
+
+if ($eventKey.StartsWith("permission") -or $eventKey.StartsWith("approve") -or
+    $eventKey -in @("approval-requested", "approval-needed", "input-required") -or
+    $notifType -eq "permission_prompt") {
+    $mapped = "Notification"; $ntype = "permission_prompt"
+} elseif ($eventKey -in @("start", "session-start", "sessionstart")) {
+    $mapped = "SessionStart"
+} elseif ($eventKey -in @("sessionend", "session-end")) {
+    $mapped = "SessionEnd"
+} elseif ($eventKey -in @("userpromptsubmit", "user-prompt-submit")) {
+    $mapped = "UserPromptSubmit"
+} elseif ($eventKey -eq "idle-prompt") {
+    $mapped = "Notification"; $ntype = "idle_prompt"
+} elseif ($eventKey -in @("pretooluse", "pre-tool-use")) {
+    exit 0   # fires before every tool — too noisy
+} elseif ($eventKey -in @("posttooluse", "post-tool-use")) {
+    if (Test-ToolFailure) { $mapped = "PostToolUseFailure" } else { exit 0 }
+} elseif ($eventKey.StartsWith("error") -or $eventKey.StartsWith("fail")) {
+    $mapped = "PostToolUseFailure"
+} elseif ($eventKey -in @("stop", "agent-turn-complete", "turn-complete", "complete", "done")) {
+    $mapped = "Stop"
+} else {
+    $mapped = "Stop"   # preserve legacy notify default
+}
+
+# Session id (codex- prefix), sanitised.
+$rawSid = "$(Get-Field $inputJson 'session_id')"
+if (-not $rawSid) { $rawSid = "$(Get-Field $inputJson 'conversation_id')" }
+if (-not $rawSid) { $rawSid = "$(Get-Field $inputJson 'thread_id')" }
+if (-not $rawSid -and $env:CODEX_SESSION_ID) { $rawSid = $env:CODEX_SESSION_ID }
+if (-not $rawSid) { $rawSid = "$PID" }
+$safeSid = ($rawSid -replace '[^A-Za-z0-9._:-]', '-').Trim('-')
+if (-not $safeSid) { $safeSid = "$PID" }
+
+$cwd = "$(Get-Field $inputJson 'cwd')"
+if (-not $cwd) { $cwd = "$(Get-Field $inputJson 'workspace_root')" }
+if (-not $cwd) { $cwd = $PWD.Path }
+
 $payload = @{
     hook_event_name   = $mapped
     notification_type = $ntype
-    cwd               = $PWD.Path
-    session_id        = $sessionId
-    permission_mode   = ""
+    cwd               = $cwd
+    session_id        = "codex-$safeSid"
+    permission_mode   = "$(Get-Field $inputJson 'permission_mode')"
     source            = "codex"
-} | ConvertTo-Json -Compress
+}
+
+if ($mapped -eq "PostToolUseFailure") {
+    $tn = "$(Get-Field $inputJson 'tool_name')"
+    if (-not $tn) { $tn = "$(Get-Field $inputJson 'tool')" }
+    if (-not $tn) { $tn = "Bash" }
+    $payload["tool_name"] = $tn
+    $err = "$(Get-Field $inputJson 'error')"
+    if (-not $err) { $err = "$(Get-Field $inputJson 'message')" }
+    if (-not $err) { $err = "Codex event: $rawEvent" }
+    $payload["error"] = $err
+}
+
+$payloadJson = $payload | ConvertTo-Json -Compress
 
 # Pipe to peon.ps1
-$payload | powershell -NoProfile -NonInteractive -File $PeonScript 2>$null
+$payloadJson | powershell -NoProfile -NonInteractive -File $PeonScript 2>$null
 
 exit 0

--- a/adapters/codex.sh
+++ b/adapters/codex.sh
@@ -1,12 +1,18 @@
 #!/bin/bash
 # peon-ping adapter for OpenAI Codex CLI
-# Translates Codex notify events into peon.sh stdin JSON
+# Translates Codex events into peon.sh stdin JSON.
 #
-# Setup: Add to ~/.codex/config.toml:
+# Codex ships a stable hook event set (SessionStart, UserPromptSubmit,
+# PreToolUse, PostToolUse, Stop) delivered as JSON on stdin with a
+# `hook_event_name` field, AND a legacy `notify` callback (event name passed
+# as argv). This adapter handles both: it prefers stdin stable-hook JSON when
+# present and falls back to the argv notify event.
+#
+# Setup (legacy notify): Add to ~/.codex/config.toml:
 #   notify = ["bash", "/absolute/path/to/.claude/hooks/peon-ping/adapters/codex.sh"]
 #
-# Or if installed locally:
-#   notify = ["bash", "/absolute/path/to/peon-ping/adapters/codex.sh"]
+# Setup (stable hooks): point Codex's hooks at this script; it reads
+#   `hook_event_name` from the stdin JSON. Consult `codex` docs for your version.
 
 set -euo pipefail
 
@@ -22,10 +28,13 @@ else
   CODEX_STDIN="$(cat)"
 fi
 
-_CODEX_EVENT="$CODEX_EVENT" _CODEX_STDIN="$CODEX_STDIN" python3 - <<'PY' | bash "$PEON_SH"
+# Map to a CESP payload. Silent events (PreToolUse, successful PostToolUse)
+# print nothing, so peon.sh is never invoked for per-tool-call chatter.
+MAPPED_JSON="$(_CODEX_EVENT="$CODEX_EVENT" _CODEX_STDIN="$CODEX_STDIN" python3 - <<'PY'
 import json
 import os
 import re
+import sys
 
 
 def first_non_empty(*values):
@@ -50,6 +59,38 @@ if raw_stdin:
     except Exception:
         event_data = {}
 
+
+def is_tool_failure():
+    """Detect a failed tool call from a stable-hook PostToolUse payload.
+
+    Codex's PostToolUse carries the structured tool result, so a failure may
+    be signalled by a nested ``tool_response`` object (error flags / non-zero
+    exit_code), a top-level exit_code, or ``success == false`` — not just an
+    event name starting with ``error``.
+    """
+    if event_data.get("error"):
+        return True
+    tr = event_data.get("tool_response")
+    if isinstance(tr, dict):
+        if tr.get("error") or tr.get("is_error") or tr.get("isError"):
+            return True
+        ec = tr.get("exit_code", tr.get("exitCode"))
+        try:
+            if ec is not None and int(ec) != 0:
+                return True
+        except Exception:
+            pass
+    ec = event_data.get("exit_code", event_data.get("exitCode"))
+    try:
+        if ec is not None and int(ec) != 0:
+            return True
+    except Exception:
+        pass
+    if str(event_data.get("success", "")).lower() == "false":
+        return True
+    return False
+
+
 workspace_roots = event_data.get("workspace_roots")
 root0 = ""
 if isinstance(workspace_roots, list) and workspace_roots:
@@ -73,12 +114,28 @@ if (
 ):
     mapped_event = "Notification"
     mapped_ntype = "permission_prompt"
-elif event_key in ("start", "session-start"):
+elif event_key in ("start", "session-start", "sessionstart"):
     mapped_event = "SessionStart"
+    mapped_ntype = notif_type
+elif event_key in ("session-end", "sessionend"):
+    mapped_event = "SessionEnd"
+    mapped_ntype = notif_type
+elif event_key in ("user-prompt-submit", "userpromptsubmit"):
+    mapped_event = "UserPromptSubmit"
     mapped_ntype = notif_type
 elif event_key == "idle-prompt":
     mapped_event = "Notification"
     mapped_ntype = "idle_prompt"
+elif event_key in ("pre-tool-use", "pretooluse"):
+    # Fires before every tool call — far too noisy; emit nothing.
+    sys.exit(0)
+elif event_key in ("post-tool-use", "posttooluse"):
+    if is_tool_failure():
+        mapped_event = "PostToolUseFailure"
+        mapped_ntype = notif_type
+    else:
+        # Successful tool call — stay silent (peon has no PostToolUse handler).
+        sys.exit(0)
 elif event_key.startswith("error") or event_key.startswith("fail"):
     mapped_event = "PostToolUseFailure"
     mapped_ntype = notif_type
@@ -123,6 +180,7 @@ payload = {
 summary = first_non_empty(
     event_data.get("transcript_summary", ""),
     event_data.get("summary", ""),
+    event_data.get("last_assistant_message", ""),
 )
 if isinstance(summary, str) and summary:
     payload["transcript_summary"] = summary[:120]
@@ -141,3 +199,8 @@ if mapped_event == "PostToolUseFailure":
 
 print(json.dumps(payload))
 PY
+)" || MAPPED_JSON=""
+
+if [ -n "$MAPPED_JSON" ]; then
+  printf '%s' "$MAPPED_JSON" | bash "$PEON_SH"
+fi

--- a/tests/codex.bats
+++ b/tests/codex.bats
@@ -75,3 +75,49 @@ assert last.get('session_id') == 'codex-sess-42', last
 assert last.get('cwd') == '/tmp/codex-proj', last
 "
 }
+
+# ============================================================
+# Stable Codex hooks (stdin hook_event_name, PascalCase)
+# ============================================================
+
+@test "stable SessionStart maps to session.start and plays greeting" {
+  run_codex "" '{"hook_event_name":"SessionStart","session_id":"s1"}'
+  [ "$CODEX_EXIT" -eq 0 ]
+  afplay_was_called
+  sound=$(afplay_sound)
+  [[ "$sound" == *"/packs/peon/sounds/Hello"* ]]
+}
+
+@test "stable Stop maps to task.complete and plays completion sound" {
+  run_codex "" '{"hook_event_name":"Stop","session_id":"s1"}'
+  [ "$CODEX_EXIT" -eq 0 ]
+  afplay_was_called
+  sound=$(afplay_sound)
+  [[ "$sound" == *"/packs/peon/sounds/Done"* ]]
+}
+
+@test "stable failed PostToolUse maps to PostToolUseFailure (error sound)" {
+  run_codex "" '{"hook_event_name":"PostToolUse","tool_name":"Bash","tool_response":{"exit_code":1}}'
+  [ "$CODEX_EXIT" -eq 0 ]
+  afplay_was_called
+  sound=$(afplay_sound)
+  [[ "$sound" == *"/packs/peon/sounds/Error"* ]]
+}
+
+@test "stable successful PostToolUse is silent" {
+  run_codex "" '{"hook_event_name":"PostToolUse","tool_response":{"exit_code":0}}'
+  [ "$CODEX_EXIT" -eq 0 ]
+  ! afplay_was_called
+}
+
+@test "stable PreToolUse is silent" {
+  run_codex "" '{"hook_event_name":"PreToolUse","session_id":"s1"}'
+  [ "$CODEX_EXIT" -eq 0 ]
+  ! afplay_was_called
+}
+
+@test "stable UserPromptSubmit plays no sound" {
+  run_codex "" '{"hook_event_name":"UserPromptSubmit","session_id":"s1"}'
+  [ "$CODEX_EXIT" -eq 0 ]
+  ! afplay_was_called
+}

--- a/tests/codex.bats
+++ b/tests/codex.bats
@@ -121,3 +121,27 @@ assert last.get('cwd') == '/tmp/codex-proj', last
   [ "$CODEX_EXIT" -eq 0 ]
   ! afplay_was_called
 }
+
+@test "stable PostToolUse failure via top-level exit_code plays error sound" {
+  run_codex "" '{"hook_event_name":"PostToolUse","tool_name":"Bash","exit_code":2}'
+  [ "$CODEX_EXIT" -eq 0 ]
+  afplay_was_called
+  sound=$(afplay_sound)
+  [[ "$sound" == *"/packs/peon/sounds/Error"* ]]
+}
+
+@test "stable PostToolUse failure via success=false plays error sound" {
+  run_codex "" '{"hook_event_name":"PostToolUse","tool_name":"Bash","success":"false"}'
+  [ "$CODEX_EXIT" -eq 0 ]
+  afplay_was_called
+  sound=$(afplay_sound)
+  [[ "$sound" == *"/packs/peon/sounds/Error"* ]]
+}
+
+@test "stable PostToolUse failure via tool_response.is_error plays error sound" {
+  run_codex "" '{"hook_event_name":"PostToolUse","tool_name":"Bash","tool_response":{"is_error":true}}'
+  [ "$CODEX_EXIT" -eq 0 ]
+  afplay_was_called
+  sound=$(afplay_sound)
+  [[ "$sound" == *"/packs/peon/sounds/Error"* ]]
+}


### PR DESCRIPTION
## Summary

Brings the Codex adapter up to date with Codex's **stable hook event set** (`SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PostToolUse`, `Stop`) delivered as JSON on stdin, and brings the Windows adapter (`codex.ps1`) to functional parity with the bash adapter (`codex.sh`). The legacy `notify` argv callback path is preserved as a non-breaking fallback on both platforms.

The headline behavior: a **failed** stable-hook `PostToolUse` now sounds `task.error`, instead of being silently swallowed. Previously the adapter only recognized a failure when the event *name* itself started with `error`/`fail` — but Codex's `PostToolUse` carries the structured tool result, so the failure signal lives in the payload (`tool_response`, `exit_code`, `success`), not the event name.

## What changed

**`adapters/codex.sh`** (+75)
- Adds `is_tool_failure()` — detects a failed `PostToolUse` from any of: `error`, nested `tool_response.{error,is_error,isError}`, nested `tool_response.exit_code`, top-level `exit_code`, or `success == false`. A failed `PostToolUse` maps to `PostToolUseFailure` (→ `task.error`).
- Stays **silent** on `PreToolUse` (fires before every tool call — far too noisy) and on a **successful** `PostToolUse` (peon has no `PostToolUse` completion handler), so peon is never invoked for per-tool-call chatter.
- Maps `SessionEnd` and `UserPromptSubmit`.
- The legacy `notify` argv path is unchanged. The existing event-name `error*`/`fail*` mapping is retained as a fallback.

**`adapters/codex.ps1`** (+146 / -54)
- Was argv-only (62 lines). Now reads stdin JSON, mirrors the full event set, runs `Test-ToolFailure` (the `is_tool_failure()` equivalent), sanitizes the session id, and emits `source: "codex"` — functional parity with `codex.sh`.
- **Hang fix** (see below).

**`tests/codex.bats`** (+70)
- 6 new stable-hook cases: `SessionStart` → greeting, `Stop` → completion, failed `PostToolUse` → error sound, successful `PostToolUse` silent, `PreToolUse` silent, `UserPromptSubmit` silent.
- 3 more failure-signal cases so every `is_tool_failure()` branch is exercised: top-level `exit_code`, `success == false`, and `tool_response.is_error` (the original cases only covered nested `tool_response.exit_code`).
- All pre-existing legacy `notify` cases are retained.

## Why

Upstream's Codex adapter only treated an event as a failure when the event *name* matched `error*`. Under Codex's stable hooks, a tool failure arrives as a normal `PostToolUse` event whose *payload* indicates failure — so real failures produced no `task.error` sound. This change reads the actual failure signals from the payload and keeps the adapter quiet for the high-frequency, no-op cases.

## The Windows hang fix

On the legacy `notify` (argv) path, `codex.ps1` must **not** touch stdin. In that mode the inherited stdin handle can be redirected-but-open with no EOF, and `StreamReader.ReadToEnd()` would block forever — a real hang for Windows `notify` callers. The fix: only read stdin when **no** argv event is present (the stable-hooks path). The argv event alone drives legacy calls.

## Testing

- Codex Pester suite **9/9 green** locally: `tests/adapters-windows.Tests.ps1` (content-regex checks) + `tests/peon-adapters.Tests.ps1` (functional).
- `bash -n adapters/codex.sh` clean.
- The failure mappings verified end-to-end (each `is_tool_failure()` signal → `task.error`).
- CI on this PR runs BATS on macOS (`test`) and Pester on Windows (`test-windows`).

> Note for maintainers: the **Vercel** check on this PR will fail with *"Authorization required to deploy"*. That is fork deploy-auth only (a fork PR can't deploy the maintainer's Vercel project) — it is **not** a code failure. The `test` and `test-windows` jobs are the meaningful signals.

## Review caveats (full context)

Two honest caveats surfaced during review that maintainers should weigh:

1. **sh/ps1 stdin asymmetry (known, pending confirmation).** `codex.ps1` skips stdin entirely whenever an argv event is present — this is what prevents the hang above. `codex.sh` always reads stdin. If Codex ever delivers **both** an argv event **and** a JSON stdin body on Windows, `codex.ps1` would drop the stdin payload and act on the argv event alone. This hinges on the open question of exactly what Codex emits in the wild; flagging it as a known asymmetry rather than a silent assumption. If confirmation shows Codex can send both together on Windows, the ps1 stdin guard would need to be revisited.

2. **Intentional legacy-path behavior change.** On the legacy `notify` argv path, `codex.ps1` now maps `error` → `PostToolUseFailure` (it previously fell through to the completion sound), matching `codex.sh`. **Existing Windows `notify` callers that pass `error` will now hear the error sound instead of the completion sound.** This is deliberate (parity with bash + correct semantics), but it is a user-observable change for that specific caller.

## How to review

- Start with `adapters/codex.sh` `is_tool_failure()` and the `PreToolUse`/`PostToolUse` mapping branches — that's the core behavior.
- Diff `adapters/codex.ps1` against `codex.sh`: same event set, `Test-ToolFailure` ≅ `is_tool_failure()`. The one deliberate divergence is the stdin guard (caveat 1).
- `tests/codex.bats`: the 9 added cases map 1:1 to the behaviors above; legacy cases are unchanged.
- Sanity-check the two caveats against your knowledge of what Codex emits on Windows.
