### PR TITLE
feat(install): --openpeon tool-agnostic install root (~/.openpeon)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1150,6 +1150,17 @@ If `~/.claude/hooks/peon-ping/packs/` already exists with packs, a `--kimi` inst
 - Context compaction → Token limit sound
 - Sub-agent spawned → Sub-agent tracking
 
+### Tool-agnostic install root (`--openpeon`)
+
+Install everything (hooks, packs, `settings.json`) under `~/.openpeon` instead of `~/.claude`:
+
+```bash
+curl -fsSL peonping.com/install | bash -s -- --openpeon
+# Windows: powershell -File install.ps1 -OpenPeon
+```
+
+Useful for an OpenPeon-branded or tool-agnostic setup: `peon.sh` auto-discovers `~/.openpeon/packs` via its packs-anchored fallback, so adapters pointed at that root work without `~/.claude`. The same reroot is also available with no flag via `CLAUDE_CONFIG_DIR=~/.openpeon bash install.sh`.
+
 ### oh-my-pi (omp) setup
 
 A native TypeScript extension for [oh-my-pi](https://github.com/can1357/oh-my-pi) (`omp`) with full [CESP v1.0](https://github.com/PeonPing/openpeon) conformance. Subscribes to omp's `ExtensionAPI` lifecycle events and routes them through `peon.sh` so omp users get every peon-ping feature: sound packs, desktop notifications, trainer reminders, mobile push, SSH/devcontainer relay, and tab-title updates.

--- a/README_zh.md
+++ b/README_zh.md
@@ -1041,6 +1041,17 @@ curl -fsSL peonping.com/install | bash -s -- --kimi
 - 上下文压缩 → Token 限制音效
 - 子 Agent 启动 → 子 Agent 跟踪
 
+### 工具无关的安装根目录（`--openpeon`）
+
+将全部内容（钩子、语音包、`settings.json`）安装到 `~/.openpeon` 而非 `~/.claude`：
+
+```bash
+curl -fsSL peonping.com/install | bash -s -- --openpeon
+# Windows：powershell -File install.ps1 -OpenPeon
+```
+
+适用于 OpenPeon 品牌化或工具无关的部署：`peon.sh` 会通过其 packs 锚定回退自动发现 `~/.openpeon/packs`，因此指向该根目录的适配器无需 `~/.claude` 即可工作。无需此标志时，也可用 `CLAUDE_CONFIG_DIR=~/.openpeon bash install.sh` 实现相同的重定向。
+
 ### oh-my-pi (omp) 设置
 
 [oh-my-pi](https://github.com/can1357/oh-my-pi)（`omp`）的原生 TypeScript 扩展，完全符合 [CESP v1.0](https://github.com/PeonPing/openpeon) 规范。订阅 omp 的 `ExtensionAPI` 生命周期事件，并通过 `peon.sh` 路由，让 omp 用户享受 peon-ping 的所有功能：语音包、桌面通知、训练提醒、移动推送、SSH/devcontainer 中继及标签页标题更新。

--- a/install.ps1
+++ b/install.ps1
@@ -10,6 +10,7 @@ param(
     [string]$Lang = "",
     [switch]$Local,
     [switch]$Global,
+    [switch]$OpenPeon,
     [switch]$InitLocalConfig
 )
 
@@ -66,7 +67,8 @@ if ($policy -eq "Restricted") {
 # --- Paths ---
 $GlobalClaudeDir = Join-Path $env:USERPROFILE ".claude"
 $LocalClaudeDir = Join-Path $PWD.Path ".claude"
-$ClaudeDir = if ($Local) { $LocalClaudeDir } else { $GlobalClaudeDir }
+$OpenPeonDir = Join-Path $env:USERPROFILE ".openpeon"
+$ClaudeDir = if ($OpenPeon) { $OpenPeonDir } elseif ($Local) { $LocalClaudeDir } else { $GlobalClaudeDir }
 $InstallDir = Join-Path $ClaudeDir "hooks\peon-ping"
 $SettingsFile = Join-Path $ClaudeDir "settings.json"
 $RegistryUrl = "https://peonping.github.io/registry/index.json"

--- a/install.sh
+++ b/install.sh
@@ -10,6 +10,7 @@ INSTALL_ALL=false
 CUSTOM_PACKS=""
 OPENCLAW_MODE=false
 KIMI_MODE=false
+OPENPEON_MODE=false
 NO_SHARED_PACKS=false
 NO_RC=false
 ROVODEV_ONLY=false
@@ -20,6 +21,7 @@ for arg in "$@"; do
     --local) LOCAL_MODE=true ;;
     --openclaw) OPENCLAW_MODE=true ;;
     --kimi) KIMI_MODE=true ;;
+    --openpeon) OPENPEON_MODE=true ;;
     --no-shared-packs) NO_SHARED_PACKS=true ;;
     --init-local-config) INIT_LOCAL_CONFIG=true ;;
     --all) INSTALL_ALL=true ;;
@@ -39,6 +41,9 @@ Options:
                        no Claude config required). When ~/.claude/hooks/
                        peon-ping/packs exists, Kimi's packs/ is symlinked
                        to it so a single install serves both IDEs.
+  --openpeon           Install under ~/.openpeon instead of ~/.claude (a
+                       tool-agnostic root; peon.sh auto-discovers its packs via
+                       the packs-anchored fallback when ~/.claude is absent).
   --no-shared-packs    Disable the --kimi pack symlink and download a
                        separate copy of packs into ~/.kimi/...
   --init-local-config  Create local config only, then exit
@@ -54,6 +59,12 @@ HELPEOF
 done
 
 GLOBAL_BASE="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+# --openpeon reroots the global install at a tool-agnostic ~/.openpeon so every
+# downstream path (hooks, packs, settings.json, rovodev, config-preserve) lands
+# under the same root. peon.sh's packs-anchored fallback auto-discovers it.
+if [ "$OPENPEON_MODE" = true ]; then
+  GLOBAL_BASE="$HOME/.openpeon"
+fi
 LOCAL_BASE="$PWD/.claude"
 OPENCLAW_BASE="$HOME/.openclaw"
 KIMI_BASE="$HOME/.kimi"
@@ -294,7 +305,7 @@ if [ "$NO_RC" = false ]; then
 fi
 
 # Auto-detect OpenClaw if present and Claude Code is not
-if [ "$OPENCLAW_MODE" = false ] && [ "$KIMI_MODE" = false ] && [ "$LOCAL_MODE" = false ]; then
+if [ "$OPENCLAW_MODE" = false ] && [ "$KIMI_MODE" = false ] && [ "$LOCAL_MODE" = false ] && [ "$OPENPEON_MODE" = false ]; then
   if [ -d "$OPENCLAW_BASE" ] && [ ! -d "$GLOBAL_BASE" ]; then
     OPENCLAW_MODE=true
     echo "Auto-detected OpenClaw installation (no Claude Code found)."
@@ -302,7 +313,7 @@ if [ "$OPENCLAW_MODE" = false ] && [ "$KIMI_MODE" = false ] && [ "$LOCAL_MODE" =
 fi
 
 # Auto-detect Kimi Code if present and Claude Code/OpenClaw are not
-if [ "$OPENCLAW_MODE" = false ] && [ "$KIMI_MODE" = false ] && [ "$LOCAL_MODE" = false ]; then
+if [ "$OPENCLAW_MODE" = false ] && [ "$KIMI_MODE" = false ] && [ "$LOCAL_MODE" = false ] && [ "$OPENPEON_MODE" = false ]; then
   if [ -d "$KIMI_BASE" ] && [ ! -d "$GLOBAL_BASE" ]; then
     KIMI_MODE=true
     echo "Auto-detected Kimi Code installation (no Claude Code found)."

--- a/install.sh
+++ b/install.sh
@@ -1432,8 +1432,14 @@ if [ -d "$HOME/.rovodev" ]; then
   echo ""
   echo "Detected Rovo Dev CLI installation, registering event hooks..."
   # Re-invoke ourselves with --rovodev-only to handle config registration
-  # This avoids duplicating the YAML manipulation logic
-  bash "$0" --rovodev-only 2>/dev/null || true
+  # This avoids duplicating the YAML manipulation logic. Propagate --openpeon
+  # so the child reroots GLOBAL_BASE and registers the rovodev adapter under
+  # the same ~/.openpeon root rather than reverting to ~/.claude.
+  if [ "$OPENPEON_MODE" = true ]; then
+    bash "$0" --rovodev-only --openpeon 2>/dev/null || true
+  else
+    bash "$0" --rovodev-only 2>/dev/null || true
+  fi
 fi
 
 # --- Auto-detect Kimi Code CLI and start watcher daemon ---

--- a/tests/install.bats
+++ b/tests/install.bats
@@ -246,6 +246,31 @@ print('OK')
   [ -f "$LOCAL_INSTALL_DIR/packs/peon/openpeon.json" ]
 }
 
+# --- --openpeon mode tests ---
+
+@test "--openpeon installs under ~/.openpeon instead of ~/.claude" {
+  bash "$CLONE_DIR/install.sh" --openpeon
+  OPENPEON_INSTALL_DIR="$TEST_HOME/.openpeon/hooks/peon-ping"
+  [ -f "$OPENPEON_INSTALL_DIR/peon.sh" ]
+  [ -f "$OPENPEON_INSTALL_DIR/config.json" ]
+  [ -f "$OPENPEON_INSTALL_DIR/VERSION" ]
+  [ -f "$OPENPEON_INSTALL_DIR/packs/peon/openpeon.json" ]
+  # the default ~/.claude target must NOT receive the install
+  [ ! -f "$INSTALL_DIR/peon.sh" ]
+}
+
+@test "--openpeon registers hooks under ~/.openpeon/settings.json" {
+  bash "$CLONE_DIR/install.sh" --openpeon
+  [ -f "$TEST_HOME/.openpeon/settings.json" ]
+  /usr/bin/python3 -c "
+import json
+s = json.load(open('$TEST_HOME/.openpeon/settings.json'))
+hooks = s.get('hooks', {})
+assert 'Stop' in hooks, 'Stop hook not registered under ~/.openpeon'
+assert any('peon.sh' in h.get('command','') for entry in hooks['Stop'] for h in entry.get('hooks', [])), 'peon.sh not wired into ~/.openpeon Stop hook'
+"
+}
+
 @test "--local registers hooks in project-level settings.json" {
   cd "$PROJECT_DIR"
   bash "$CLONE_DIR/install.sh" --local


### PR DESCRIPTION
## Summary

Adds an `--openpeon` flag (and `-OpenPeon` switch on Windows) to the installer that reroots a **global** install from `~/.claude` to a tool-agnostic `~/.openpeon`. Everything a global install normally drops under `~/.claude` — hooks, packs, `settings.json`, Rovo Dev registration, and config-preserve-on-update — lands under the single `~/.openpeon` root instead.

This came out of a high-rigor review, so I want to put the full picture in front of you before you spend time on it — including the part that argues *against* merging as-is.

## Please read first: redundancy caveat + open question

**This flag is convenience, not new capability.** Two existing mechanisms already cover most of what it does:

1. **`peon.sh`'s packs-anchored fallback (#523)** already auto-discovers `~/.openpeon/packs` at runtime, so the *playback* side already works against that root with no installer change.
2. **`CLAUDE_CONFIG_DIR=~/.openpeon bash install.sh`** already reroots `GLOBAL_BASE` to `~/.openpeon` today — with **zero new code**. The installer reads `CLAUDE_CONFIG_DIR` and threads it through every downstream path.

So the marginal value of `--openpeon` is narrow but real: **one command** puts hooks + `settings.json` + packs + the CLI under one root, without the caller having to know the env-var incantation or remember to export it. That is the entire delta — a discoverable, documented one-liner over an undocumented env var.

**Open question for maintainers:** do you actually want a dedicated `--openpeon` flag, or would you rather just **document `CLAUDE_CONFIG_DIR=~/.openpeon`** and skip the surface-area addition? I genuinely don't have a strong opinion here and I'm happy to **close this PR** if the env-var path is what you'd prefer to point people at. I'm filing it as a draft precisely so we can have that conversation before committing to a new public flag.

One smaller design note worth surfacing: this implementation **writes `~/.openpeon/settings.json`** (rather than skipping `settings.json` generation for the alt root). That's the more useful behavior — adapters pointed at `~/.openpeon` get a working hook registration without a separate step — but flagging it explicitly in case the intent was to leave settings out.

## What changed

- **`install.sh`** — new `--openpeon` flag overrides `GLOBAL_BASE` to `~/.openpeon` so hooks, packs, `settings.json`, Rovo Dev registration, and config-preserve all root under one tool-agnostic dir. Added to the OpenClaw and Kimi auto-detect guards so it's treated as an explicit mode (auto-detection won't fire when it's set). Help text added. The flag is also propagated through the `--rovodev-only` self-re-invocation, so the child process reroots `GLOBAL_BASE` and registers the Rovo Dev adapter under `~/.openpeon` instead of reverting to `~/.claude`.
- **`install.ps1`** — `-OpenPeon` switch reroots `$ClaudeDir` to `~/.openpeon`.
- **`tests/install.bats`** — two cases: install lands under `~/.openpeon` (and explicitly **not** under `~/.claude`); hooks are registered in `~/.openpeon/settings.json`.
- **`README.md` / `README_zh.md`** — a short "Tool-agnostic install root (`--openpeon`)" section that also documents the `CLAUDE_CONFIG_DIR=~/.openpeon` equivalent.

## Why

Some users want an OpenPeon-branded / tool-agnostic install that doesn't live under `~/.claude` (e.g. when peon-ping is driven by an adapter rather than Claude Code itself). The packs-anchored fallback already makes playback work against `~/.openpeon`; this puts the *install* on the same footing with one command. See the caveat above for why this may or may not be worth a dedicated flag.

## Testing

- `install.sh` is `bash -n` clean.
- `install.ps1` parses clean (`[Parser]::ParseFile`, zero errors).
- Path routing verified: `--openpeon` → `~/.openpeon/hooks/peon-ping` and `~/.openpeon/settings.json`.
- Live end-to-end install run under the mock-curl test harness: files land under `~/.openpeon`, the registered hook command points at `~/.openpeon/.../peon.sh`, there are **zero `~/.claude` references** in the result, and `~/.claude` is left untouched.
- New BATS cases assert both the install-location reroot and the `settings.json` hook registration.

## CI note

CI runs BATS on macOS (`test`) and Pester on Windows (`test-windows`) — those are the checks to watch. The Vercel check will fail with **"Authorization required to deploy"**; that's just fork deploy-auth (the fork can't deploy the site preview), **not a code failure** — nothing in this PR touches the website.
