### PR TITLE
RFC: pi adapter — likely duplicate of omp, requesting maintainer decision

### DIFF
--- a/adapters/pi.sh
+++ b/adapters/pi.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+# peon-ping adapter for Pi (earendil-works/pi, badlogic/pi-mono)
+# Installs the thin TypeScript extension that routes Pi lifecycle events
+# through peon.sh (or peon.ps1 on Windows).
+#
+# Pi auto-discovers extensions from ~/.pi/agent/extensions/ and loads them via
+# jiti (no build step). This installer drops peon-ping.ts there.
+#
+# Requires peon-ping installed first:
+#   brew install PeonPing/tap/peon-ping
+#   # or: curl -fsSL peonping.com/install | bash
+#
+# Install:
+#   bash adapters/pi.sh
+# Or directly:
+#   curl -fsSL https://raw.githubusercontent.com/PeonPing/peon-ping/main/adapters/pi.sh | bash
+# Uninstall:
+#   bash adapters/pi.sh --uninstall
+
+set -euo pipefail
+
+EXTENSION_NAME="peon-ping.ts"
+PLUGIN_URL="https://raw.githubusercontent.com/PeonPing/peon-ping/main/adapters/pi/peon-ping.ts"
+PI_EXTENSIONS_DIR="${PI_EXTENSIONS_DIR:-$HOME/.pi/agent/extensions}"
+PEON_SH_CANDIDATES=(
+  "$HOME/.claude/hooks/peon-ping/peon.sh"
+  "$HOME/.openpeon/hooks/peon-ping/peon.sh"
+  "$HOME/.openclaw/hooks/peon-ping/peon.sh"
+)
+# Resolve this script's own directory so a local install can copy the vendored
+# extension instead of downloading it.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LOCAL_EXTENSION="$SCRIPT_DIR/pi/$EXTENSION_NAME"
+
+BOLD=$'\033[1m' DIM=$'\033[2m' RED=$'\033[31m' GREEN=$'\033[32m' YELLOW=$'\033[33m' RESET=$'\033[0m'
+
+info()  { printf "%s>%s %s\n" "$GREEN" "$RESET" "$*"; }
+warn()  { printf "%s!%s %s\n" "$YELLOW" "$RESET" "$*"; }
+error() { printf "%sx%s %s\n" "$RED" "$RESET" "$*" >&2; }
+
+# --- Uninstall ---
+if [ "${1:-}" = "--uninstall" ]; then
+  info "Uninstalling peon-ping extension from Pi..."
+  rm -f "$PI_EXTENSIONS_DIR/$EXTENSION_NAME"
+  info "Extension removed."
+  exit 0
+fi
+
+# --- Preflight: find peon.sh ---
+PEON_SH=""
+for candidate in "${PEON_SH_CANDIDATES[@]}"; do
+  if [ -f "$candidate" ]; then
+    PEON_SH="$candidate"
+    break
+  fi
+done
+
+if [ -z "$PEON_SH" ]; then
+  error "peon.sh not found. Install peon-ping first:"
+  error "  brew install PeonPing/tap/peon-ping"
+  error "  # or: curl -fsSL peonping.com/install | bash"
+  exit 1
+fi
+
+# --- Install extension ---
+info "Installing peon-ping extension for Pi..."
+mkdir -p "$PI_EXTENSIONS_DIR"
+rm -f "$PI_EXTENSIONS_DIR/$EXTENSION_NAME"
+
+if [ -f "$LOCAL_EXTENSION" ]; then
+  cp "$LOCAL_EXTENSION" "$PI_EXTENSIONS_DIR/$EXTENSION_NAME"
+  info "Extension copied from $LOCAL_EXTENSION"
+elif command -v curl &>/dev/null; then
+  info "Downloading extension..."
+  curl -fsSL "$PLUGIN_URL" -o "$PI_EXTENSIONS_DIR/$EXTENSION_NAME"
+else
+  error "Neither a local copy nor curl is available to install the extension."
+  exit 1
+fi
+info "Extension installed to $PI_EXTENSIONS_DIR/$EXTENSION_NAME"
+
+# --- Done ---
+echo ""
+info "${BOLD}peon-ping extension installed for Pi!${RESET}"
+echo ""
+printf "  %sExtension:%s %s\n" "$DIM" "$RESET" "$PI_EXTENSIONS_DIR/$EXTENSION_NAME"
+printf "  %speon.sh:%s %s\n" "$DIM" "$RESET" "$PEON_SH"
+echo ""
+info "Restart Pi (or run /reload) to activate. All peon-ping features now available."
+info "Configure: peon config | peon trainer on | peon packs list"

--- a/adapters/pi/package.json
+++ b/adapters/pi/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "peon-ping-pi",
+  "private": true,
+  "type": "module",
+  "description": "peon-ping extension for Pi (earendil-works/pi) — routes Pi lifecycle events through peon.sh/peon.ps1",
+  "pi": {
+    "extensions": ["./peon-ping.ts"]
+  },
+  "devDependencies": {
+    "typescript": "^5.8.3"
+  }
+}

--- a/adapters/pi/peon-ping.ts
+++ b/adapters/pi/peon-ping.ts
@@ -1,0 +1,120 @@
+/**
+ * peon-ping for Pi (earendil-works/pi, badlogic/pi-mono) — Thin Extension
+ *
+ * Routes Pi coding-agent lifecycle events through peon.sh (or peon.ps1 on
+ * Windows) instead of re-implementing sound playback, notifications, and
+ * trainer features in TypeScript. Pi users get ALL peon-ping features:
+ * sound packs & rotation, desktop/mobile notifications, trainer reminders,
+ * spam detection, SSH/devcontainer relay, and all `peon` CLI config.
+ *
+ * Pi extensions are default-export factory functions `(pi: ExtensionAPI)`
+ * auto-discovered from ~/.pi/agent/extensions/ and loaded via jiti (no
+ * compile step). Events are subscribed with `pi.on(name, cb)`.
+ *
+ * Event mapping (Pi -> peon hook_event_name):
+ *   session_start   -> SessionStart       (greeting)
+ *   agent_end       -> Stop               (task complete)
+ *   tool_result*    -> PostToolUseFailure (only on a failed tool result)
+ *
+ * Original community adapter: npm `pi-peon-ping`. Vendored first-party here
+ * with thanks to its author; coordinate upstream attribution on release.
+ *
+ * Requires peon-ping installed: brew install PeonPing/tap/peon-ping
+ *   or: curl -fsSL peonping.com/install | bash
+ */
+
+import { spawn } from "node:child_process"
+import * as fs from "node:fs"
+import * as os from "node:os"
+import * as path from "node:path"
+
+// `@earendil-works/pi-coding-agent` is provided by the Pi runtime at load
+// time; type it loosely so the extension stays dependency-light and resilient
+// to Pi API drift (event payloads vary per event).
+type ExtensionAPI = {
+  on: (event: string, cb: (event: any, ctx: any) => any) => void
+}
+
+const PEON_SH_CANDIDATES = [
+  path.join(os.homedir(), ".claude", "hooks", "peon-ping", "peon.sh"),
+  path.join(os.homedir(), ".openpeon", "hooks", "peon-ping", "peon.sh"),
+  path.join(os.homedir(), ".openclaw", "hooks", "peon-ping", "peon.sh"),
+]
+
+const PEON_PS1_CANDIDATES = [
+  path.join(os.homedir(), ".claude", "hooks", "peon-ping", "peon.ps1"),
+  path.join(os.homedir(), ".openpeon", "hooks", "peon-ping", "peon.ps1"),
+]
+
+function firstExisting(candidates: string[]): string | null {
+  for (const p of candidates) {
+    try {
+      if (fs.existsSync(p)) return p
+    } catch {
+      /* ignore */
+    }
+  }
+  return null
+}
+
+export default function (pi: ExtensionAPI): void {
+  const isWindows = process.platform === "win32"
+  const peonScript = isWindows ? firstExisting(PEON_PS1_CANDIDATES) : firstExisting(PEON_SH_CANDIDATES)
+
+  if (!peonScript) {
+    console.warn("[peon-ping] peon.sh/peon.ps1 not found. Install peon-ping first:")
+    console.warn("  brew install PeonPing/tap/peon-ping")
+    console.warn("  # or: curl -fsSL peonping.com/install | bash")
+    return
+  }
+
+  const cwd = process.cwd()
+  const sessionId = `pi-${Date.now().toString(36)}`
+
+  function firePeon(event: string, extra: Record<string, unknown> = {}): void {
+    const payload = JSON.stringify({
+      hook_event_name: event,
+      notification_type: "",
+      cwd,
+      session_id: sessionId,
+      permission_mode: "",
+      source: "pi",
+      ...extra,
+    })
+
+    try {
+      const child = isWindows
+        ? spawn("powershell", ["-NoProfile", "-NonInteractive", "-File", peonScript!], {
+            stdio: ["pipe", "ignore", "ignore"],
+            detached: true,
+          })
+        : spawn("bash", [peonScript!], {
+            stdio: ["pipe", "ignore", "ignore"],
+            detached: true,
+          })
+      child.stdin.write(payload)
+      child.stdin.end()
+      child.unref()
+    } catch {
+      /* never let a sound failure break the agent */
+    }
+  }
+
+  pi.on("session_start", () => {
+    firePeon("SessionStart")
+  })
+
+  pi.on("agent_end", () => {
+    firePeon("Stop")
+  })
+
+  // Best-effort failure cue: only fire on a tool result that clearly errored.
+  pi.on("tool_result", (event: any) => {
+    const result = event?.result ?? event
+    const failed = result?.isError === true || result?.is_error === true || !!event?.error
+    if (!failed) return
+    const toolName = event?.toolName ?? event?.tool_name ?? "Bash"
+    const error = (event?.error ?? result?.error ?? "Tool failed").toString().slice(0, 180)
+    firePeon("PostToolUseFailure", { tool_name: String(toolName).slice(0, 64), error })
+  })
+}

--- a/adapters/pi/tsconfig.json
+++ b/adapters/pi/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["**/*.ts"]
+}

--- a/tests/pi.bats
+++ b/tests/pi.bats
@@ -1,0 +1,85 @@
+#!/usr/bin/env bats
+
+# Pi is a TypeScript-extension agent (earendil-works/pi), vendored under
+# adapters/pi/ with a bash installer (adapters/pi.sh). There is no audio path
+# to exercise here (the extension shells out to peon.sh/peon.ps1 at runtime),
+# so this suite asserts the installer and extension *structure*.
+
+setup() {
+  REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+  PI_SH="$REPO_ROOT/adapters/pi.sh"
+  PI_TS="$REPO_ROOT/adapters/pi/peon-ping.ts"
+}
+
+# ============================================================
+# Installer (adapters/pi.sh)
+# ============================================================
+
+@test "installer has valid bash syntax" {
+  run bash -n "$PI_SH"
+  [ "$status" -eq 0 ]
+}
+
+@test "installer targets ~/.pi/agent/extensions" {
+  run grep -q 'agent/extensions' "$PI_SH"
+  [ "$status" -eq 0 ]
+}
+
+@test "installer supports --uninstall" {
+  run grep -q -- '--uninstall' "$PI_SH"
+  [ "$status" -eq 0 ]
+}
+
+@test "installer copies the local vendored extension or falls back to curl" {
+  run grep -Eq 'cp "\$LOCAL_EXTENSION"|curl -fsSL "\$PLUGIN_URL"' "$PI_SH"
+  [ "$status" -eq 0 ]
+}
+
+# ============================================================
+# Extension (adapters/pi/peon-ping.ts)
+# ============================================================
+
+@test "extension file exists" {
+  [ -f "$PI_TS" ]
+}
+
+@test "extension exports a default factory" {
+  run grep -Eq 'export default function' "$PI_TS"
+  [ "$status" -eq 0 ]
+}
+
+@test "extension subscribes via pi.on" {
+  run grep -q 'pi.on(' "$PI_TS"
+  [ "$status" -eq 0 ]
+}
+
+@test "extension maps session_start to SessionStart" {
+  run grep -q 'session_start' "$PI_TS"
+  [ "$status" -eq 0 ]
+  run grep -q '"SessionStart"' "$PI_TS"
+  [ "$status" -eq 0 ]
+}
+
+@test "extension maps agent_end to Stop" {
+  run grep -q 'agent_end' "$PI_TS"
+  [ "$status" -eq 0 ]
+  run grep -q '"Stop"' "$PI_TS"
+  [ "$status" -eq 0 ]
+}
+
+@test "extension maps a failed tool_result to PostToolUseFailure" {
+  run grep -q 'tool_result' "$PI_TS"
+  [ "$status" -eq 0 ]
+  run grep -q 'PostToolUseFailure' "$PI_TS"
+  [ "$status" -eq 0 ]
+}
+
+@test "extension tags session id with pi- prefix" {
+  run grep -q 'pi-' "$PI_TS"
+  [ "$status" -eq 0 ]
+}
+
+@test "extension does not throw into the agent on spawn failure" {
+  run grep -q 'catch' "$PI_TS"
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## ⚠️ RFC / likely duplicate — please advise

I'm opening this as a draft RFC, not a merge request. My own high-rigor review of this change concluded it is **very likely a duplicate** of the existing first-party `omp` adapter, and that it should probably just be **closed**. I'm surfacing it transparently so you can make the call rather than quietly sitting on it. Here is what my review found, in my own words:

1. **It very likely duplicates the existing first-party `omp` adapter.** Same product (oh-my-pi by can1357), same `ExtensionAPI` event bus (`session_start`, `tool_result.isError`). The `adapters/pi/peon-ping.ts` here is effectively a renamed, feature-reduced shape of `adapters/omp/peon-ping.ts` — it drops `turn_start`, `auto_compaction_start`, and `session_shutdown` handling, and the tab-title behavior. So it's a strictly smaller version of something that already exists and works.

2. **As written, it would never fire.** This adapter installs the extension to `~/.pi/agent/extensions`, but oh-my-pi loads extensions from `~/.omp/agent/extensions` (per the product's own docs: `~/.omp/config.yml`, `~/.omp/extensions`, `~/.omp/agent/`). The directory mismatch means the extension would never be discovered or loaded at runtime.

3. **Upstream already treats `pi` as an alias of `omp`.** `peon.sh`'s `IDE_ALIASES` already maps `pi` → `omp` (alongside `oh-my-pi` → `omp` and `oh_my_pi` → `omp`). So the project already considers `pi` to be `omp` and ships a single correct `omp` adapter for it.

### The one question for maintainers

**Is there a `pi` variant genuinely distinct from oh-my-pi / `omp` that warrants a separate adapter?**

- If **yes**, then there's a real gap and this can be reworked into something correct (fixing at minimum the extensions path and re-adding the dropped events).
- If **no** — which is what my review strongly suggests — then **please close this. No offense taken.** I'd recommend closing it unless a distinct `pi` actually exists.

I'm raising this for completeness and a clean decision, not to argue for merge. My own recommendation is to close it.

## What's in the diff

Add-only. 5 new files, 319 insertions, 0 deletions. It does **not** delete or alter the existing `omp` adapter — that stays exactly as-is.

- `adapters/pi.sh` — installer for the Pi extension
- `adapters/pi/peon-ping.ts` — the thin extension (routes lifecycle events through `peon.sh` / `peon.ps1`)
- `adapters/pi/package.json`
- `adapters/pi/tsconfig.json`
- `tests/pi.bats` — BATS coverage for the adapter

## CI note

A Vercel check will fail with "Authorization required to deploy." That's the fork deploy-auth behavior on cross-repo PRs (the fork can't deploy to the upstream Vercel project) and is benign — it's unrelated to the adapter code.
