### PR TITLE
feat(mobile): make ntfy notification priority configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1401,6 +1401,33 @@ peon mobile pushover <user_key> <app_token>
 peon mobile telegram <bot_token> <chat_id>
 ```
 
+### Notification priority (ntfy)
+
+By default peon-ping derives the ntfy priority from the event type (permission
+prompts are `high`, routine events `default`/`low`). On iOS the lower tiers can
+arrive **silently** — the banner shows but no sound plays. Set an explicit
+priority to make alerts audible:
+
+```bash
+peon mobile ntfy my-peon-notifications --priority=max
+```
+
+You can also add a `priority` key to `mobile_notify` in `config.json`:
+
+```json
+"mobile_notify": {
+  "service": "ntfy",
+  "topic": "my-peon-notifications",
+  "server": "https://ntfy.sh",
+  "priority": "max"
+}
+```
+
+Accepted values are ntfy priority names (`max`/`urgent`, `high`, `default`,
+`low`, `min`) or numbers `1`–`5`. When set, it applies to every event,
+overriding the per-event default; leave it unset to keep the original behavior.
+The same value also maps to Pushover priorities for that service.
+
 ### Mobile commands
 
 ```bash

--- a/peon.sh
+++ b/peon.sh
@@ -1122,6 +1122,7 @@ print('MOBILE_USER_KEY=' + q(mn.get('user_key', '')))
 print('MOBILE_APP_TOKEN=' + q(mn.get('app_token', '')))
 print('MOBILE_CHAT_ID=' + q(mn.get('chat_id', '')))
 print('MOBILE_BOT_TOKEN=' + q(mn.get('bot_token', '')))
+print('MOBILE_PRIORITY=' + q(str(mn.get('priority', '') or '')))
 " 2>/dev/null) || return 0
 
   safe_eval_python "$mobile_vars" || return 0
@@ -1135,6 +1136,16 @@ print('MOBILE_BOT_TOKEN=' + q(mn.get('bot_token', '')))
     yellow) priority="default" ;;
     blue) priority="low" ;;
   esac
+
+  # An explicit priority in config overrides the color-derived default.
+  # Accepts ntfy priority names (max/urgent, high, default, low, min) or
+  # numbers 1-5. Invalid values are ignored so behavior stays predictable.
+  # Useful on iOS, where lower tiers often arrive silently.
+  if [ -n "${MOBILE_PRIORITY:-}" ]; then
+    case "$MOBILE_PRIORITY" in
+      max|urgent|5|high|4|default|3|low|2|min|1) priority="$MOBILE_PRIORITY" ;;
+    esac
+  fi
 
   # Synchronous mode for tests (avoid race with backgrounded curl)
   local use_bg=true
@@ -1168,8 +1179,10 @@ print('MOBILE_BOT_TOKEN=' + q(mn.get('bot_token', '')))
       [ -z "$MOBILE_USER_KEY" ] || [ -z "$MOBILE_APP_TOKEN" ] && return 0
       local po_priority=0
       case "$priority" in
-        high) po_priority=1 ;;
-        low) po_priority=-1 ;;
+        max|urgent|5) po_priority=1 ;;
+        high|4) po_priority=1 ;;
+        low|2) po_priority=-1 ;;
+        min|1) po_priority=-2 ;;
       esac
       if [ "$use_bg" = true ]; then
         nohup curl -sf \
@@ -3432,23 +3445,28 @@ print(msg)
       ntfy)
         TOPIC="${3:-}"
         if [ -z "$TOPIC" ]; then
-          echo "Usage: peon mobile ntfy <topic> [--server=URL] [--token=TOKEN]" >&2
+          echo "Usage: peon mobile ntfy <topic> [--server=URL] [--token=TOKEN] [--priority=max|urgent|high|default|low|min]" >&2
           echo "" >&2
           echo "Setup:" >&2
           echo "  1. Install ntfy app on your phone (ntfy.sh)" >&2
           echo "  2. Subscribe to your topic in the app" >&2
           echo "  3. Run: peon mobile ntfy my-unique-topic" >&2
+          echo "" >&2
+          echo "Tip: on iOS, lower priorities can arrive silently. Use" >&2
+          echo "     --priority=max for an audible alert on every event." >&2
           exit 1
         fi
         NTFY_SERVER="https://ntfy.sh"
         NTFY_TOKEN=""
+        NTFY_PRIORITY=""
         for arg in "${@:4}"; do
           case "$arg" in
-            --server=*) NTFY_SERVER="${arg#--server=}" ;;
-            --token=*)  NTFY_TOKEN="${arg#--token=}" ;;
+            --server=*)   NTFY_SERVER="${arg#--server=}" ;;
+            --token=*)    NTFY_TOKEN="${arg#--token=}" ;;
+            --priority=*) NTFY_PRIORITY="${arg#--priority=}" ;;
           esac
         done
-        export PEON_ENV_NTFY_TOPIC="$TOPIC" PEON_ENV_NTFY_SERVER="$NTFY_SERVER" PEON_ENV_NTFY_TOKEN="$NTFY_TOKEN"
+        export PEON_ENV_NTFY_TOPIC="$TOPIC" PEON_ENV_NTFY_SERVER="$NTFY_SERVER" PEON_ENV_NTFY_TOKEN="$NTFY_TOKEN" PEON_ENV_NTFY_PRIORITY="$NTFY_PRIORITY"
         python3 -c "
 import json, os
 config_path = os.environ.get('PEON_ENV_CONFIG', '')
@@ -3463,11 +3481,15 @@ cfg['mobile_notify'] = {
     'server': os.environ.get('PEON_ENV_NTFY_SERVER', 'https://ntfy.sh'),
     'token': os.environ.get('PEON_ENV_NTFY_TOKEN', '')
 }
+_prio = os.environ.get('PEON_ENV_NTFY_PRIORITY', '')
+if _prio:
+    cfg['mobile_notify']['priority'] = _prio
 json.dump(cfg, open(config_path, 'w'), indent=2)
 "
         echo "peon-ping: mobile notifications enabled via ntfy"
         echo "  Topic:  $TOPIC"
         echo "  Server: $NTFY_SERVER"
+        [ -n "$NTFY_PRIORITY" ] && echo "  Priority: $NTFY_PRIORITY"
         echo ""
         echo "Install the ntfy app and subscribe to '$TOPIC'"
         # Send test notification
@@ -3580,6 +3602,9 @@ else:
         server = mn.get('server', 'https://ntfy.sh')
         print(f'  Topic:  {topic}')
         print(f'  Server: {server}')
+        prio = mn.get('priority')
+        if prio:
+            print(f'  Priority: {prio}')
     elif service == 'pushover':
         ukey = mn.get('user_key', '?')
         print(f'  User:   {ukey[:8]}...')

--- a/tests/peon.bats
+++ b/tests/peon.bats
@@ -2939,6 +2939,46 @@ assert mn['enabled'] == True
 "
 }
 
+@test "mobile ntfy priority override from config wins over event default" {
+  cat > "$TEST_DIR/config.json" <<'JSON'
+{
+  "default_pack": "peon", "volume": 0.5, "enabled": true, "categories": {},
+  "mobile_notify": { "enabled": true, "service": "ntfy", "topic": "test-topic", "server": "https://ntfy.sh", "priority": "max" }
+}
+JSON
+  # PermissionRequest is normally Priority: high; an explicit config priority overrides it.
+  run_peon '{"hook_event_name":"PermissionRequest","cwd":"/tmp/myproject","session_id":"s1","permission_mode":"default"}'
+  [ "$PEON_EXIT" -eq 0 ]
+  mobile_was_called
+  cmdline=$(mobile_cmdline)
+  [[ "$cmdline" == *"Priority: max"* ]]
+  [[ "$cmdline" != *"Priority: high"* ]]
+}
+
+@test "mobile ntfy invalid priority falls back to event default" {
+  cat > "$TEST_DIR/config.json" <<'JSON'
+{
+  "default_pack": "peon", "volume": 0.5, "enabled": true, "categories": {},
+  "mobile_notify": { "enabled": true, "service": "ntfy", "topic": "test-topic", "server": "https://ntfy.sh", "priority": "bogus" }
+}
+JSON
+  run_peon '{"hook_event_name":"PermissionRequest","cwd":"/tmp/myproject","session_id":"s1","permission_mode":"default"}'
+  [ "$PEON_EXIT" -eq 0 ]
+  mobile_was_called
+  cmdline=$(mobile_cmdline)
+  [[ "$cmdline" == *"Priority: high"* ]]
+}
+
+@test "peon mobile ntfy --priority persists in config" {
+  bash "$PEON_SH" mobile ntfy my-test-topic --priority=max
+  python3 -c "
+import json
+cfg = json.load(open('$TEST_DIR/config.json'))
+mn = cfg['mobile_notify']
+assert mn.get('priority') == 'max', f'expected max, got {mn.get(\"priority\")}'
+"
+}
+
 @test "peon mobile off disables mobile" {
   # First configure
   bash "$PEON_SH" mobile ntfy some-topic


### PR DESCRIPTION
# feat(mobile): make ntfy notification priority configurable

## Summary
Adds an optional, user-configurable notification priority for ntfy mobile push, via a `mobile_notify.priority` config key and a `peon mobile ntfy --priority=` flag. This lets users guarantee an audible alert on every event most importantly on iOS, where lower-priority notifications routinely arrive silently. Backward compatible: when no priority is set, behavior is exactly as before.

## Problem / root cause
The ntfy `Priority:` header was hardcoded, derived solely from an internal event "color" map in `send_mobile_notification()`:
```bash
local priority="default"
case "$color" in
  red)    priority="high" ;;     # ntfy priority 4
  yellow) priority="default" ;;  # ntfy priority 3
  blue)   priority="low" ;;      # ntfy priority 2
esac
```
On iOS, Apple only reliably plays a sound/vibration for the higher tiers. The `default` and `low` tiers frequently deliver a silent banner. The message shows in the app, but there's no sound, so the notification is easy to miss.

## The fix
Introduce an explicit priority that overrides the per-event color default:
- **Config:** `mobile_notify.priority` in `config.json`
- **CLI:** `peon mobile ntfy <topic> --priority=<value>`

Accepted values are ntfy priority names (`max`/`urgent`, `high`, `default`, `low`, `min`) or numbers `1`-`5`. Invalid values are ignored so behavior stays predictable. The value is passed straight through to ntfy's `Priority:` header, and is also mapped to the equivalent Pushover priority for that service. It's surfaced in `peon mobile status`.
```jsonc
"mobile_notify": {
  "service": "ntfy",
  "topic": "my-peon-notifications",
  "server": "https://ntfy.sh",
  "priority": "max"          // every event arrives audible on iOS
}
```
```bash
peon mobile ntfy my-peon-notifications --priority=max
```

## Behavior & compatibility
- **Unset (default):** identical to current behavior, priority is still derived from the event color. No migration needed.
- **Set:** the configured value applies to all events, overriding the color map.
- **Invalid value:** ignored; falls back to the color-derived default.
- Applies to ntfy and (mapped) Pushover; Telegram is unaffected (no priority concept).

## Changes
- `peon.sh`
  - Read `mobile_notify.priority` into `MOBILE_PRIORITY`.
  - Apply/validate the override after the color map (ntfy + Pushover).
  - Parse and persist `--priority=` in `peon mobile ntfy` setup.
  - Show priority in `peon mobile status`.
- `README.md` new "Notification priority (ntfy)" section.
- `tests/peon.bats` 3 new tests: config priority overrides the event default; invalid priority falls back to the event default; `--priority` persists into config.

## Testing
```bash
bats tests/peon.bats -f "mobile|priority"
```
All mobile tests pass, including the three added here.