### PR TITLE
fix(notify): nohup overlay osascript so it survives hook exit

### DIFF
--- a/scripts/notify.sh
+++ b/scripts/notify.sh
@@ -382,7 +382,7 @@ case "$PEON_PLATFORM" in
             PEON_CMUX_FOCUS_SOCKET="$cmux_socket_path" \
             PEON_CMUX_FOCUS_WORKSPACE="$cmux_workspace_id" \
             PEON_CMUX_FOCUS_SURFACE="$cmux_surface_id" \
-            osascript -l JavaScript "$overlay_script" "$overlay_msg" "$color" "$local_icon_arg" "$slot" "$dismiss_secs" "$bundle_id" "$ide_pid" "$session_tty" "$subtitle" "$notif_position" "$notify_type" "$all_screens" "$_si" "$close_button" >/dev/null 2>&1 &
+            nohup osascript -l JavaScript "$overlay_script" "$overlay_msg" "$color" "$local_icon_arg" "$slot" "$dismiss_secs" "$bundle_id" "$ide_pid" "$session_tty" "$subtitle" "$notif_position" "$notify_type" "$all_screens" "$_si" "$close_button" >/dev/null 2>&1 &
             _overlay_pids="$_overlay_pids $!"
           done
         else
@@ -393,7 +393,7 @@ case "$PEON_PLATFORM" in
           PEON_CMUX_FOCUS_SOCKET="$cmux_socket_path" \
           PEON_CMUX_FOCUS_WORKSPACE="$cmux_workspace_id" \
           PEON_CMUX_FOCUS_SURFACE="$cmux_surface_id" \
-          osascript -l JavaScript "$overlay_script" "$overlay_msg" "$color" "$local_icon_arg" "$slot" "$dismiss_secs" "$bundle_id" "$ide_pid" "$session_tty" "$subtitle" "$notif_position" "$notify_type" "$all_screens" "" "$close_button" >/dev/null 2>&1 &
+          nohup osascript -l JavaScript "$overlay_script" "$overlay_msg" "$color" "$local_icon_arg" "$slot" "$dismiss_secs" "$bundle_id" "$ide_pid" "$session_tty" "$subtitle" "$notif_position" "$notify_type" "$all_screens" "" "$close_button" >/dev/null 2>&1 &
           _overlay_pids="$!"
         fi
         # Save session state for stacking


### PR DESCRIPTION
## My setup
- macOS (Apple Silicon), single display
- iTerm2, with Claude Code running **inside tmux**
- peon-ping via Homebrew, `notification_style: overlay`

## What I was seeing
Sounds are working fine, but at some point my desktop overlay banners stopped working. Double checked the settings and they're supposed to fire when my terminal is unfocused, so I started investigating. I suspected the focus gate, but debug logging showed that peon was dispatching with `focused=false`. Peon thought it was showing the overlay but nothing ever appeared on screen.

## What's actually going on
Claude Code runs hooks with no controlling TTY. When `peon.sh` exits, the hook's session gets torn down and anything it spawned catches a SIGHUP.

The sound handles this fine because peon launches it with `nohup afplay … &`. The overlay's `osascript` is launched with a plain `&`, no `nohup`. On top of that, the overlay spawns about 600ms after `peon.sh` has already exited (that gap is the focus-detection `osascript`). So the overlay tries to draw after its session is already gone, and the SIGHUP kills it before anything renders.

Sound worked, overlay didn't, even though the logs said it dispatched.

## The fix
Add `nohup` to both overlay spawn paths (all-screens and single) so they survive the parent hook exiting, same as the sound already does. Two-line change.

Confirmed fixed on my setup. Bug's in 2.28.0 and still in 2.30.0.
