### PR TITLE
Fix leading audio clipped on the first sound after idle (pre-roll silence)

### DIFF
--- a/scripts/peon-play.swift
+++ b/scripts/peon-play.swift
@@ -8,9 +8,10 @@ import CoreAudio
 import AudioToolbox
 import Foundation
 
-// MARK: - Argument parsing (-v <volume> <file>)
+// MARK: - Argument parsing (-v <volume> [-p <prerollMs>] <file>)
 
 var volume: Float = 1.0
+var prerollMs: Double = 300   // silence pushed before the file to cover device wake-up
 var filePath: String?
 
 var args = Array(CommandLine.arguments.dropFirst())
@@ -18,13 +19,15 @@ while !args.isEmpty {
     let arg = args.removeFirst()
     if arg == "-v", !args.isEmpty {
         volume = max(0, min(1, Float(args.removeFirst()) ?? 1.0))
+    } else if arg == "-p", !args.isEmpty {
+        prerollMs = max(0, Double(args.removeFirst()) ?? prerollMs)
     } else if filePath == nil {
         filePath = arg
     }
 }
 
 guard let filePath = filePath else {
-    fputs("Usage: peon-play [-v volume] <file>\n", stderr)
+    fputs("Usage: peon-play [-v volume] [-p prerollMs] <file>\n", stderr)
     exit(1)
 }
 
@@ -94,6 +97,19 @@ do {
 } catch {
     fputs("Error: cannot start audio engine: \(error.localizedDescription)\n", stderr)
     exit(1)
+}
+
+// Pre-roll: schedule a short silent buffer before the file. An idle output
+// device (notably Bluetooth A2DP, which suspends within seconds) does not
+// stream PCM the instant engine.start() returns — it needs ~100-300ms to wake.
+// Without this, the first samples are fed to a sink that isn't live yet and the
+// leading syllable is clipped ("appy to" instead of "Happy to"). The silence
+// gives the device time to come up so the file starts on a live stream.
+let prerollFrames = AVAudioFrameCount((format.sampleRate * prerollMs / 1000.0).rounded())
+if prerollFrames > 0,
+   let silence = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: prerollFrames) {
+    silence.frameLength = prerollFrames   // zeroed on allocation == silence
+    playerNode.scheduleBuffer(silence, at: nil, options: [])
 }
 
 playerNode.scheduleFile(audioFile, at: nil, completionCallbackType: .dataPlayedBack) { _ in


### PR DESCRIPTION
## What this fixes

When a sound plays after a few seconds of silence, the start of the line gets clipped ("appy to" instead of "Happy to"). Another sound right after is fine. Worst on Bluetooth. Full write-up in #543.

## Why it happens

`peon-play` starts the engine and plays the first sample immediately:

```swift
try engine.start()
playerNode.scheduleFile(audioFile, ...)
playerNode.play()
```

`engine.start()` returns before the output device is actually streaming PCM. On an idle device the first samples land on a sink that isn't live yet, so the leading audio is dropped. Bluetooth A2DP is the worst case: it suspends within a few seconds and takes ~100-300ms to re-establish and wake the DAC. Built-in speakers wake fast enough to hide it.

## The change

Schedule a short silent buffer before the file so the device has time to come up and the real audio starts on a live stream. Default 300ms, tunable with a new `-p <ms>` flag. No change to existing call sites: `peon.sh` keeps invoking it as `peon-play -v <vol> <file>`.

Tradeoff: on a warm device this adds an inaudible 300ms lead-in. On a cold or Bluetooth device it restores the clipped onset. 300ms covers the typical wake window; very slow devices can pass a higher `-p`.

## Testing

3-phase A/B on a Sennheiser MOMENTUM 4 over Bluetooth A2DP:
- warm (one line x3 back to back): only the first clips
- cold (30s idle, current build): clips
- cold + 300ms pre-roll: clean

Builds clean with the documented `swiftc` line. The `bats` suite mocks `peon-play`, so this Swift-only change is outside its scope and the CLI stays backward-compatible.
