### PR TITLE
Fix install/uninstall deleting other tools' hooks named notify.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1143,6 +1143,28 @@ import json, os, sys
 
 settings_path = '$(py_path "$HOOK_SETTINGS")'
 hook_cmd = '$(py_path "$HOOK_CMD")'
+install_dir = '$(py_path "$INSTALL_DIR")'
+_home = os.path.expanduser('~')
+# peon's own notify.sh is either bundled under the peon-ping dir or the legacy
+# <base>/hooks/notify.sh one level above it. Match absolute and ~-relative
+# forms so we catch the path however the stored command spells it.
+_legacy_notify = os.path.join(os.path.dirname(install_dir), 'notify.sh')
+def _path_markers(p):
+    m = [p]
+    if p.startswith(_home):
+        m.append('~' + p[len(_home):])
+    return m
+_peon_notify_markers = _path_markers(install_dir) + _path_markers(_legacy_notify)
+
+def _is_peon_hook(cmd):
+    # Only strip hooks peon installed. 'notify.sh' is a generic name other
+    # tools register too (e.g. ~/.deckard/hooks/notify.sh), so qualify it to
+    # peon's own copy; sibling tools' notify.sh hooks must survive.
+    if 'peon.sh' in cmd:
+        return True
+    if 'notify.sh' in cmd:
+        return any(m in cmd for m in _peon_notify_markers)
+    return False
 
 # Load existing settings
 if os.path.exists(settings_path):
@@ -1201,8 +1223,7 @@ for event in events:
         h = dict(h)
         h['hooks'] = [
             hk for hk in h.get('hooks', [])
-            if 'notify.sh' not in hk.get('command', '')
-            and 'peon.sh' not in hk.get('command', '')
+            if not _is_peon_hook(hk.get('command', ''))
         ]
         if h['hooks']:
             cleaned.append(h)

--- a/tests/install.bats
+++ b/tests/install.bats
@@ -176,6 +176,39 @@ print('OK')
 "
 }
 
+@test "update preserves a sibling notify.sh hook from another tool (e.g. deckard)" {
+  # First install to establish peon hooks
+  bash "$CLONE_DIR/install.sh"
+  [ -f "$TEST_HOME/.claude/settings.json" ]
+
+  # Another tool registers its own notify.sh hook in events peon also uses.
+  # The command literally contains 'notify.sh', which the installer used to
+  # over-match and strip (deleting the other tool's hooks).
+  /usr/bin/python3 -c "
+import json
+p = '$TEST_HOME/.claude/settings.json'
+s = json.load(open(p))
+for event in ('Notification', 'SessionStart', 'Stop'):
+    s['hooks'].setdefault(event, [])
+    s['hooks'][event].append({'matcher': '', 'hooks': [{'type': 'command', 'command': 'bash ~/.deckard/hooks/notify.sh ' + event.lower()}]})
+json.dump(s, open(p, 'w'), indent=2)
+"
+
+  # Re-run install (simulates peon update)
+  bash "$CLONE_DIR/install.sh"
+
+  # The sibling notify.sh hooks must survive, and peon must still be registered
+  /usr/bin/python3 -c "
+import json
+s = json.load(open('$TEST_HOME/.claude/settings.json'))
+for event in ('Notification', 'SessionStart', 'Stop'):
+    cmds = [h.get('command','') for entry in s['hooks'].get(event, []) for h in entry.get('hooks', [])]
+    assert any('.deckard/hooks/notify.sh' in c for c in cmds), event + ' lost sibling notify.sh: ' + repr(cmds)
+    assert any('peon.sh' in c for c in cmds), event + ' missing peon.sh after update'
+print('OK')
+"
+}
+
 @test "fresh install creates VERSION file" {
   bash "$CLONE_DIR/install.sh"
   [ -f "$INSTALL_DIR/VERSION" ]
@@ -329,6 +362,37 @@ print('OK')
   # Install and skill directories removed
   [ ! -d "$LOCAL_INSTALL_DIR" ]
   [ ! -d "$PROJECT_DIR/.claude/skills/peon-ping-toggle" ]
+}
+
+@test "--local uninstall preserves a sibling notify.sh hook from another tool" {
+  cd "$PROJECT_DIR"
+  bash "$CLONE_DIR/install.sh" --local
+  [ -f "$PROJECT_DIR/.claude/settings.json" ]
+
+  # Another tool registers its own notify.sh hook alongside peon's
+  /usr/bin/python3 -c "
+import json
+p = '$PROJECT_DIR/.claude/settings.json'
+s = json.load(open(p))
+for event in ('Notification', 'SessionStart', 'Stop'):
+    s['hooks'].setdefault(event, [])
+    s['hooks'][event].append({'matcher': '', 'hooks': [{'type': 'command', 'command': 'bash ~/.deckard/hooks/notify.sh ' + event.lower()}]})
+json.dump(s, open(p, 'w'), indent=2)
+"
+
+  # Run uninstall
+  bash "$LOCAL_INSTALL_DIR/uninstall.sh"
+
+  # peon hooks gone, sibling notify.sh hooks preserved
+  /usr/bin/python3 -c "
+import json
+s = json.load(open('$PROJECT_DIR/.claude/settings.json'))
+hooks = s.get('hooks', {})
+all_cmds = [h.get('command','') for entries in hooks.values() for entry in entries for h in entry.get('hooks', [])]
+assert not any('peon.sh' in c for c in all_cmds), 'peon.sh survived uninstall: ' + repr(all_cmds)
+assert any('.deckard/hooks/notify.sh' in c for c in all_cmds), 'sibling notify.sh was wiped by uninstall: ' + repr(all_cmds)
+print('OK')
+"
 }
 
 @test "--local hook paths point to project directory not global" {

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -31,6 +31,29 @@ _remove_peon_hooks() {
 import json, os
 
 settings_path = '$target'
+install_dir = '$INSTALL_DIR'
+_home = os.path.expanduser('~')
+# peon's own notify.sh is either bundled under the peon-ping dir or the legacy
+# <base>/hooks/notify.sh one level above it. Match absolute and ~-relative
+# forms so we catch the path however the stored command spells it.
+_legacy_notify = os.path.join(os.path.dirname(install_dir), 'notify.sh')
+def _path_markers(p):
+    m = [p]
+    if p.startswith(_home):
+        m.append('~' + p[len(_home):])
+    return m
+_peon_notify_markers = _path_markers(install_dir) + _path_markers(_legacy_notify)
+
+def _is_peon_hook(cmd):
+    # Only strip hooks peon installed. 'notify.sh' is a generic name other
+    # tools register too (e.g. ~/.deckard/hooks/notify.sh), so qualify it to
+    # peon's own copy; sibling tools' notify.sh hooks must survive.
+    if 'peon.sh' in cmd or 'hook-handle-use.sh' in cmd:
+        return True
+    if 'notify.sh' in cmd:
+        return any(m in cmd for m in _peon_notify_markers)
+    return False
+
 with open(settings_path) as f:
     settings = json.load(f)
 
@@ -44,9 +67,7 @@ for event, entries in list(hooks.items()):
         original_inner = h.get('hooks', [])
         kept = [
             hk for hk in original_inner
-            if 'peon.sh' not in hk.get('command', '')
-            and 'hook-handle-use.sh' not in hk.get('command', '')
-            and 'notify.sh' not in hk.get('command', '')
+            if not _is_peon_hook(hk.get('command', ''))
         ]
         if len(kept) != len(original_inner):
             changed = True


### PR DESCRIPTION
## What this fixes

`install.sh` and `uninstall.sh` strip peon's own hooks from `settings.json` with a bare substring match on `notify.sh`. That filename is generic, so any sibling hook whose command contains it (for example another tool's `~/.deckard/hooks/notify.sh`) gets deleted too, silently. Full write-up in #545.

This is adjacent to #484, which preserved whole sibling matcher entries. That fix is intact; the per-hook filter underneath it still matched by bare substring, so a sibling hook named `notify.sh` slipped through.

## The change

Qualify the `notify.sh` match to peon's own copy:
- the bundled one under the `peon-ping/` install dir, or
- the legacy `<base>/hooks/notify.sh` that older installs registered.

Matching uses both absolute and `~`-relative path forms, so it holds regardless of how the stored command spells the path (`bash ~/.deckard/...`, absolute, with trailing args). `peon.sh` and `hook-handle-use.sh` are peon-specific names and left as-is.

## Testing

Two regression tests added to `tests/install.bats`, both fail on `main` and pass with this change:
- update (re-install) preserves a sibling hook named `notify.sh`
- `--local` uninstall preserves a sibling hook named `notify.sh`

Full `bats tests/install.bats` is green (63 tests), including the existing #484 sibling-preservation test.
