### PR TITLE
fix(warp): focus the exact tab on notification click via WARP_FOCUS_URL

### DIFF
--- a/peon.sh
+++ b/peon.sh
@@ -972,6 +972,8 @@ send_notification() {
       if [ "$PEON_PLATFORM" = "mac" ]; then
         export PEON_BUNDLE_ID="$(_mac_terminal_bundle_id)"
         export PEON_IDE_PID="$(_mac_ide_pid)"
+        # Warp's per-session deep link; opening it on click focuses the exact tab.
+        export PEON_WARP_FOCUS_URL="${WARP_FOCUS_URL:-}"
         _peon_cmux_surface="${CMUX_SURFACE_ID:-${CMUX_PANEL_ID:-}}"
         _peon_cmux_cli="$(_cmux_cli_path)"
         if [ -n "${CMUX_WORKSPACE_ID:-}" ] && [ -n "$_peon_cmux_surface" ] && [ -n "$_peon_cmux_cli" ]; then

--- a/scripts/mac-overlay.js
+++ b/scripts/mac-overlay.js
@@ -27,6 +27,9 @@ function run(argv) {
   var env = $.NSProcessInfo.processInfo.environment;
   var clickCommandValue = env.objectForKey($('PEON_CLICK_COMMAND'));
   var clickCommand = clickCommandValue && !clickCommandValue.isNil() ? ObjC.unwrap(clickCommandValue) : '';
+  var warpFocusUrlValue = env.objectForKey($('PEON_WARP_FOCUS_URL'));
+  var warpFocusUrl = warpFocusUrlValue && !warpFocusUrlValue.isNil() ? ObjC.unwrap(warpFocusUrlValue) : '';
+  if (warpFocusUrl.indexOf('warp://') !== 0) warpFocusUrl = '';
   var cmuxFocusHelperValue = env.objectForKey($('PEON_CMUX_FOCUS_HELPER'));
   var cmuxFocusCliValue = env.objectForKey($('PEON_CMUX_FOCUS_CLI'));
   var cmuxFocusSocketValue = env.objectForKey($('PEON_CMUX_FOCUS_SOCKET'));
@@ -155,6 +158,26 @@ function run(argv) {
               // Signal ALL sibling overlays to dismiss (event-driven, no polling!)
               $.NSDistributedNotificationCenter.defaultCenter.postNotificationNameObject($(dismissNotificationName), $.NSString.string);
               // Small delay to ensure notification is delivered before we terminate
+              $.NSTimer.scheduledTimerWithTimeIntervalTargetSelectorUserInfoRepeats(
+                0.05, $.NSApp, 'terminate:', null, false
+              );
+              return;
+            }
+            // activateWithOptions() won't cross Spaces from this accessory-policy
+            // process; Warp's deep link does, and also selects the exact tab.
+            // Fall back to AppleScript activate (app + Space, no tab) on older Warp.
+            if (bundleId === 'dev.warp.Warp-Stable') {
+              var warpTask = $.NSTask.alloc.init;
+              if (warpFocusUrl) {
+                warpTask.setLaunchPath($('/usr/bin/open'));
+                warpTask.setArguments($([warpFocusUrl]));
+              } else {
+                warpTask.setLaunchPath($('/usr/bin/osascript'));
+                warpTask.setArguments($(['-e', 'tell application "Warp" to activate']));
+              }
+              warpTask.launch;
+              warpTask.waitUntilExit;
+              $.NSDistributedNotificationCenter.defaultCenter.postNotificationNameObject($(dismissNotificationName), $.NSString.string);
               $.NSTimer.scheduledTimerWithTimeIntervalTargetSelectorUserInfoRepeats(
                 0.05, $.NSApp, 'terminate:', null, false
               );

--- a/scripts/notify.sh
+++ b/scripts/notify.sh
@@ -254,6 +254,7 @@ case "$PEON_PLATFORM" in
       overlay_script="$(_find_overlay)" 2>/dev/null || true
     bundle_id="${PEON_BUNDLE_ID:-}"
     ide_pid="${PEON_IDE_PID:-}"
+    warp_focus_url="${PEON_WARP_FOCUS_URL:-}"
     cmux_workspace_id="${PEON_CMUX_WORKSPACE_ID:-}"
     cmux_surface_id="${PEON_CMUX_SURFACE_ID:-}"
     cmux_socket_path="${PEON_CMUX_SOCKET_PATH:-}"
@@ -377,6 +378,7 @@ case "$PEON_PLATFORM" in
           for _si in $(seq 0 $((screen_count - 1))); do
             _notify_debug "overlay spawn screen=$_si"
             PEON_CLICK_COMMAND="$click_command" \
+            PEON_WARP_FOCUS_URL="$warp_focus_url" \
             PEON_CMUX_FOCUS_HELPER="$cmux_focus_helper" \
             PEON_CMUX_FOCUS_CLI="$cmux_cli" \
             PEON_CMUX_FOCUS_SOCKET="$cmux_socket_path" \
@@ -388,6 +390,7 @@ case "$PEON_PLATFORM" in
         else
           _notify_debug "overlay spawn mode=single dismiss=$dismiss_secs script=$(printf '%q' "$overlay_script")"
           PEON_CLICK_COMMAND="$click_command" \
+          PEON_WARP_FOCUS_URL="$warp_focus_url" \
           PEON_CMUX_FOCUS_HELPER="$cmux_focus_helper" \
           PEON_CMUX_FOCUS_CLI="$cmux_cli" \
           PEON_CMUX_FOCUS_SOCKET="$cmux_socket_path" \

--- a/tests/mac-overlay.bats
+++ b/tests/mac-overlay.bats
@@ -213,6 +213,18 @@ json.dump(c, open('$TEST_DIR/config.json', 'w'))
   [[ "$(overlay_log)" == *"dev.warp.Warp-Stable"* ]]
 }
 
+@test "macOS overlay receives WARP_FOCUS_URL for Warp tab click-to-focus" {
+  WARP_FOCUS_URL="warp://session/deadbeefcafe" TERM_PROGRAM=WarpTerminal \
+    run_peon '{"hook_event_name":"Stop","cwd":"/tmp/myproject","session_id":"s1","permission_mode":"default"}'
+  [ "$PEON_EXIT" -eq 0 ]
+  overlay_was_called
+  # Assert on the overlay-spawn line, so the URL is proven to reach the overlay
+  # process itself — not merely the screen-count probe's inherited environment.
+  spawn_line="$(overlay_log | grep 'mac-overlay')"
+  [[ "$spawn_line" == *"dev.warp.Warp-Stable"* ]]
+  [[ "$spawn_line" == *"warp://session/deadbeefcafe"* ]]
+}
+
 @test "macOS overlay passes bundle ID for Zed click-to-focus" {
   TERM_PROGRAM=zed run_peon '{"hook_event_name":"Stop","cwd":"/tmp/myproject","session_id":"s1","permission_mode":"default"}'
   [ "$PEON_EXIT" -eq 0 ]

--- a/tests/setup.bash
+++ b/tests/setup.bash
@@ -287,8 +287,13 @@ elif [[ "$*" == *"iTerm2"* ]] && [[ "$*" == *"tty"* ]]; then
     cat "${CLAUDE_PEON_DIR}/.mock_iterm_active_ttys"
   fi
 elif [[ "$1" == "-l" ]] && [[ "$2" == "JavaScript" ]]; then
-  # JXA overlay call — log to overlay.log with full arguments
-  echo "$@" >> "${CLAUDE_PEON_DIR}/overlay.log"
+  # JXA call — log argv. For the overlay spawn (not the screen-count probe),
+  # also surface PEON_WARP_FOCUS_URL, which reaches it via env rather than argv.
+  _overlay_line="$@"
+  if [[ "$*" == *mac-overlay* ]] && [ -n "${PEON_WARP_FOCUS_URL:-}" ]; then
+    _overlay_line="$_overlay_line PEON_WARP_FOCUS_URL=${PEON_WARP_FOCUS_URL}"
+  fi
+  echo "$_overlay_line" >> "${CLAUDE_PEON_DIR}/overlay.log"
 else
   echo "$@" >> "${CLAUDE_PEON_DIR}/osascript.log"
 fi


### PR DESCRIPTION
Fixes #547.

Clicking a notification overlay never brought **Warp** forward when it was on another macOS Space. `activateWithOptions()` returns success from the overlay's accessory-policy process but doesn't cross Spaces; only iTerm2 had a per-window path, so every other terminal fell through to that no-op.

Warp injects a per-session deep link (`WARP_FOCUS_URL=warp://session/<uuid>`) and registers the `warp://` scheme. This threads it from the hook environment to the overlay click handler, which `open`s it — switching app, Space, and the exact tab. Falls back to AppleScript `activate` (app + Space, no tab) on older Warp builds without the deep link, mirroring the existing iTerm2 handling.

Verified live on macOS 26.4.1 + Warp: click now lands on the originating tab across Spaces. New test asserts the overlay is spawned with the URL in its environment (fails red when the source export is removed).
