### PR TITLE
nix: build meeting-detect and peon-play swift helpers

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -35,7 +35,8 @@
           inherit version;
           src = ./.;
 
-          nativeBuildInputs = [ pkgs.makeWrapper ];
+          nativeBuildInputs = [ pkgs.makeWrapper ]
+            ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [ pkgs.swift ];
           dontConfigure = true;
           dontBuild = true;
 
@@ -55,6 +56,20 @@
               [ -f "$f" ] && cp "$f" "$share/scripts/"
             done
             chmod +x "$share/scripts/"*.sh 2>/dev/null || true
+
+            ${pkgs.lib.optionalString pkgs.stdenv.isDarwin ''
+              # Build native macOS helpers (install.sh does this for curl-based
+              # installs; the Nix package needs the same step or meeting_detect /
+              # the Sound Effects device path are silent no-ops). Non-fatal on
+              # failure since peon.sh already falls back gracefully at runtime.
+              swiftc -O -o "$share/scripts/meeting-detect" \
+                scripts/meeting-detect.swift -framework CoreAudio \
+                || echo "warning: failed to build meeting-detect; meeting_detect will be a no-op"
+              swiftc -O -o "$share/scripts/peon-play" \
+                scripts/peon-play.swift \
+                -framework AVFoundation -framework CoreAudio -framework AudioToolbox \
+                || echo "warning: failed to build peon-play; falling back to afplay"
+            ''}
 
             # Wrap hook scripts so they can find python3 (and other runtime deps)
             # regardless of the PATH Claude Code passes to UserPromptSubmit hooks.


### PR DESCRIPTION
## Summary

The Nix package's `installPhase` only copies the `.sh`/`.js` helper scripts into `$share/scripts`. Unlike `install.sh` (the curl-based installer), it never compiles `scripts/meeting-detect.swift` or `scripts/peon-play.swift` with `swiftc`, so those binaries never land in a Nix install.

Practical effect (see #539): with a Nix install, setting `meeting_detect: true` in config is silently a no-op — `find_bundled_script "meeting-detect"` never finds a binary, `detect_meeting` always returns false, and sounds keep playing during calls. `peon-play` is similarly always unavailable, so Nix installs silently fall back to `afplay` for the Sound Effects device path.

## Fix

- Add `pkgs.swift` to `nativeBuildInputs` on Darwin.
- In `installPhase`, compile both helpers with the same `swiftc -O ... -framework ...` invocations `install.sh` already uses, guarded by `pkgs.stdenv.isDarwin`.
- Match `install.sh`'s graceful degradation: a failed compile prints a warning instead of failing the whole derivation, since `peon.sh` already falls back cleanly at runtime when the binary is missing.

Verified locally on aarch64-darwin: `nix build .#default` produces working `meeting-detect` (outputs `MIC_IN_USE`/`MIC_NOT_IN_USE`) and `peon-play` binaries in `$share/scripts`.

## Test plan

- [x] `nix build .#default` succeeds on aarch64-darwin
- [x] Resulting `share/peon-ping/scripts/meeting-detect` runs and reports mic status
- [x] Resulting `share/peon-ping/scripts/peon-play` runs (prints usage with no args)
- [ ] CI / maintainer check on x86_64-darwin