### PR TITLE
fix: don't log user prompt content in UserPromptSubmit hooks

### DIFF
--- a/scripts/hook-handle-rename.sh
+++ b/scripts/hook-handle-rename.sh
@@ -8,7 +8,8 @@ LOG_FILE="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/peon-ping/hook-handle-rename
 LOG_FALLBACK="${TMPDIR:-/tmp}/peon-ping-hook.log"
 log() {
   local line="[$(date '+%Y-%m-%d %H:%M:%S')] $*"
-  echo "$line" >> "$LOG_FILE" 2>/dev/null || echo "$line" >> "$LOG_FALLBACK" 2>/dev/null || true
+  # umask is scoped to the subshell so only the log file is created 0600
+  ( umask 077; echo "$line" >> "$LOG_FILE" 2>/dev/null || echo "$line" >> "$LOG_FALLBACK" 2>/dev/null || true )
 }
 
 log "invoked stdin_len=${#INPUT}"
@@ -66,7 +67,7 @@ except:
 
 # Check if this is a /peon-ping-rename command
 if ! echo "$PROMPT" | grep -qE '^\s*/peon-ping-rename(\s+.*)?$'; then
-  log "passthrough: not_our_cmd prompt_preview=${PROMPT:0:80}..."
+  log "passthrough: not_our_cmd prompt_len=${#PROMPT}"
   echo '{"continue": true}'
   exit 0
 fi

--- a/scripts/hook-handle-use.ps1
+++ b/scripts/hook-handle-use.ps1
@@ -7,6 +7,8 @@ $ErrorActionPreference = 'Stop'
 
 $LogFile = if ($env:CLAUDE_CONFIG_DIR) { "$env:CLAUDE_CONFIG_DIR/hooks/peon-ping/hook-handle-use.log" } else { "$env:USERPROFILE/.claude/hooks/peon-ping/hook-handle-use.log" }
 $LogFallback = "$env:TEMP\peon-ping-hook.log"
+# Log lines must never carry prompt text: the log inherits the ACL of its parent
+# directory, and prompts can contain credentials the user pasted into the chat.
 function Write-Log {
     param($Msg)
     $line = "[$(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')] $Msg"
@@ -61,7 +63,7 @@ if (-not $cliMode) {
     }
 
     if ($prompt -notmatch '^\s*/peon-ping-use\s+(\S+)') {
-        Write-Log "passthrough: not_our_cmd prompt_preview=$($prompt.Substring(0, [Math]::Min(80, $prompt.Length)))..."
+        Write-Log "passthrough: not_our_cmd prompt_len=$($prompt.Length)"
         Write-Response -Continue $true
         exit 0
     }

--- a/scripts/hook-handle-use.sh
+++ b/scripts/hook-handle-use.sh
@@ -8,7 +8,8 @@ LOG_FILE="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/peon-ping/hook-handle-use.lo
 LOG_FALLBACK="${TMPDIR:-/tmp}/peon-ping-hook.log"
 log() {
   local line="[$(date '+%Y-%m-%d %H:%M:%S')] $*"
-  echo "$line" >> "$LOG_FILE" 2>/dev/null || echo "$line" >> "$LOG_FALLBACK" 2>/dev/null || true
+  # umask is scoped to the subshell so only the log file is created 0600
+  ( umask 077; echo "$line" >> "$LOG_FILE" 2>/dev/null || echo "$line" >> "$LOG_FALLBACK" 2>/dev/null || true )
 }
 
 log "invoked stdin_len=${#INPUT}"
@@ -37,7 +38,7 @@ except:
 
 # Check if this is a /peon-ping-use command
 if ! echo "$PROMPT" | grep -qE '^\s*/peon-ping-use\s+\S+'; then
-  log "passthrough: not_our_cmd prompt_preview=${PROMPT:0:80}..."
+  log "passthrough: not_our_cmd prompt_len=${#PROMPT}"
   echo '{"continue": true}'
   exit 0
 fi


### PR DESCRIPTION
## What

`scripts/hook-handle-use.sh`, `scripts/hook-handle-rename.sh` and `scripts/hook-handle-use.ps1` write the first 80 characters of the user's prompt to a plaintext log file:

```sh
log "passthrough: not_our_cmd prompt_preview=${PROMPT:0:80}..."
```

These are `UserPromptSubmit` hooks, so this line runs on every prompt that is not a `/peon-ping-*` command, which is nearly all of them.

## Why it matters

Prompts routinely contain secrets that users paste into a session: access tokens, API keys, passwords, connection strings. Those land in `~/.claude/hooks/peon-ping/hook-handle-{use,rename}.log`, which is created with the process umask (mode 0644 on a default setup), so it is readable by every local user and by any process running as that user.

These hook logs are also unconditional and unpruned. The structured logging in `peon.sh` is opt-in via `peon debug on` and has a `debug_retention_days` setting; the hook logs have neither, and they do not record prompt content anywhere else.

The passthrough line exists to answer "why didn't my slash command fire". The prompt length is enough to diagnose that.

## What changed

- Log `prompt_len` instead of `prompt_preview=<first 80 chars>` in all three scripts.
- Create the shell log files with `umask 077` so they are not world-readable. The umask is scoped to a subshell, so `config.json` and `.state.json`, written later in the same script, keep their current permissions.
- The PowerShell log inherits the ACL of its parent directory under `%USERPROFILE%`, so it gets an explanatory comment rather than a permission change.

3 files, +9/-5, two of which are comments. No behaviour change to the slash commands.

## Verification

- `bash -n` and `shellcheck` clean, no new warnings.
- Ran both shell hooks with a payload containing a fake credential: the log records `prompt_len=74`, the credential appears in no log file, and the log is created mode `0600`.
- `/peon-ping-use <pack>`, the unknown-pack error path, and `/peon-ping-rename <name>` all behave as before.

## Note for existing installs

`umask` applies only at file creation, so an existing `hook-handle-*.log` keeps its current mode and the prompt text already captured in it. Anyone wanting that history gone should delete the two log files:

```sh
rm -f ~/.claude/hooks/peon-ping/hook-handle-use.log \
      ~/.claude/hooks/peon-ping/hook-handle-rename.log
```
