### PR TITLE
fix: uninstaller handles symlinked rc files and removes the rename hook

### DIFF
--- a/tests/install.bats
+++ b/tests/install.bats
@@ -523,6 +523,42 @@ TOML
   grep -q "$INSTALL_DIR/adapters/codex.sh" "$TEST_HOME/.codex/config.toml"
 }
 
+@test "uninstall cleans a symlinked rc file and preserves the symlink" {
+  # dotfiles-style setup: ~/.zshrc is a symlink into a managed directory.
+  # BSD sed -i refuses symlinks, so the cleanup must not edit in place.
+  mkdir -p "$TEST_HOME/dotfiles"
+  echo "alias ll='ls -la'" > "$TEST_HOME/dotfiles/zshrc"
+  ln -s "$TEST_HOME/dotfiles/zshrc" "$TEST_HOME/.zshrc"
+
+  bash "$CLONE_DIR/install.sh"
+  grep -qF 'peon-ping/completions.bash' "$TEST_HOME/.zshrc"
+
+  bash "$INSTALL_DIR/uninstall.sh"
+
+  # still a symlink pointing at the same target
+  [ -L "$TEST_HOME/.zshrc" ]
+  [ "$(readlink "$TEST_HOME/.zshrc")" = "$TEST_HOME/dotfiles/zshrc" ]
+  # peon lines removed (through the symlink), unrelated content kept
+  ! grep -qF 'alias peon=' "$TEST_HOME/.zshrc"
+  ! grep -qF 'peon-ping/completions.bash' "$TEST_HOME/.zshrc"
+  ! grep -qF '# peon-ping quick controls' "$TEST_HOME/.zshrc"
+  grep -qF "alias ll='ls -la'" "$TEST_HOME/dotfiles/zshrc"
+}
+
+@test "uninstall removes hook-handle-rename registrations from settings and Cursor" {
+  mkdir -p "$TEST_HOME/.cursor"
+  bash "$CLONE_DIR/install.sh"
+  # install registers both command handlers
+  grep -q 'hook-handle-rename' "$TEST_HOME/.claude/settings.json"
+  grep -q 'hook-handle-rename' "$TEST_HOME/.cursor/hooks.json"
+
+  bash "$INSTALL_DIR/uninstall.sh"
+
+  # no handler registration survives in either file
+  ! grep -q 'hook-handle-' "$TEST_HOME/.claude/settings.json"
+  ! grep -q 'hook-handle-' "$TEST_HOME/.cursor/hooks.json"
+}
+
 @test "--local hook paths point to project directory not global" {
   cd "$PROJECT_DIR"
   bash "$CLONE_DIR/install.sh" --local

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -48,7 +48,10 @@ def _is_peon_hook(cmd):
     # Only strip hooks peon installed. 'notify.sh' is a generic name other
     # tools register too (e.g. ~/.deckard/hooks/notify.sh), so qualify it to
     # peon's own copy; sibling tools' notify.sh hooks must survive.
-    if 'peon.sh' in cmd or 'hook-handle-use.sh' in cmd:
+    # 'hook-handle-' covers every handler peon registers (hook-handle-use.sh,
+    # hook-handle-rename.sh, and any future hook-handle-*.sh) — install.sh
+    # registers all of them, so uninstall must strip all of them.
+    if 'peon.sh' in cmd or 'hook-handle-' in cmd:
         return True
     if 'notify.sh' in cmd:
         return any(m in cmd for m in _peon_notify_markers)
@@ -124,7 +127,7 @@ for event, entries in list(hooks.items()):
     original_count = len(entries)
     entries = [
         h for h in entries
-        if not ('hook-handle-use' in h.get('command', ''))
+        if 'hook-handle-' not in h.get('command', '')
     ]
     if len(entries) < original_count:
         events_cleaned.append(event)
@@ -365,17 +368,30 @@ print('Restored notify.sh hooks for: SessionStart, UserPromptSubmit, Stop, Notif
   fi
 fi
 
+# Delete lines from a file, working for both regular files and symlinks.
+# BSD sed's `-i` aborts on a symlinked target ("in-place editing only works
+# for regular files"), which breaks the common dotfiles setup where rc files
+# are symlinks. Filter through a temp file and copy the content back with a
+# redirect, which follows the symlink and preserves it (and its target).
+_delete_lines() {
+  local file="$1"
+  shift
+  local tmp
+  tmp="$(mktemp)"
+  sed "$@" "$file" > "$tmp"
+  cat "$tmp" > "$file"
+  rm -f "$tmp"
+}
+
 # --- Remove shell alias and completions from rc files ---
 for rcfile in "$HOME/.zshrc" "$HOME/.bashrc"; do
   if [ -f "$rcfile" ] && [ -w "$rcfile" ]; then
     if grep -qF 'alias peon=' "$rcfile" || grep -qF 'peon-ping/completions.bash' "$rcfile"; then
       # Remove peon-ping lines (alias, completion, comment)
-      sed -i.bak \
+      _delete_lines "$rcfile" \
         -e '/# peon-ping quick controls/d' \
         -e '/alias peon=/d' \
-        -e '/peon-ping\/completions\.bash/d' \
-        "$rcfile"
-      rm -f "${rcfile}.bak"
+        -e '/peon-ping\/completions\.bash/d'
       echo "Cleaned peon-ping lines from $(basename "$rcfile")"
     fi
   fi
@@ -385,11 +401,9 @@ done
 FISH_CONFIG="$HOME/.config/fish/config.fish"
 if [ -f "$FISH_CONFIG" ] && [ -w "$FISH_CONFIG" ]; then
   if grep -qF 'function peon' "$FISH_CONFIG"; then
-    sed -i.bak \
+    _delete_lines "$FISH_CONFIG" \
       -e '/# peon-ping quick controls/d' \
-      -e '/function peon;.*peon\.sh/d' \
-      "$FISH_CONFIG"
-    rm -f "${FISH_CONFIG}.bak"
+      -e '/function peon;.*peon\.sh/d'
     echo "Cleaned peon-ping lines from config.fish"
   fi
 fi


### PR DESCRIPTION
Two defects in `uninstall.sh`, both observed during a real uninstall on macOS with a symlinked dotfiles setup.

## 1. rc-file cleanup fails on symlinked rc files

The shell-alias/completion cleanup runs `sed -i.bak` directly on `~/.zshrc` (and `~/.bashrc`, and the fish config). When the rc file is a **symlink** — the classic dotfiles layout where `~/.zshrc` points into a managed repo — BSD sed exits 1 with:

```
sed: /Users/.../.zshrc: in-place editing only works for regular files
```

Under `set -euo pipefail` that aborts the uninstall step, leaving peon's alias/completion lines behind.

**Fix:** a small `_delete_lines` helper filters the file through a temp file and copies the content back with a redirect (`cat "$tmp" > "$file"`), which follows the symlink and preserves both the symlink and its target. Works for regular files and symlinks, and on both BSD and GNU sed. Applied to the `.zshrc`/`.bashrc` loop and the fish config block.

## 2. Hook-removal matcher misses `hook-handle-rename.sh`

`install.sh` registers **both** `hook-handle-use.sh` and `hook-handle-rename.sh` (UserPromptSubmit) into Claude Code `settings.json` (lines 1246-1247) and `~/.cursor/hooks.json` (lines 1323-1324). The uninstaller's matcher only recognised `peon.sh` and `hook-handle-use.sh`, so after uninstall the `hook-handle-rename.sh` script file is deleted but its registration survives — a dead hook that fires on every prompt.

**Fix:** the matcher now keys on the `hook-handle-` prefix (both the settings.json and the Cursor path), covering `hook-handle-use.sh`, `hook-handle-rename.sh`, and any future `hook-handle-*.sh`. These are peon-specific names, so this stays as safe as the previous literal match; the `notify.sh` path-qualification (generic name) is untouched.

Complements #553's note about the rename hook — that PR fixed what the rename hook logs; this one makes sure the uninstaller actually removes its registration.

## Verification

Reproduced both in isolated temp dirs (`bash -n` + `shellcheck` clean, exit 0):

**A — symlinked `.zshrc`:** baseline `sed -i.bak` fails with "in-place editing only works for regular files"; after the fix the peon lines are removed, unrelated lines kept, the file stays a symlink pointing at the same target, and no `.bak` litter is left.

**B — settings.json with `peon.sh` + `hook-handle-use.sh` + `hook-handle-rename.sh` plus a sibling tool's hook:** pre-fix run leaves the `hook-handle-rename.sh` registration behind (bug confirmed); post-fix run removes all three peon entries, the sibling tool's hook survives, and the JSON stays valid.

## Regression tests

Added two bats tests to `tests/install.bats` (the file where the existing uninstall coverage lives):

- **`uninstall cleans a symlinked rc file and preserves the symlink`** — dotfiles-style `~/.zshrc` symlink, real install → uninstall; asserts the symlink and its target survive, peon lines are removed, unrelated content is kept. CI runs on macOS, so this exercises BSD sed — the environment where the old in-place edit fails.
- **`uninstall removes hook-handle-rename registrations from settings and Cursor`** — install with `~/.cursor` present registers both handlers; asserts uninstall strips every `hook-handle-*` registration from `settings.json` and `~/.cursor/hooks.json`.

Both fail against the pre-fix `uninstall.sh` and pass with the fix; the full `install.bats` suite is green (70/70).
