### PR TITLE
Fix overlay subtitle rendering + tmux-aware focus and click-to-pane

### DIFF
--- a/peon.sh
+++ b/peon.sh
@@ -1050,7 +1050,36 @@ send_notification() {
 }
 
 # --- Platform-aware terminal focus check ---
+# Returns 0 if the agent's own tmux pane is the one currently on screen
+# (active pane, active window, attached session); 1 if it's in a background
+# tmux window/pane or a detached session. No-op (returns 0) outside tmux or
+# when the state can't be determined, so callers fall through to app checks.
+_tmux_pane_is_current() {
+  [ -n "${TMUX:-}" ] || return 0
+  local pane info attached window_active pane_active
+  pane="${TMUX_PANE:-}"
+  if [ -n "$pane" ]; then
+    info=$(tmux display-message -p -t "$pane" '#{session_attached} #{window_active} #{pane_active}' 2>/dev/null || true)
+  else
+    info=$(tmux display-message -p '#{session_attached} #{window_active} #{pane_active}' 2>/dev/null || true)
+  fi
+  [ -z "$info" ] && return 0
+  attached=$(printf '%s\n' "$info" | awk '{print $1}')
+  window_active=$(printf '%s\n' "$info" | awk '{print $2}')
+  pane_active=$(printf '%s\n' "$info" | awk '{print $3}')
+  if [ "${attached:-0}" -ge 1 ] 2>/dev/null && [ "$window_active" = "1" ] && [ "$pane_active" = "1" ]; then
+    return 0
+  fi
+  return 1
+}
+
 terminal_is_focused() {
+  # tmux-aware short-circuit: if this agent's pane isn't the one on screen
+  # (background window/pane or detached session), treat as NOT focused so the
+  # notification fires regardless of which terminal app is frontmost.
+  if [ -n "${TMUX:-}" ] && ! _tmux_pane_is_current; then
+    return 1
+  fi
   case "$PEON_PLATFORM" in
     mac)
       local frontmost

--- a/scripts/mac-overlay.js
+++ b/scripts/mac-overlay.js
@@ -129,43 +129,16 @@ function run(argv) {
               return;
             }
 
-            if (clickCommand) {
-              activateBundle(bundleId);
-              runClickCommand(clickCommand);
-              $.NSDistributedNotificationCenter.defaultCenter.postNotificationNameObject($(dismissNotificationName), $.NSString.string);
-              $.NSTimer.scheduledTimerWithTimeIntervalTargetSelectorUserInfoRepeats(
-                0.05, $.NSApp, 'terminate:', null, false
-              );
-              return;
-            }
-
-            // iTerm2: raise the specific window containing our session
-            if (sessionTty && bundleId === 'com.googlecode.iterm2') {
-              var task = $.NSTask.alloc.init;
-              task.setLaunchPath($('/usr/bin/osascript'));
-              task.setArguments($(['-l', 'JavaScript', '-e',
-                'var iTerm=Application("iTerm2");var ws=iTerm.windows();var f=0;' +
-                'for(var w=0;w<ws.length&&!f;w++){var ts=ws[w].tabs();' +
-                'for(var t=0;t<ts.length&&!f;t++){var ss=ts[t].sessions();' +
-                'for(var s=0;s<ss.length&&!f;s++){try{if(ss[s].tty()==="' + sessionTty + '")' +
-                '{ts[t].select();ss[s].select();var wn=ws[w].name();' +
-                'var se=Application("System Events");var sw=se.processes["iTerm2"].windows();' +
-                'for(var i=0;i<sw.length;i++){try{if(sw[i].name()===wn){sw[i].actions["AXRaise"].perform();break}}catch(e2){}}' +
-                'ws[w].index=1;iTerm.activate();f=1}}catch(e){}}}}'
-              ]));
-              task.launch;
-              task.waitUntilExit;
-              // Signal ALL sibling overlays to dismiss (event-driven, no polling!)
-              $.NSDistributedNotificationCenter.defaultCenter.postNotificationNameObject($(dismissNotificationName), $.NSString.string);
-              // Small delay to ensure notification is delivered before we terminate
-              $.NSTimer.scheduledTimerWithTimeIntervalTargetSelectorUserInfoRepeats(
-                0.05, $.NSApp, 'terminate:', null, false
-              );
-              return;
-            }
-            // activateWithOptions() won't cross Spaces from this accessory-policy
-            // process; Warp's deep link does, and also selects the exact tab.
-            // Fall back to AppleScript activate (app + Space, no tab) on older Warp.
+            // non-cmux: activate the terminal app, raise the tab hosting our
+            // session, THEN run any custom focus command (e.g. tmux
+            // select-window/select-pane) last — so tmux switches to the
+            // agent's pane after the correct terminal tab is already up.
+            var activated = false;
+            // Warp: activateWithOptions() won't cross Spaces from this
+            // accessory-policy process; Warp's deep link does, and also selects
+            // the exact tab. Fall back to AppleScript activate (app + Space, no
+            // tab) on older Warp. Don't return, so a custom click command (tmux)
+            // still runs last, same as every other terminal.
             if (bundleId === 'dev.warp.Warp-Stable') {
               var warpTask = $.NSTask.alloc.init;
               if (warpFocusUrl) {
@@ -177,15 +150,9 @@ function run(argv) {
               }
               warpTask.launch;
               warpTask.waitUntilExit;
-              $.NSDistributedNotificationCenter.defaultCenter.postNotificationNameObject($(dismissNotificationName), $.NSString.string);
-              $.NSTimer.scheduledTimerWithTimeIntervalTargetSelectorUserInfoRepeats(
-                0.05, $.NSApp, 'terminate:', null, false
-              );
-              return;
+              activated = true;
             }
-            var activated = false;
-            // Primary: activate by bundle ID
-            if (bundleId) activated = activateBundle(bundleId);
+            if (!activated && bundleId) activated = activateBundle(bundleId);
             // Fallback: activate by IDE PID (for embedded terminals)
             if (!activated && idePid > 0) {
               var ideApp = $.NSRunningApplication.runningApplicationWithProcessIdentifier(idePid);
@@ -193,23 +160,30 @@ function run(argv) {
                 ideApp.activateWithOptions($.NSApplicationActivateIgnoringOtherApps);
               }
             }
-            // iTerm2: try tab/window-level focus after app activation (fire-and-forget)
+            // iTerm2: raise the specific window/tab hosting our session (by tty)
             if (sessionTty && bundleId === 'com.googlecode.iterm2') {
               try {
-                var task = $.NSTask.alloc.init;
-                task.setLaunchPath($('/usr/bin/osascript'));
-                task.setArguments($(['-l', 'JavaScript', '-e',
+                var itask = $.NSTask.alloc.init;
+                itask.setLaunchPath($('/usr/bin/osascript'));
+                itask.setArguments($(['-l', 'JavaScript', '-e',
                   'var iTerm=Application("iTerm2");var ws=iTerm.windows();var f=0;' +
                   'for(var w=0;w<ws.length&&!f;w++){var ts=ws[w].tabs();' +
                   'for(var t=0;t<ts.length&&!f;t++){var ss=ts[t].sessions();' +
                   'for(var s=0;s<ss.length&&!f;s++){try{if(ss[s].tty()==="' + sessionTty + '")' +
-                  '{ts[t].select();ss[s].select();ws[w].index=1;f=1}}catch(e){}}}}'
+                  '{ts[t].select();ss[s].select();var wn=ws[w].name();' +
+                  'var se=Application("System Events");var sw=se.processes["iTerm2"].windows();' +
+                  'for(var i=0;i<sw.length;i++){try{if(sw[i].name()===wn){sw[i].actions["AXRaise"].perform();break}}catch(e2){}}' +
+                  'ws[w].index=1;iTerm.activate();f=1}}catch(e){}}}}'
                 ]));
-                task.launch;
+                itask.launch;
+                itask.waitUntilExit;
               } catch(e) {}
             }
+            // Custom focus command — e.g. `tmux select-window/select-pane` to
+            // jump to the agent's OWN pane, which app/tab focus can't reach.
+            if (clickCommand) runClickCommand(clickCommand);
 
-            // Signal ALL sibling overlays to dismiss
+            // Signal ALL sibling overlays to dismiss (event-driven, no polling)
             $.NSDistributedNotificationCenter.defaultCenter.postNotificationNameObject($(dismissNotificationName), $.NSString.string);
             // Small delay to ensure notification is delivered before we terminate
             $.NSTimer.scheduledTimerWithTimeIntervalTargetSelectorUserInfoRepeats(

--- a/scripts/mac-overlay.js
+++ b/scripts/mac-overlay.js
@@ -326,12 +326,40 @@ function run(argv) {
       }
     }
 
-    // Message label — vertically centered
-    var font = $.NSFont.boldSystemFontOfSize(16);
-    var textHeight = font.ascender - font.descender + font.leading + 4;
-    var textY = (winHeight - textHeight) / 2;
+    // Message label(s). When a subtitle is supplied (argv[8]), stack the
+    // title on top and the subtitle below; otherwise render a single,
+    // vertically-centered line (original behavior).
+    var hasSubtitle = subtitle && subtitle.length > 0;
+    var titleFont = $.NSFont.boldSystemFontOfSize(16);
+    var titleHeight = titleFont.ascender - titleFont.descender + titleFont.leading + 4;
+
+    var titleY;
+    if (hasSubtitle) {
+      var subFont = $.NSFont.systemFontOfSize(12);
+      var subHeight = subFont.ascender - subFont.descender + subFont.leading + 4;
+      var gap = 2;
+      var blockBottom = (winHeight - (titleHeight + gap + subHeight)) / 2;
+      titleY = blockBottom + subHeight + gap; // title above subtitle
+      var subLabel = $.NSTextField.alloc.initWithFrame(
+        $.NSMakeRect(textX, blockBottom, textWidth, subHeight)
+      );
+      subLabel.setStringValue($(subtitle));
+      subLabel.setBezeled(false);
+      subLabel.setDrawsBackground(false);
+      subLabel.setEditable(false);
+      subLabel.setSelectable(false);
+      subLabel.setTextColor($.NSColor.colorWithSRGBRedGreenBlueAlpha(1, 1, 1, 0.85));
+      subLabel.setAlignment($.NSTextAlignmentCenter);
+      subLabel.setFont(subFont);
+      subLabel.setLineBreakMode($.NSLineBreakByTruncatingTail);
+      subLabel.cell.setWraps(false);
+      contentView.addSubview(subLabel);
+    } else {
+      titleY = (winHeight - titleHeight) / 2;
+    }
+
     var label = $.NSTextField.alloc.initWithFrame(
-      $.NSMakeRect(textX, textY, textWidth, textHeight)
+      $.NSMakeRect(textX, titleY, textWidth, titleHeight)
     );
     label.setStringValue($(message));
     label.setBezeled(false);
@@ -340,7 +368,7 @@ function run(argv) {
     label.setSelectable(false);
     label.setTextColor($.NSColor.whiteColor);
     label.setAlignment($.NSTextAlignmentCenter);
-    label.setFont(font);
+    label.setFont(titleFont);
     label.setLineBreakMode($.NSLineBreakByTruncatingTail);
     label.cell.setWraps(false);
     contentView.addSubview(label);

--- a/scripts/notify.sh
+++ b/scripts/notify.sh
@@ -307,6 +307,18 @@ case "$PEON_PLATFORM" in
     if [ -z "$click_command" ]; then
       click_command="$(_cmux_click_command "$cmux_focus_helper" "$cmux_cli" "$cmux_socket_path" "$cmux_workspace_id" "$cmux_surface_id")" || true
     fi
+    # Inside tmux, clicking the overlay must also switch tmux to the agent's own
+    # window/pane — activating the terminal app alone lands on whatever tmux
+    # window was last active. Build a focus command (explicit -S socket so it
+    # works from the overlay's detached env) targeting this agent's pane. Tried
+    # before the generic terminal-window focus below, since the overlay already
+    # raises the hosting terminal window natively and the pane switch is the
+    # part that only tmux can do.
+    if [ -z "$click_command" ] && [ -n "${TMUX:-}" ] && [ -n "${TMUX_PANE:-}" ] && command -v tmux >/dev/null 2>&1; then
+      _pp_tsock=$(printf '%q' "${TMUX%%,*}")
+      _pp_tpane=$(printf '%q' "$TMUX_PANE")
+      click_command="tmux -S $_pp_tsock switch-client -t $_pp_tpane 2>/dev/null; tmux -S $_pp_tsock select-window -t $_pp_tpane 2>/dev/null; tmux -S $_pp_tsock select-pane -t $_pp_tpane 2>/dev/null"
+    fi
     if [ -z "$click_command" ]; then
       click_command="$(_terminal_focus_click_command "$bundle_id" "${PEON_SESSION_TTY:-}")" || true
       # The overlay focuses iTerm2 sessions natively but cannot derive an IDE


### PR DESCRIPTION
Three related fixes to the macOS overlay / focus path, each in its own commit so they can be reviewed (or split) independently.

### 1. `fix(overlay): render the subtitle argument (was silently dropped)`
`scripts/mac-overlay.js` accepts a `subtitle` positional arg (argv[8]) — documented in the usage comment and populated by `notify.sh` — but never created a text view for it. The only label drawn is `message` (argv[0]). So any notification whose body lives in the subtitle (e.g. a `{summary}` stop template, where notify.sh puts the project name in the main label and the message in the subtitle) silently loses its body text; you get just the title + the "click to focus" hint. Fix renders the subtitle as a second, smaller stacked line below the title; layout is unchanged when there's no subtitle.

### 2. `fix(focus): make terminal_is_focused tmux-pane aware`
`terminal_is_focused` decides focus purely at the terminal-app level. Inside tmux one surface multiplexes many panes/windows and `PEON_SESSION_TTY` resolves to the shared `#{client_tty}`, so an agent finishing in a **background tmux window** or a **detached session** is treated as "focused" and its notification is suppressed. Adds `_tmux_pane_is_current()` (checks `#{session_attached}` / `#{window_active}` / `#{pane_active}` for the agent's own `$TMUX_PANE`) and a short-circuit: when `$TMUX` is set and the pane isn't the one on screen, return not-focused so the notification fires. No-op outside tmux or when the state can't be read (falls through to the existing app-level logic).

### 3. `feat(click): focus the agent's own tmux pane on overlay click`
Under tmux, clicking the overlay activated the terminal app (and raised the iTerm2 tab by tty) but never ran `tmux select-window`/`select-pane`, so it landed on whatever tmux window was last active. `notify.sh` now builds a focus command targeting the agent's pane (`switch-client` → `select-window` → `select-pane`, with an explicit `-S <socket>` so it works from the overlay's detached env). `mac-overlay.js`'s click handler previously ran a custom `clickCommand` as an exclusive early-return that skipped the iTerm2 tab-raise; it's restructured to activate the app, raise the iTerm2 tab, **then** run the focus command last (and de-duplicates the two near-identical iTerm2 blocks).

---

Backward compatible: no behavior change outside tmux / when there's no subtitle. Verified locally on macOS + iTerm2 + tmux (summary now shows in the toast; background-window notifications fire; clicking jumps to the agent's pane).
