### PR TITLE
Focus the exact terminal window when a standard notification is clicked (macOS)

### DIFF
--- a/scripts/notify.sh
+++ b/scripts/notify.sh
@@ -11,6 +11,7 @@
 #   PEON_BUNDLE_ID      macOS terminal bundle ID for click-to-focus (empty = skip)
 #   PEON_IDE_PID        macOS IDE ancestor PID for click-to-focus (empty = skip)
 #   PEON_CMUX_*         cmux workspace/surface/socket/CLI for exact click-to-focus
+#   PEON_SESSION_TTY    session tty for iTerm2 exact tab/window click-to-focus
 #   PEON_NOTIF_POSITION notification position: top-center|top-right|top-left|bottom-right|bottom-left|bottom-center
 #   PEON_NOTIF_DISMISS  dismiss time in seconds (0 = persistent until clicked)
 #   TERM_PROGRAM        Terminal emulator name (for iTerm2/Kitty escape sequences)
@@ -143,6 +144,46 @@ _cmux_click_command() {
   printf '%s\n' "${click_command% }"
 }
 
+# Build a click command that focuses the exact window the session lives in,
+# rather than just activating the app (with several windows open, -activate
+# lands on whichever was focused last, not the one that pinged). Used when no
+# cmux target or explicit PEON_CLICK_COMMAND is set.
+#   iTerm2:         select the tab/session whose tty matches PEON_SESSION_TTY
+#                   (same approach as the overlay's session focus)
+#   VS Code family: `open -b <bundle> <workspace dir>` raises the window that
+#                   has the workspace open. VS Code, Cursor, and Windsurf all
+#                   set TERM_PROGRAM=vscode; the caller has already resolved
+#                   the running IDE's bundle id. Uses the git toplevel as the
+#                   workspace dir (the hook cwd may be a subdirectory, which
+#                   would open a new window instead of focusing the existing
+#                   one), falling back to the cwd outside a repo.
+_terminal_focus_click_command() {
+  local bundle_id="$1"
+  local session_tty="$2"
+  local focus_dir jxa
+
+  if [ "$bundle_id" = "com.googlecode.iterm2" ] && [ -n "$session_tty" ]; then
+    jxa='function run(argv){var tty=argv[0];var iTerm=Application("iTerm2");var ws=iTerm.windows();'
+    jxa+='for(var w=0;w<ws.length;w++){var ts=ws[w].tabs();'
+    jxa+='for(var t=0;t<ts.length;t++){var ss=ts[t].sessions();'
+    jxa+='for(var s=0;s<ss.length;s++){try{if(ss[s].tty()===tty)'
+    jxa+='{ts[t].select();ss[s].select();ws[w].index=1;iTerm.activate();return}}catch(e){}}}}'
+    jxa+='iTerm.activate()}'
+    printf '/usr/bin/osascript -l JavaScript -e %q %q' "$jxa" "$session_tty"
+    return 0
+  fi
+
+  if [ "${TERM_PROGRAM:-}" = "vscode" ] && [ -n "$bundle_id" ]; then
+    focus_dir="$(git rev-parse --show-toplevel 2>/dev/null)" || focus_dir=""
+    [ -n "$focus_dir" ] || focus_dir="$PWD"
+    [ -d "$focus_dir" ] || return 1
+    printf '/usr/bin/open -b %q %q' "$bundle_id" "$focus_dir"
+    return 0
+  fi
+
+  return 1
+}
+
 _cmux_notify() {
   local cmux_cli="$1"
   local cmux_workspace_id="$2"
@@ -264,6 +305,15 @@ case "$PEON_PLATFORM" in
     cmux_focus_helper="$(_find_cmux_focus_helper)" 2>/dev/null || true
     if [ -z "$click_command" ]; then
       click_command="$(_cmux_click_command "$cmux_focus_helper" "$cmux_cli" "$cmux_socket_path" "$cmux_workspace_id" "$cmux_surface_id")" || true
+    fi
+    if [ -z "$click_command" ]; then
+      click_command="$(_terminal_focus_click_command "$bundle_id" "${PEON_SESSION_TTY:-}")" || true
+      # The overlay focuses iTerm2 sessions natively but cannot derive an IDE
+      # window target itself; hand it the command via the env passthrough it
+      # already honors.
+      if [ -n "$click_command" ] && [ -z "${PEON_CLICK_COMMAND:-}" ] && [ "$bundle_id" != "com.googlecode.iterm2" ]; then
+        export PEON_CLICK_COMMAND="$click_command"
+      fi
     fi
     _notify_debug "mac overlay_script=$(printf '%q' "$overlay_script") bundle=$(printf '%q' "$bundle_id") click_command=$(printf '%q' "$click_command") workspace=$(printf '%q' "$cmux_workspace_id") surface=$(printf '%q' "$cmux_surface_id")"
     if [ -n "$overlay_script" ]; then

--- a/tests/mac-overlay.bats
+++ b/tests/mac-overlay.bats
@@ -288,6 +288,53 @@ json.dump(c, open('$TEST_DIR/config.json', 'w'))
   ! [[ "$(terminal_notifier_log)" == *"-activate"* ]]
 }
 
+@test "standard: iTerm2 exact session focus via -execute when session tty known" {
+  # TERM_PROGRAM empty models tmux-inside-iTerm / detached contexts, where
+  # the bundle id comes from the ITERM_SESSION_ID fallback and the OSC 9
+  # escape path is unavailable.
+  local notify_script="$TEST_DIR/scripts/notify.sh"
+  TERM_PROGRAM="" PEON_PLATFORM=mac PEON_NOTIF_STYLE=standard PEON_SYNC=1 \
+    PEON_BUNDLE_ID="com.googlecode.iterm2" PEON_SESSION_TTY="/dev/ttys042" \
+    bash "$notify_script" "test msg" "test title" "blue" ""
+  [ -f "$TEST_DIR/terminal_notifier.log" ]
+  [[ "$(terminal_notifier_log)" == *"-execute"* ]]
+  [[ "$(terminal_notifier_log)" == *"osascript"* ]]
+  [[ "$(terminal_notifier_log)" == *"ttys042"* ]]
+}
+
+@test "standard: no -execute for iTerm2 when session tty unknown" {
+  local notify_script="$TEST_DIR/scripts/notify.sh"
+  TERM_PROGRAM="" PEON_PLATFORM=mac PEON_NOTIF_STYLE=standard PEON_SYNC=1 \
+    PEON_BUNDLE_ID="com.googlecode.iterm2" PEON_SESSION_TTY="" \
+    bash "$notify_script" "test msg" "test title" "blue" ""
+  [ -f "$TEST_DIR/terminal_notifier.log" ]
+  [[ "$(terminal_notifier_log)" == *"-activate"* ]]
+  ! [[ "$(terminal_notifier_log)" == *"-execute"* ]]
+}
+
+@test "standard: VS Code family window focus via open -b with workspace dir" {
+  local notify_script="$TEST_DIR/scripts/notify.sh"
+  cd "$TEST_DIR"  # not a git repo, so the workspace dir falls back to cwd
+  TERM_PROGRAM=vscode PEON_PLATFORM=mac PEON_NOTIF_STYLE=standard PEON_SYNC=1 \
+    PEON_BUNDLE_ID="com.microsoft.VSCode" \
+    bash "$notify_script" "test msg" "test title" "blue" ""
+  [ -f "$TEST_DIR/terminal_notifier.log" ]
+  [[ "$(terminal_notifier_log)" == *"-execute"* ]]
+  [[ "$(terminal_notifier_log)" == *"/usr/bin/open -b com.microsoft.VSCode"* ]]
+  [[ "$(terminal_notifier_log)" == *"$TEST_DIR"* ]]
+}
+
+@test "standard: cmux click command takes precedence over terminal focus fallback" {
+  local notify_script="$TEST_DIR/scripts/notify.sh"
+  PEON_PLATFORM=mac PEON_NOTIF_STYLE=standard PEON_SYNC=1 \
+    PEON_BUNDLE_ID="com.googlecode.iterm2" PEON_SESSION_TTY="/dev/ttys042" \
+    PEON_CLICK_COMMAND="/usr/local/bin/custom-focus arg1" \
+    bash "$notify_script" "test msg" "test title" "blue" ""
+  [ -f "$TEST_DIR/terminal_notifier.log" ]
+  [[ "$(terminal_notifier_log)" == *"custom-focus"* ]]
+  ! [[ "$(terminal_notifier_log)" == *"osascript"* ]]
+}
+
 # ============================================================
 # Standard mode fallback
 # ============================================================


### PR DESCRIPTION
## Problem

Standard (Notification Center) banners pass only `-activate <bundle-id>` to terminal-notifier. Activating the app raises whichever of its windows was focused last, so with several iTerm windows or several IDE windows open, clicking a notification does not land on the session that pinged. The overlay already solves this for iTerm2 sessions; standard mode and IDE windows have no equivalent.

## Change

Adds a `_terminal_focus_click_command` fallback in `scripts/notify.sh`, used only when no cmux target or explicit `PEON_CLICK_COMMAND` is set:

- **iTerm2**: an osascript that selects the tab/session whose tty matches `PEON_SESSION_TTY` and raises its window (same approach as the overlay's session focus). This applies where the `*` dispatch branch runs, e.g. tmux inside iTerm and detached contexts that resolve the bundle id from `ITERM_SESSION_ID`; the OSC 9 escape path for plain `TERM_PROGRAM=iTerm.app` is unchanged.
- **VS Code family** (VS Code, Cursor, Windsurf; all set `TERM_PROGRAM=vscode`): `open -b <bundle> <workspace dir>`, which raises the window that has the workspace open. The git toplevel is used as the workspace dir so hooks fired from a subdirectory still match the window, falling back to the cwd outside a repo.

The command is wired to terminal-notifier via `-execute`, and exported as `PEON_CLICK_COMMAND` for the IDE case so the default overlay's click handler (which already honors that env var) gains exact IDE window focus as well.

## Behavior notes

- The first click triggers a one-time macOS Automation prompt (terminal-notifier controlling iTerm2). Declining leaves the existing `-activate` app-level behavior.
- If the workspace folder is not open in any IDE window, `open -b` opens a new window for it, the same as `code <folder>`.

## Testing

- Five new bats tests in `tests/mac-overlay.bats` covering the iTerm command, the no-tty fallback, the VS Code command, and cmux/custom command precedence. All 86 tests in the file pass locally on macOS.
- Manually verified on macOS 26 with iTerm2: the generated command selects exactly the session whose tty matches among multiple windows, and `open -b` raises the IDE window that has the folder open.