### PR TITLE
fix(codex): prevent dangling hooks from interrupting sessions

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -3804,8 +3804,9 @@ if ((-not $Local) -and (Test-Path $CodexDir)) {
 
     function Get-PeonCodexAdapterMarkers([string]$InstallRoot) {
         $markers = New-Object System.Collections.Generic.List[string]
+        $normalizedRoot = Normalize-PeonCodexPath $InstallRoot
         foreach ($adapterName in @("codex.ps1", "codex.sh")) {
-            $adapterPath = Join-Path (Join-Path $InstallRoot "adapters") $adapterName
+            $adapterPath = "$normalizedRoot/adapters/$adapterName"
             foreach ($marker in (Get-PeonCodexMarkers $adapterPath)) {
                 $markers.Add($marker)
             }
@@ -3886,17 +3887,79 @@ if ((-not $Local) -and (Test-Path $CodexDir)) {
     }
 
     function Remove-PeonCodexConfigText([string]$Content, [string]$InstallRoot) {
-        $managedPattern = '(?ms)\r?\n?# peon-ping Codex hooks begin.*?# peon-ping Codex hooks end\r?\n?'
-        $contentWithoutBlocks = ([regex]$managedPattern).Replace($Content, {
-            param($match)
-            if (Test-PeonCodexTextForInstall $match.Value $InstallRoot) { "`n" } else { $match.Value }
-        })
-
-        $lines = @($contentWithoutBlocks -split "\r?\n")
+        if ([string]::IsNullOrEmpty($Content)) { return "" }
+        $newline = if ($Content.Contains("`r`n")) { "`r`n" } else { "`n" }
+        $lines = @($Content -split "\r?\n")
+        $structuralLine = New-Object 'bool[]' $lines.Count
+        $multilineDelimiter = ""
+        for ($lineIndex = 0; $lineIndex -lt $lines.Count; $lineIndex++) {
+            $structuralLine[$lineIndex] = -not $multilineDelimiter
+            if ($multilineDelimiter) {
+                if ($lines[$lineIndex].Contains($multilineDelimiter)) { $multilineDelimiter = "" }
+                continue
+            }
+            if ($lines[$lineIndex].TrimStart().StartsWith('#')) { continue }
+            foreach ($delimiter in @('"""', "'''")) {
+                $delimiterCount = ([regex]::Matches($lines[$lineIndex], [regex]::Escape($delimiter))).Count
+                if (($delimiterCount % 2) -eq 1) {
+                    $multilineDelimiter = $delimiter
+                    break
+                }
+            }
+        }
         $kept = New-Object System.Collections.Generic.List[string]
         for ($i = 0; $i -lt $lines.Count; $i++) {
             $line = $lines[$i]
-            if ($line.Trim() -match '^notify\s*=') {
+            $parentMatch = if ($structuralLine[$i]) {
+                [regex]::Match($line, '^\s*\[\[hooks\.([^\.\]]+)\]\]\s*(?:#.*)?$')
+            } else { [System.Text.RegularExpressions.Match]::Empty }
+            if ($parentMatch.Success) {
+                $eventName = $parentMatch.Groups[1].Value
+                $parentLines = New-Object System.Collections.Generic.List[string]
+                $parentLines.Add($line)
+                while (($i + 1) -lt $lines.Count -and
+                    ((-not $structuralLine[$i + 1]) -or $lines[$i + 1] -notmatch '^\s*\[\[?[^\]]+\]\]?') -and
+                    $lines[$i + 1].Trim() -notin @('# peon-ping Codex hooks begin', '# peon-ping Codex hooks end')) {
+                    $i++
+                    $parentLines.Add($lines[$i])
+                }
+
+                $childBlocks = New-Object System.Collections.Generic.List[object]
+                while (($i + 1) -lt $lines.Count -and
+                    $structuralLine[$i + 1] -and
+                    $lines[$i + 1] -match "^\s*\[\[hooks\.$([regex]::Escape($eventName))\.hooks\]\]\s*(?:#.*)?$") {
+                    $i++
+                    $childLines = New-Object System.Collections.Generic.List[string]
+                    $childLines.Add($lines[$i])
+                    while (($i + 1) -lt $lines.Count -and
+                        ((-not $structuralLine[$i + 1]) -or $lines[$i + 1] -notmatch '^\s*\[\[?[^\]]+\]\]?') -and
+                        $lines[$i + 1].Trim() -notin @('# peon-ping Codex hooks begin', '# peon-ping Codex hooks end')) {
+                        $i++
+                        $childLines.Add($lines[$i])
+                    }
+                    $childBlocks.Add(@($childLines))
+                }
+
+                $remainingChildren = New-Object System.Collections.Generic.List[object]
+                $removedChild = $false
+                foreach ($childBlock in $childBlocks) {
+                    $childText = @($childBlock | Where-Object {
+                        $_.Trim() -match '^command(?:_windows|Windows)?\s*='
+                    }) -join $newline
+                    if (Test-PeonCodexTextForInstall $childText $InstallRoot) {
+                        $removedChild = $true
+                    } else {
+                        $remainingChildren.Add($childBlock)
+                    }
+                }
+
+                if ((-not $removedChild) -or $remainingChildren.Count -gt 0) {
+                    foreach ($parentLine in $parentLines) { $kept.Add($parentLine) }
+                    foreach ($childBlock in $remainingChildren) {
+                        foreach ($childLine in $childBlock) { $kept.Add($childLine) }
+                    }
+                }
+            } elseif ($line.Trim() -match '^notify\s*=') {
                 $blockLines = New-Object System.Collections.Generic.List[string]
                 $blockLines.Add($line)
                 $balance = Get-PeonTomlBracketDelta $line
@@ -3914,13 +3977,81 @@ if ((-not $Local) -and (Test-Path $CodexDir)) {
                 $kept.Add($line)
             }
         }
-        return ($kept -join "`n").TrimEnd()
+
+        # Codex may append its own tables before our legacy end marker. Remove
+        # only the marker lines for this install root, never the content between.
+        $markerStructuralLine = New-Object 'bool[]' $kept.Count
+        $multilineDelimiter = ""
+        for ($lineIndex = 0; $lineIndex -lt $kept.Count; $lineIndex++) {
+            $markerStructuralLine[$lineIndex] = -not $multilineDelimiter
+            if ($multilineDelimiter) {
+                if ($kept[$lineIndex].Contains($multilineDelimiter)) { $multilineDelimiter = "" }
+                continue
+            }
+            if ($kept[$lineIndex].TrimStart().StartsWith('#')) { continue }
+            foreach ($delimiter in @('"""', "'''")) {
+                $delimiterCount = ([regex]::Matches($kept[$lineIndex], [regex]::Escape($delimiter))).Count
+                if (($delimiterCount % 2) -eq 1) {
+                    $multilineDelimiter = $delimiter
+                    break
+                }
+            }
+        }
+        $withoutMarkers = New-Object System.Collections.Generic.List[string]
+        $insideTargetMarkers = $false
+        for ($i = 0; $i -lt $kept.Count; $i++) {
+            $line = $kept[$i]
+            if ($markerStructuralLine[$i] -and $line.Trim() -eq '# peon-ping Codex hooks begin') {
+                $next = $i + 1
+                while ($next -lt $kept.Count -and [string]::IsNullOrWhiteSpace($kept[$next])) { $next++ }
+                $markerInstallDir = if ($next -lt $kept.Count) {
+                    Get-PeonCodexBlockInstallDir ("$line$newline$($kept[$next])")
+                } else { "" }
+                $isTargetMarker = $false
+                foreach ($installMarker in (Get-PeonCodexMarkers $InstallRoot)) {
+                    if ([string]::Equals($markerInstallDir, $installMarker, [System.StringComparison]::OrdinalIgnoreCase)) {
+                        $isTargetMarker = $true
+                        break
+                    }
+                }
+                if ($isTargetMarker) {
+                    $insideTargetMarkers = $true
+                    while (($i + 1) -lt $next) { $i++ }
+                    $i = $next
+                    continue
+                }
+            }
+            if ($insideTargetMarkers -and $markerStructuralLine[$i] -and $line.Trim() -eq '# peon-ping Codex hooks end') {
+                $insideTargetMarkers = $false
+                continue
+            }
+            $withoutMarkers.Add($line)
+        }
+        return ($withoutMarkers -join $newline).TrimEnd("`r", "`n")
+    }
+
+    function Set-PeonCodexConfigAtomic([string]$Path, [string]$Content) {
+        $directory = Split-Path -Parent $Path
+        $leaf = Split-Path -Leaf $Path
+        $tempPath = Join-Path $directory ".$leaf.peon-ping-$PID-$([guid]::NewGuid().ToString('N')).tmp"
+        $backupPath = "$tempPath.backup"
+        try {
+            Set-Content -Path $tempPath -Value $Content -Encoding UTF8
+            if (Test-Path $Path) {
+                [System.IO.File]::Replace($tempPath, $Path, $backupPath)
+            } else {
+                Move-Item -Path $tempPath -Destination $Path
+            }
+        } finally {
+            Remove-Item -Path $tempPath -Force -ErrorAction SilentlyContinue
+            Remove-Item -Path $backupPath -Force -ErrorAction SilentlyContinue
+        }
     }
 
     $codexAdapterPath = Join-Path $InstallDir "adapters\codex.ps1"
     $installDirLiteral = ConvertTo-PowerShellSingleQuotedString $InstallDir
     $adapterLiteral = ConvertTo-PowerShellSingleQuotedString $codexAdapterPath
-    $codexHookCommand = "powershell -NoProfile -NonInteractive -Command `"`$env:CLAUDE_PEON_DIR = $installDirLiteral; & $adapterLiteral`""
+    $codexHookCommand = "powershell -NoProfile -NonInteractive -Command `"try { `$env:CLAUDE_PEON_DIR = $installDirLiteral; if (Test-Path -LiteralPath $adapterLiteral) { `$hookInput = [Console]::In.ReadToEnd(); `$hookInput | & powershell -NoProfile -NonInteractive -File $adapterLiteral 2>`$null | Out-Null } } catch {}; exit 0`""
 
     $codexBegin = "# peon-ping Codex hooks begin"
     $codexEnd = "# peon-ping Codex hooks end"
@@ -3935,8 +4066,10 @@ if ((-not $Local) -and (Test-Path $CodexDir)) {
     )
 
     $codexContent = ""
+    $codexNewline = "`n"
     if (Test-Path $CodexConfigFile) {
         $codexContent = Get-Content $CodexConfigFile -Raw
+        if ($codexContent.Contains("`r`n")) { $codexNewline = "`r`n" }
     }
 
     $codexContent = Remove-PeonCodexConfigText $codexContent $InstallDir
@@ -3953,20 +4086,21 @@ if ((-not $Local) -and (Test-Path $CodexDir)) {
         $codexBlock.Add("[[hooks.$($evt.Name).hooks]]")
         $codexBlock.Add('type = "command"')
         $codexBlock.Add("command = $(ConvertTo-TomlBasicString $codexHookCommand)")
+        $codexBlock.Add("command_windows = $(ConvertTo-TomlBasicString $codexHookCommand)")
         $codexBlock.Add("timeout = 30")
         $codexBlock.Add("")
     }
     $codexBlock.Add($codexEnd)
 
-    $codexBlockText = $codexBlock -join "`n"
+    $codexBlockText = $codexBlock -join $codexNewline
     if ($codexContent) {
-        $codexContent = "$codexContent`n`n$codexBlockText`n"
+        $codexContent = "$codexContent$codexNewline$codexNewline$codexBlockText$codexNewline"
     } else {
-        $codexContent = "$codexBlockText`n"
+        $codexContent = "$codexBlockText$codexNewline"
     }
 
     New-Item -ItemType Directory -Path $CodexDir -Force | Out-Null
-    Set-Content -Path $CodexConfigFile -Value $codexContent -Encoding UTF8
+    Set-PeonCodexConfigAtomic $CodexConfigFile $codexContent
     Write-Host "  Codex hooks registered for: $($codexEvents.Name -join ', ')" -ForegroundColor Green
     Write-Host "  Open Codex /hooks to review and trust the peon-ping commands if prompted." -ForegroundColor Yellow
 }

--- a/install.sh
+++ b/install.sh
@@ -631,6 +631,7 @@ if [ -n "$SCRIPT_DIR" ]; then
     mkdir -p "$INSTALL_DIR/scripts"
     cp "$SCRIPT_DIR/scripts/"*.sh "$INSTALL_DIR/scripts/" 2>/dev/null || true
     cp "$SCRIPT_DIR/scripts/"*.ps1 "$INSTALL_DIR/scripts/" 2>/dev/null || true
+    cp "$SCRIPT_DIR/scripts/"*.py "$INSTALL_DIR/scripts/" 2>/dev/null || true
     cp "$SCRIPT_DIR/scripts/"*.swift "$INSTALL_DIR/scripts/" 2>/dev/null || true
     cp "$SCRIPT_DIR/scripts/"*.js "$INSTALL_DIR/scripts/" 2>/dev/null || true
   fi
@@ -669,6 +670,7 @@ else
   curl -fsSL "$REPO_BASE/adapters/eca.sh" -o "$INSTALL_DIR/adapters/eca.sh" 2>/dev/null || true
   mkdir -p "$INSTALL_DIR/scripts"
   curl -fsSL "$REPO_BASE/scripts/hook-handle-use.sh" -o "$INSTALL_DIR/scripts/hook-handle-use.sh" 2>/dev/null || true
+  curl -fsSL "$REPO_BASE/scripts/codex-config.py" -o "$INSTALL_DIR/scripts/codex-config.py"
   curl -fsSL "$REPO_BASE/scripts/hook-handle-use.ps1" -o "$INSTALL_DIR/scripts/hook-handle-use.ps1" 2>/dev/null || true
   curl -fsSL "$REPO_BASE/scripts/win-play.ps1" -o "$INSTALL_DIR/scripts/win-play.ps1" 2>/dev/null || true
   curl -fsSL "$REPO_BASE/scripts/hook-handle-rename.sh" -o "$INSTALL_DIR/scripts/hook-handle-rename.sh" 2>/dev/null || true
@@ -1465,178 +1467,19 @@ CODEX_ADAPTER="$INSTALL_DIR/adapters/codex.sh"
 if [ "$LOCAL_MODE" != true ] && [ -d "$CODEX_DIR" ]; then
   echo ""
   echo "Detected OpenAI Codex installation, registering stable hooks..."
-
-  CODEX_CONFIG_PATH="$(py_path "$CODEX_CONFIG")" \
-  CODEX_INSTALL_DIR="$(py_path "$INSTALL_DIR")" \
-  CODEX_ADAPTER_PATH="$(py_path "$CODEX_ADAPTER")" \
-  python3 <<'PY'
-import json
-import os
-import re
-import shlex
-
-config_path = os.environ['CODEX_CONFIG_PATH']
-install_dir = os.environ['CODEX_INSTALL_DIR']
-adapter_path = os.environ['CODEX_ADAPTER_PATH']
-
-begin = '# peon-ping Codex hooks begin'
-end = '# peon-ping Codex hooks end'
-events = [
-    ('SessionStart', 'startup|resume|clear'),
-    ('UserPromptSubmit', ''),
-    ('PermissionRequest', ''),
-    ('PreCompact', 'manual|auto'),
-    ('SubagentStart', ''),
-    ('SubagentStop', ''),
-    ('Stop', ''),
-]
-
-def normalize_codex_path(value):
-    value = str(value or '').strip().strip('"').strip("'")
-    value = value.replace('\\\\', '\\').replace('\\', '/')
-    return value.rstrip('/')
-
-def marker_variants(path):
-    variants = set()
-    if path:
-        variants.add(normalize_codex_path(path))
-    home = os.path.expanduser('~')
-    if path.startswith(home):
-        variants.add(normalize_codex_path('~' + path[len(home):]))
-    return {v for v in variants if v}
-
-install_markers = marker_variants(install_dir)
-adapter_markers = set()
-for adapter_name in ('codex.sh', 'codex.ps1'):
-    adapter_markers.update(marker_variants(os.path.join(install_dir, 'adapters', adapter_name)))
-
-_path_chars = set('ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789._~:/-')
-
-def text_has_path_token(text, path):
-    text = normalize_codex_path(text)
-    path = normalize_codex_path(path)
-    start = 0
-    while True:
-        idx = text.find(path, start)
-        if idx < 0:
-            return False
-        before = text[idx - 1] if idx > 0 else ''
-        after_idx = idx + len(path)
-        after = text[after_idx] if after_idx < len(text) else ''
-        before_ok = not before or before not in _path_chars
-        after_ok = not after or after not in _path_chars
-        if before_ok and after_ok:
-            return True
-        start = idx + 1
-
-def block_install_dir(text):
-    match = re.search(r'(?m)^\s*#\s*install_dir\s*=\s*(.*?)\s*$', text)
-    return normalize_codex_path(match.group(1)) if match else ''
-
-def is_current_peon_codex(text):
-    if 'peon-ping' not in text:
-        return False
-    if not re.search(r'adapters[\\/]+codex\.(sh|ps1)', text):
-        return False
-    explicit_install_dir = block_install_dir(text)
-    if explicit_install_dir:
-        return explicit_install_dir in install_markers
-    return any(text_has_path_token(text, adapter_path) for adapter_path in adapter_markers)
-
-def remove_current_managed_blocks(text):
-    def replace(match):
-        block = match.group(0)
-        return '\n' if is_current_peon_codex(block) else block
-    return re.sub(
-        r'(?ms)\n?# peon-ping Codex hooks begin.*?# peon-ping Codex hooks end\n?',
-        replace,
-        text,
-    )
-
-def bracket_delta(line):
-    delta = 0
-    quote = ''
-    escaped = False
-    for ch in line:
-        if quote:
-            if quote == '"' and escaped:
-                escaped = False
-                continue
-            if quote == '"' and ch == '\\':
-                escaped = True
-                continue
-            if ch == quote:
-                quote = ''
-            continue
-        if ch in ('"', "'"):
-            quote = ch
-        elif ch == '#':
-            break
-        elif ch == '[':
-            delta += 1
-        elif ch == ']':
-            delta -= 1
-    return delta
-
-def remove_current_legacy_notify(text):
-    lines = text.splitlines()
-    kept = []
-    i = 0
-    while i < len(lines):
-        line = lines[i]
-        stripped = line.strip()
-        if re.match(r'^notify\s*=', stripped):
-            block = [line]
-            balance = bracket_delta(line)
-            i += 1
-            while balance > 0 and i < len(lines):
-                block.append(lines[i])
-                balance += bracket_delta(lines[i])
-                i += 1
-            block_text = '\n'.join(block)
-            if is_current_peon_codex(block_text):
-                continue
-            kept.extend(block)
-            continue
-        kept.append(line)
-        i += 1
-    return '\n'.join(kept).rstrip()
-
-if os.path.exists(config_path):
-    with open(config_path) as f:
-        content = f.read()
-else:
-    content = ''
-
-content = remove_current_managed_blocks(content)
-content = remove_current_legacy_notify(content)
-
-command = 'CLAUDE_PEON_DIR={} bash {}'.format(
-    shlex.quote(install_dir),
-    shlex.quote(adapter_path),
-)
-
-block = [begin, '# install_dir = ' + install_dir]
-for event, matcher in events:
-    block.append(f'[[hooks.{event}]]')
-    if matcher:
-        block.append(f'matcher = {json.dumps(matcher)}')
-    block.append('')
-    block.append(f'[[hooks.{event}.hooks]]')
-    block.append('type = "command"')
-    block.append(f'command = {json.dumps(command)}')
-    block.append('timeout = 30')
-    block.append('')
-block.append(end)
-
-new_content = (content + '\n\n' if content else '') + '\n'.join(block) + '\n'
-os.makedirs(os.path.dirname(config_path), exist_ok=True)
-with open(config_path, 'w') as f:
-    f.write(new_content)
-
-print('Codex hooks registered for: ' + ', '.join(event for event, _ in events))
-print('Open Codex /hooks to review and trust the peon-ping commands if prompted.')
-PY
+  if [ -f "$CODEX_ADAPTER" ]; then
+    python3 "$INSTALL_DIR/scripts/codex-config.py" install \
+      --config "$CODEX_CONFIG" \
+      --install-dir "$INSTALL_DIR" \
+      --adapter "$CODEX_ADAPTER"
+    echo "Codex hooks registered for: SessionStart, UserPromptSubmit, PermissionRequest, PreCompact, SubagentStart, SubagentStop, Stop"
+    echo "Open Codex /hooks to review and trust the peon-ping commands if prompted."
+  else
+    python3 "$INSTALL_DIR/scripts/codex-config.py" clean \
+      --config "$CODEX_CONFIG" \
+      --install-dir "$INSTALL_DIR"
+    echo "Warning: Codex adapter is missing; stale peon-ping hooks were removed instead of registered."
+  fi
 fi
 
 # --- Register event hooks for Rovo Dev CLI if ~/.rovodev exists ---

--- a/scripts/codex-config.py
+++ b/scripts/codex-config.py
@@ -1,0 +1,363 @@
+#!/usr/bin/env python3
+"""Safely register and remove peon-ping's inline Codex hooks."""
+
+import argparse
+import json
+import os
+import re
+import shlex
+import stat
+import tempfile
+
+
+BEGIN_MARKER = '# peon-ping Codex hooks begin'
+END_MARKER = '# peon-ping Codex hooks end'
+EVENTS = (
+    ('SessionStart', 'startup|resume|clear'),
+    ('UserPromptSubmit', ''),
+    ('PermissionRequest', ''),
+    ('PreCompact', 'manual|auto'),
+    ('SubagentStart', ''),
+    ('SubagentStop', ''),
+    ('Stop', ''),
+)
+PATH_CHARS = set('ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789._~:/-')
+TABLE_RE = re.compile(r'^\s*(\[\[|\[)\s*(.*?)\s*(\]\]|\])\s*(?:#.*)?(?:\r?\n)?$')
+INSTALL_DIR_RE = re.compile(r'^\s*#\s*install_dir\s*=\s*(.*?)\s*(?:\r?\n)?$')
+COMMAND_RE = re.compile(r'^\s*(command|command_windows)\s*=\s*(.*?)\s*(?:\r?\n)?$')
+
+
+def normalize_path(value):
+    value = str(value or '').strip().strip('"').strip("'")
+    value = value.replace('\\\\', '\\').replace('\\', '/')
+    return value.rstrip('/')
+
+
+def path_variants(path):
+    variants = {normalize_path(path)} if path else set()
+    home = os.path.expanduser('~')
+    if path.startswith(home):
+        variants.add(normalize_path('~' + path[len(home):]))
+    return {value for value in variants if value}
+
+
+def text_has_path_token(text, path):
+    text = normalize_path(text)
+    path = normalize_path(path)
+    start = 0
+    while path:
+        index = text.find(path, start)
+        if index < 0:
+            return False
+        before = text[index - 1] if index else ''
+        after_index = index + len(path)
+        after = text[after_index] if after_index < len(text) else ''
+        if (not before or before not in PATH_CHARS) and (not after or after not in PATH_CHARS):
+            return True
+        start = index + 1
+    return False
+
+
+class CodexConfigEditor:
+    def __init__(self, install_dir):
+        self.install_dir = normalize_path(install_dir)
+        self.install_markers = path_variants(self.install_dir)
+        self.adapter_markers = set()
+        for adapter_name in ('codex.sh', 'codex.ps1'):
+            self.adapter_markers.update(
+                path_variants(os.path.join(self.install_dir, 'adapters', adapter_name))
+            )
+
+    def is_current_adapter_text(self, text):
+        if not re.search(r'adapters[\\/]+codex\.(?:sh|ps1)', text, re.IGNORECASE):
+            return False
+        return any(text_has_path_token(text, marker) for marker in self.adapter_markers)
+
+    def _remove_owned_marker_comments(self, text):
+        lines = text.splitlines(keepends=True)
+        remove = set()
+        outside_multiline = []
+        multiline_state = None
+        for line in lines:
+            outside_multiline.append(multiline_state is None)
+            multiline_state = self._advance_multiline_state(line, multiline_state)
+        begin_indexes = [
+            index
+            for index, line in enumerate(lines)
+            if outside_multiline[index] and line.strip() == BEGIN_MARKER
+        ]
+
+        for position, begin_index in enumerate(begin_indexes):
+            limit = begin_indexes[position + 1] if position + 1 < len(begin_indexes) else len(lines)
+            end_index = None
+            for index in range(begin_index + 1, limit):
+                if outside_multiline[index] and lines[index].strip() == END_MARKER:
+                    end_index = index
+                    break
+            region_end = end_index + 1 if end_index is not None else limit
+            region = ''.join(lines[begin_index:region_end])
+            explicit_install_dirs = []
+            for index in range(begin_index + 1, region_end):
+                match = INSTALL_DIR_RE.match(lines[index]) if outside_multiline[index] else None
+                if match:
+                    explicit_install_dirs.append(normalize_path(match.group(1)))
+
+            owned = any(value in self.install_markers for value in explicit_install_dirs)
+            if not owned:
+                owned = self.is_current_adapter_text(region)
+            if not owned:
+                continue
+
+            remove.add(begin_index)
+            if end_index is not None:
+                remove.add(end_index)
+            for index in range(begin_index + 1, region_end):
+                match = INSTALL_DIR_RE.match(lines[index]) if outside_multiline[index] else None
+                if match and normalize_path(match.group(1)) in self.install_markers:
+                    remove.add(index)
+
+        return ''.join(line for index, line in enumerate(lines) if index not in remove)
+
+    @staticmethod
+    def _advance_multiline_state(line, state):
+        index = 0
+        while index <= len(line) - 3:
+            if state:
+                marker = state
+                found = line.find(marker, index)
+                if found < 0:
+                    return state
+                if marker == '"""':
+                    backslashes = 0
+                    cursor = found - 1
+                    while cursor >= 0 and line[cursor] == '\\':
+                        backslashes += 1
+                        cursor -= 1
+                    if backslashes % 2:
+                        index = found + 3
+                        continue
+                state = None
+                index = found + 3
+                continue
+
+            basic = line.find('"""', index)
+            literal = line.find("'''", index)
+            candidates = [(basic, '"""'), (literal, "'''")]
+            candidates = [(found, marker) for found, marker in candidates if found >= 0]
+            if not candidates:
+                return None
+            found, marker = min(candidates)
+            comment = line.find('#', index, found)
+            if comment >= 0:
+                return None
+            state = marker
+            index = found + 3
+        return state
+
+    @classmethod
+    def _split_sections(cls, text):
+        lines = text.splitlines(keepends=True)
+        sections = []
+        current = []
+        current_header = None
+        multiline_state = None
+
+        for line in lines:
+            header = None if multiline_state else TABLE_RE.match(line)
+            if header and ((header.group(1) == '[[') == (header.group(3) == ']]')):
+                if current:
+                    sections.append((current_header, current))
+                current = [line]
+                current_header = (
+                    'array' if header.group(1) == '[[' else 'table',
+                    tuple(part.strip() for part in header.group(2).split('.')),
+                )
+            else:
+                current.append(line)
+            multiline_state = cls._advance_multiline_state(line, multiline_state)
+
+        if current:
+            sections.append((current_header, current))
+        return sections
+
+    @staticmethod
+    def _hook_kind(header):
+        if not header or header[0] != 'array':
+            return None
+        path = header[1]
+        if len(path) == 2 and path[0] == 'hooks':
+            return ('parent', path[1])
+        if len(path) == 3 and path[0] == 'hooks' and path[2] == 'hooks':
+            return ('handler', path[1])
+        return None
+
+    def _section_is_current_handler(self, lines):
+        for line in lines[1:]:
+            match = COMMAND_RE.match(line)
+            if match and self.is_current_adapter_text(match.group(2)):
+                return True
+        return False
+
+    def _remove_hook_sections(self, text):
+        sections = self._split_sections(text)
+        remove = set()
+
+        for index, (header, lines) in enumerate(sections):
+            kind = self._hook_kind(header)
+            if kind and kind[0] == 'handler' and self._section_is_current_handler(lines):
+                remove.add(index)
+
+        for index, (header, _) in enumerate(sections):
+            kind = self._hook_kind(header)
+            if not kind or kind[0] != 'parent':
+                continue
+            event = kind[1]
+            handler_indexes = []
+            cursor = index + 1
+            while cursor < len(sections):
+                child_kind = self._hook_kind(sections[cursor][0])
+                if not child_kind or child_kind != ('handler', event):
+                    break
+                handler_indexes.append(cursor)
+                cursor += 1
+            if handler_indexes and all(handler_index in remove for handler_index in handler_indexes):
+                remove.add(index)
+
+        return ''.join(
+            ''.join(lines)
+            for index, (_, lines) in enumerate(sections)
+            if index not in remove
+        )
+
+    @staticmethod
+    def _bracket_delta(line):
+        delta = 0
+        quote = ''
+        escaped = False
+        for character in line:
+            if quote:
+                if quote == '"' and escaped:
+                    escaped = False
+                    continue
+                if quote == '"' and character == '\\':
+                    escaped = True
+                    continue
+                if character == quote:
+                    quote = ''
+                continue
+            if character in ('"', "'"):
+                quote = character
+            elif character == '#':
+                break
+            elif character == '[':
+                delta += 1
+            elif character == ']':
+                delta -= 1
+        return delta
+
+    def _remove_legacy_notify(self, text):
+        lines = text.splitlines(keepends=True)
+        kept = []
+        index = 0
+        multiline_state = None
+        while index < len(lines):
+            line = lines[index]
+            if multiline_state is None and re.match(r'^\s*notify\s*=', line):
+                block = [line]
+                balance = self._bracket_delta(line)
+                index += 1
+                while balance > 0 and index < len(lines):
+                    block.append(lines[index])
+                    balance += self._bracket_delta(lines[index])
+                    index += 1
+                if self.is_current_adapter_text(''.join(block)):
+                    continue
+                kept.extend(block)
+                continue
+            kept.append(line)
+            multiline_state = self._advance_multiline_state(line, multiline_state)
+            index += 1
+        return ''.join(kept)
+
+    def clean(self, text, newline='\n'):
+        text = self._remove_owned_marker_comments(text)
+        text = self._remove_hook_sections(text)
+        text = self._remove_legacy_notify(text)
+        return text.rstrip() + (newline if text.strip() else '')
+
+
+def atomic_write(path, content):
+    destination = os.path.realpath(path) if os.path.islink(path) else path
+    directory = os.path.dirname(destination) or '.'
+    os.makedirs(directory, exist_ok=True)
+    existing_mode = None
+    if os.path.exists(destination):
+        existing_mode = stat.S_IMODE(os.stat(destination).st_mode)
+    descriptor, temporary_path = tempfile.mkstemp(prefix='.config.toml.', dir=directory)
+    try:
+        with os.fdopen(descriptor, 'w', encoding='utf-8', newline='') as handle:
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        if existing_mode is not None:
+            os.chmod(temporary_path, existing_mode)
+        os.replace(temporary_path, destination)
+    finally:
+        if os.path.exists(temporary_path):
+            os.unlink(temporary_path)
+
+
+def read_config(path):
+    try:
+        with open(path, encoding='utf-8', newline='') as handle:
+            return handle.read()
+    except FileNotFoundError:
+        return ''
+
+
+def build_block(install_dir, adapter_path, newline='\n'):
+    command = 'if [ -f {adapter} ]; then CLAUDE_PEON_DIR={install_dir} bash {adapter} >/dev/null 2>&1 || true; fi'.format(
+        install_dir=shlex.quote(install_dir),
+        adapter=shlex.quote(adapter_path),
+    )
+    block = [BEGIN_MARKER, '# install_dir = ' + install_dir]
+    for event, matcher in EVENTS:
+        block.append('[[hooks.{}]]'.format(event))
+        if matcher:
+            block.append('matcher = ' + json.dumps(matcher))
+        block.append('')
+        block.append('[[hooks.{}.hooks]]'.format(event))
+        block.append('type = "command"')
+        block.append('command = ' + json.dumps(command))
+        block.append('timeout = 30')
+        block.append('')
+    block.append(END_MARKER)
+    return newline.join(block) + newline
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('action', choices=('install', 'clean'))
+    parser.add_argument('--config', required=True)
+    parser.add_argument('--install-dir', required=True)
+    parser.add_argument('--adapter')
+    args = parser.parse_args()
+
+    editor = CodexConfigEditor(args.install_dir)
+    original = read_config(args.config)
+    newline = '\r\n' if '\r\n' in original else '\n'
+    content = editor.clean(original, newline)
+
+    if args.action == 'install':
+        if not args.adapter:
+            parser.error('--adapter is required for install')
+        block = build_block(args.install_dir, args.adapter, newline)
+        content = (content + newline if content else '') + block
+
+    if content != original:
+        atomic_write(args.config, content)
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/tests/adapters-windows.Tests.ps1
+++ b/tests/adapters-windows.Tests.ps1
@@ -1167,6 +1167,7 @@ Describe "uninstall.ps1" {
         $script:uninstallContent | Should -Match '\.codex\\config\.toml'
         $script:uninstallContent | Should -Match 'peon-ping Codex hooks begin'
         $script:uninstallContent | Should -Match ([regex]::Escape('adapters[\\/]+codex\.(sh|ps1)'))
+        $script:uninstallContent | Should -Match '\[System\.IO\.File\]::Replace'
     }
 
     It "Codex cleanup removes only the current install root" {
@@ -1200,13 +1201,48 @@ Describe "uninstall.ps1" {
             $content = @"
 model = "gpt-5"
 
+documentation = """
+[[hooks.Stop]]
+[[hooks.Stop.hooks]]
+type = "command"
+command = "documented C:/Users/me[1]/.claude/hooks/peon-ping/adapters/codex.ps1"
+# peon-ping Codex hooks begin
+# install_dir = $currentInstall
+# peon-ping Codex hooks end
+"""
+
+literal_documentation = '''
+[[hooks.UserPromptSubmit]]
+[[hooks.UserPromptSubmit.hooks]]
+command_windows = "documented C:/Users/me[1]/.claude/hooks/peon-ping/adapters/codex.ps1"
+'''
+
 # peon-ping Codex hooks begin
 # install_dir = $currentInstall
 [[hooks.Stop]]
+matcher = ""
 [[hooks.Stop.hooks]]
 type = "command"
 command = "powershell -NoProfile -File '$currentInstall\adapters\codex.ps1'"
 timeout = 10
+
+[[hooks.Stop.hooks]]
+type = "command"
+command = "powershell -NoProfile -File 'C:\Tools\user-stop.ps1'"
+timeout = 20
+
+[[hooks.UserPromptSubmit]]
+[[hooks.UserPromptSubmit.hooks]]
+type = "command"
+command_windows = "powershell -NoProfile -File '$currentInstall\adapters\codex.ps1'"
+timeout = 10
+
+[hooks.state]
+trusted = true
+
+[[skills.config]]
+path = "C:\Users\me[1]\.codex\skills\review\SKILL.md"
+enabled = true
 # peon-ping Codex hooks end
 
 # peon-ping Codex hooks begin
@@ -1240,6 +1276,17 @@ notify = [
             $cleaned | Should -Match ([regex]::Escape("$otherInstall\adapters\codex.ps1"))
             $cleaned | Should -Match ([regex]::Escape("$oldPrefixInstall\adapters\codex.ps1"))
             $cleaned | Should -Match 'model = "gpt-5"'
+            $cleaned | Should -Match '(?m)^\[hooks\.state\]\r?$'
+            $cleaned | Should -Match '(?m)^trusted = true\r?$'
+            $cleaned | Should -Match '(?m)^\[\[skills\.config\]\]\r?$'
+            $cleaned | Should -Match ([regex]::Escape('C:\Tools\user-stop.ps1'))
+            $cleaned | Should -Match '(?m)^matcher = ""\r?$'
+            $cleaned | Should -Match 'command = "documented C:/Users/me\[1\]/\.claude/hooks/peon-ping/adapters/codex\.ps1"'
+            $cleaned | Should -Match 'command_windows = "documented C:/Users/me\[1\]/\.claude/hooks/peon-ping/adapters/codex\.ps1"'
+            $cleaned | Should -Match "(?s)documentation = `"`"`".*?# peon-ping Codex hooks begin.*?# install_dir = $([regex]::Escape($currentInstall)).*?# peon-ping Codex hooks end.*?`"`"`""
+            $cleaned.Contains("`r`n") | Should -BeTrue
+            ($cleaned.Replace("`r`n", "")) | Should -Not -Match "`n"
+            (Remove-PeonCodexConfigText $cleaned $currentInstall) | Should -BeExactly $cleaned
         } finally {
             $env:USERPROFILE = $oldUserProfile
         }
@@ -1931,6 +1978,37 @@ Describe "install.ps1 Default Config" {
         $codexInstallerBlock | Should -Not -BeNullOrEmpty
         $codexInstallerBlock | Should -Not -Match 'PostToolUse'
         $codexInstallerBlock | Should -Not -Match 'PreToolUse'
+        $script:installContent | Should -Match 'command_windows = '
+        $script:installContent | Should -Match 'if \(Test-Path -LiteralPath \$adapterLiteral\)'
+        $script:installContent | Should -Match '\[Console\]::In\.ReadToEnd\(\)'
+        $script:installContent | Should -Match '\$hookInput \| & powershell'
+        $script:installContent | Should -Match '& powershell -NoProfile -NonInteractive -File \$adapterLiteral'
+        $script:installContent | Should -Match '2>`\$null \| Out-Null'
+        $script:installContent | Should -Match 'catch \{\}; exit 0'
+        $script:installContent | Should -Match '\[System\.IO\.File\]::Replace'
+    }
+
+    It "Codex hook wrapper ignores and silences a failing adapter process" -Skip:($env:OS -ne 'Windows_NT') {
+        $adapter = Join-Path ([System.IO.Path]::GetTempPath()) "peon-codex-fail-$([guid]::NewGuid().ToString('N')).ps1"
+        $capture = "$adapter.stdin"
+        $captureLiteral = "'" + $capture.Replace("'", "''") + "'"
+        Set-Content -Path $adapter -Value @"
+[System.IO.File]::WriteAllText($captureLiteral, [Console]::In.ReadToEnd())
+Write-Output "unexpected stdout"
+[Console]::Error.WriteLine("unexpected stderr")
+exit 37
+"@ -Encoding UTF8
+        try {
+            $adapterLiteral = "'" + $adapter.Replace("'", "''") + "'"
+            $wrapper = "try { if (Test-Path -LiteralPath $adapterLiteral) { `$hookInput = [Console]::In.ReadToEnd(); `$hookInput | & powershell -NoProfile -NonInteractive -File $adapterLiteral 2>`$null | Out-Null } } catch {}; exit 0"
+            $output = '{"hook_event_name":"Stop"}' | & powershell -NoProfile -NonInteractive -Command $wrapper 2>&1
+            $LASTEXITCODE | Should -Be 0
+            $output | Should -BeNullOrEmpty
+            (Get-Content -Path $capture -Raw) | Should -Match '"hook_event_name":"Stop"'
+        } finally {
+            Remove-Item -Path $adapter -Force -ErrorAction SilentlyContinue
+            Remove-Item -Path $capture -Force -ErrorAction SilentlyContinue
+        }
     }
 
     It "installer Codex cleanup removes only the current install root" {
@@ -1963,13 +2041,48 @@ Describe "install.ps1 Default Config" {
             $content = @"
 model = "gpt-5"
 
+documentation = """
+[[hooks.Stop]]
+[[hooks.Stop.hooks]]
+type = "command"
+command = "documented C:/Users/me[1]/.claude/hooks/peon-ping/adapters/codex.ps1"
+# peon-ping Codex hooks begin
+# install_dir = $currentInstall
+# peon-ping Codex hooks end
+"""
+
+literal_documentation = '''
+[[hooks.UserPromptSubmit]]
+[[hooks.UserPromptSubmit.hooks]]
+command_windows = "documented C:/Users/me[1]/.claude/hooks/peon-ping/adapters/codex.ps1"
+'''
+
 # peon-ping Codex hooks begin
 # install_dir = $currentInstall
 [[hooks.Stop]]
+matcher = ""
 [[hooks.Stop.hooks]]
 type = "command"
 command = "powershell -NoProfile -File '$currentInstall\adapters\codex.ps1'"
 timeout = 10
+
+[[hooks.Stop.hooks]]
+type = "command"
+command_windows = "powershell -NoProfile -File 'C:\Tools\user-stop.ps1'"
+timeout = 20
+
+[[hooks.UserPromptSubmit]]
+[[hooks.UserPromptSubmit.hooks]]
+type = "command"
+command_windows = "powershell -NoProfile -File '$currentInstall\adapters\codex.ps1'"
+timeout = 10
+
+[hooks.state]
+trusted = true
+
+[[skills.config]]
+path = "C:\Users\me[1]\.codex\skills\review\SKILL.md"
+enabled = true
 # peon-ping Codex hooks end
 
 # peon-ping Codex hooks begin
@@ -1993,6 +2106,17 @@ notify = [
             $cleaned | Should -Not -Match '(?m)^notify\s*='
             $cleaned | Should -Match ([regex]::Escape("$oldPrefixInstall\adapters\codex.ps1"))
             $cleaned | Should -Match 'model = "gpt-5"'
+            $cleaned | Should -Match '(?m)^\[hooks\.state\]\r?$'
+            $cleaned | Should -Match '(?m)^trusted = true\r?$'
+            $cleaned | Should -Match '(?m)^\[\[skills\.config\]\]\r?$'
+            $cleaned | Should -Match ([regex]::Escape('C:\Tools\user-stop.ps1'))
+            $cleaned | Should -Match '(?m)^matcher = ""\r?$'
+            $cleaned | Should -Match 'command = "documented C:/Users/me\[1\]/\.claude/hooks/peon-ping/adapters/codex\.ps1"'
+            $cleaned | Should -Match 'command_windows = "documented C:/Users/me\[1\]/\.claude/hooks/peon-ping/adapters/codex\.ps1"'
+            $cleaned | Should -Match "(?s)documentation = `"`"`".*?# peon-ping Codex hooks begin.*?# install_dir = $([regex]::Escape($currentInstall)).*?# peon-ping Codex hooks end.*?`"`"`""
+            $cleaned.Contains("`r`n") | Should -BeTrue
+            ($cleaned.Replace("`r`n", "")) | Should -Not -Match "`n"
+            (Remove-PeonCodexConfigText $cleaned $currentInstall) | Should -BeExactly $cleaned
         } finally {
             $env:USERPROFILE = $oldUserProfile
         }

--- a/tests/install.bats
+++ b/tests/install.bats
@@ -24,6 +24,7 @@ setup() {
   cp -r "$(dirname "$BATS_TEST_FILENAME")/../skills" "$CLONE_DIR/" 2>/dev/null || true
   mkdir -p "$CLONE_DIR/scripts"
   cp "$(dirname "$BATS_TEST_FILENAME")/../scripts/"*.sh "$CLONE_DIR/scripts/" 2>/dev/null || true
+  cp "$(dirname "$BATS_TEST_FILENAME")/../scripts/"*.py "$CLONE_DIR/scripts/" 2>/dev/null || true
   mkdir -p "$CLONE_DIR/adapters"
   cp "$(dirname "$BATS_TEST_FILENAME")/../adapters/"*.sh "$CLONE_DIR/adapters/" 2>/dev/null || true
 
@@ -167,10 +168,149 @@ for event in ['PreToolUse', 'PostToolUse', 'PostCompact', 'Notification', 'Sessi
     assert f'[[hooks.{event}]]' not in cfg, f'{event} should not be registered\\n{cfg}'
 assert 'notify =' not in cfg, cfg
 assert 'CLAUDE_PEON_DIR=' in cfg, cfg
+assert 'if [ -f ' in cfg and '|| true; fi' in cfg, cfg
 assert 'adapters/codex.sh' in cfg, cfg
 assert cfg.count('timeout = 30') == 7, cfg
 print('OK')
 "
+}
+
+@test "Codex hook exits zero when its adapter has been removed" {
+  mkdir -p "$TEST_HOME/.codex"
+  echo 'model = "gpt-5"' > "$TEST_HOME/.codex/config.toml"
+
+  bash "$CLONE_DIR/install.sh"
+  command=$(/usr/bin/python3 -c "
+import json
+from pathlib import Path
+for line in Path('$TEST_HOME/.codex/config.toml').read_text().splitlines():
+    if line.startswith('command = ') and 'adapters/codex.sh' in line:
+        print(json.loads(line.split('=', 1)[1].strip()))
+        break
+")
+  rm "$INSTALL_DIR/adapters/codex.sh"
+
+  run /bin/sh -lc "$command"
+
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "Codex update and uninstall preserve state skills and sibling handlers" {
+  mkdir -p "$TEST_HOME/.codex"
+  cat > "$TEST_HOME/.codex/config.toml" <<TOML
+model = "gpt-5"
+
+notes = """
+# peon-ping Codex hooks begin
+# install_dir = $INSTALL_DIR
+[[hooks.Stop]]
+[[hooks.Stop.hooks]]
+  command = "bash $INSTALL_DIR/adapters/codex.sh"
+# peon-ping Codex hooks end
+"""
+
+# peon-ping Codex hooks begin
+# install_dir = $INSTALL_DIR
+[[hooks.Stop]]
+matcher = ""
+
+[[hooks.Stop.hooks]]
+type = "command"
+command = "CLAUDE_PEON_DIR=$INSTALL_DIR bash $INSTALL_DIR/adapters/codex.sh"
+timeout = 30
+
+[[hooks.Stop.hooks]]
+type = "command"
+command = "python3 /tmp/user-stop.py"
+
+[hooks.state]
+enabled = true
+
+[hooks.state.trusted_hashes]
+"user-hook" = "sha256:keep-me"
+
+[[skills.config]]
+path = "/tmp/user-skill/SKILL.md"
+enabled = false
+
+# peon-ping Codex hooks end
+TOML
+
+  bash "$CLONE_DIR/install.sh"
+
+  /usr/bin/python3 -c "
+from pathlib import Path
+cfg = Path('$TEST_HOME/.codex/config.toml').read_text()
+assert cfg.count('[hooks.state]') == 1, cfg
+assert 'sha256:keep-me' in cfg, cfg
+assert cfg.count('[[skills.config]]') == 1, cfg
+assert '/tmp/user-skill/SKILL.md' in cfg, cfg
+assert cfg.count('python3 /tmp/user-stop.py') == 1, cfg
+commands = [line for line in cfg.splitlines() if line.startswith('command = ')]
+assert sum('$INSTALL_DIR/adapters/codex.sh' in line for line in commands) == 7, cfg
+assert '  command = ' + chr(34) + 'bash $INSTALL_DIR/adapters/codex.sh' + chr(34) in cfg, cfg
+print('OK')
+"
+
+  bash "$INSTALL_DIR/uninstall.sh"
+
+  /usr/bin/python3 -c "
+from pathlib import Path
+cfg = Path('$TEST_HOME/.codex/config.toml').read_text()
+assert '[hooks.state]' in cfg and 'sha256:keep-me' in cfg, cfg
+assert '[[skills.config]]' in cfg and '/tmp/user-skill/SKILL.md' in cfg, cfg
+assert 'python3 /tmp/user-stop.py' in cfg, cfg
+assert cfg.count('$INSTALL_DIR/adapters/codex.sh') == 1, cfg
+assert '  command = ' + chr(34) + 'bash $INSTALL_DIR/adapters/codex.sh' + chr(34) in cfg, cfg
+assert cfg.count('# peon-ping Codex hooks begin') == 1, cfg
+print('OK')
+"
+}
+
+@test "Codex config symlink and CRLF survive install and uninstall" {
+  mkdir -p "$TEST_HOME/.codex" "$TEST_HOME/dotfiles"
+  /usr/bin/python3 -c "
+from pathlib import Path
+Path('$TEST_HOME/dotfiles/codex.toml').write_bytes(b'model = ' + bytes([34]) + b'gpt-5' + bytes([34]) + b'\\r\\n')
+"
+  ln -s "$TEST_HOME/dotfiles/codex.toml" "$TEST_HOME/.codex/config.toml"
+
+  bash "$CLONE_DIR/install.sh"
+
+  [ -L "$TEST_HOME/.codex/config.toml" ]
+  /usr/bin/python3 -c "
+from pathlib import Path
+data = Path('$TEST_HOME/dotfiles/codex.toml').read_bytes()
+assert b'adapters/codex.sh' in data, data
+assert b'\\r\\n' in data, data
+assert b'\\n' not in data.replace(b'\\r\\n', b''), data
+"
+
+  bash "$INSTALL_DIR/uninstall.sh"
+
+  [ -L "$TEST_HOME/.codex/config.toml" ]
+  /usr/bin/python3 -c "
+from pathlib import Path
+data = Path('$TEST_HOME/dotfiles/codex.toml').read_bytes()
+assert b'adapters/codex.sh' not in data, data
+assert data == b'model = ' + bytes([34]) + b'gpt-5' + bytes([34]) + b'\\r\\n', data
+"
+}
+
+@test "uninstall aborts safely when the Codex config helper is missing" {
+  mkdir -p "$TEST_HOME/.codex"
+  echo 'model = "gpt-5"' > "$TEST_HOME/.codex/config.toml"
+  bash "$CLONE_DIR/install.sh"
+  rm "$INSTALL_DIR/scripts/codex-config.py"
+
+  run bash "$INSTALL_DIR/uninstall.sh"
+
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"cannot safely remove Codex hooks"* ]]
+  [[ "$output" != *"Uninstall complete"* ]]
+  [ -d "$INSTALL_DIR" ]
+  grep -q "$INSTALL_DIR/adapters/codex.sh" "$TEST_HOME/.codex/config.toml"
 }
 
 @test "install replaces stale skill symlink from older package managers" {

--- a/uninstall.ps1
+++ b/uninstall.ps1
@@ -191,8 +191,9 @@ function Get-PeonCodexMarkers([string]$InstallRoot) {
 
 function Get-PeonCodexAdapterMarkers([string]$InstallRoot) {
     $markers = New-Object System.Collections.Generic.List[string]
+    $normalizedRoot = Normalize-PeonCodexPath $InstallRoot
     foreach ($adapterName in @("codex.ps1", "codex.sh")) {
-        $adapterPath = Join-Path (Join-Path $InstallRoot "adapters") $adapterName
+        $adapterPath = "$normalizedRoot/adapters/$adapterName"
         foreach ($marker in (Get-PeonCodexMarkers $adapterPath)) {
             $markers.Add($marker)
         }
@@ -273,17 +274,79 @@ function Get-PeonTomlBracketDelta([string]$Line) {
 }
 
 function Remove-PeonCodexConfigText([string]$Content, [string]$InstallRoot) {
-    $managedPattern = '(?ms)\r?\n?# peon-ping Codex hooks begin.*?# peon-ping Codex hooks end\r?\n?'
-    $contentWithoutBlocks = ([regex]$managedPattern).Replace($Content, {
-        param($match)
-        if (Test-PeonCodexTextForInstall $match.Value $InstallRoot) { "`n" } else { $match.Value }
-    })
-
-    $lines = @($contentWithoutBlocks -split "\r?\n")
+    if ([string]::IsNullOrEmpty($Content)) { return "" }
+    $newline = if ($Content.Contains("`r`n")) { "`r`n" } else { "`n" }
+    $lines = @($Content -split "\r?\n")
+    $structuralLine = New-Object 'bool[]' $lines.Count
+    $multilineDelimiter = ""
+    for ($lineIndex = 0; $lineIndex -lt $lines.Count; $lineIndex++) {
+        $structuralLine[$lineIndex] = -not $multilineDelimiter
+        if ($multilineDelimiter) {
+            if ($lines[$lineIndex].Contains($multilineDelimiter)) { $multilineDelimiter = "" }
+            continue
+        }
+        if ($lines[$lineIndex].TrimStart().StartsWith('#')) { continue }
+        foreach ($delimiter in @('"""', "'''")) {
+            $delimiterCount = ([regex]::Matches($lines[$lineIndex], [regex]::Escape($delimiter))).Count
+            if (($delimiterCount % 2) -eq 1) {
+                $multilineDelimiter = $delimiter
+                break
+            }
+        }
+    }
     $kept = New-Object System.Collections.Generic.List[string]
     for ($i = 0; $i -lt $lines.Count; $i++) {
         $line = $lines[$i]
-        if ($line.Trim() -match '^notify\s*=') {
+        $parentMatch = if ($structuralLine[$i]) {
+            [regex]::Match($line, '^\s*\[\[hooks\.([^\.\]]+)\]\]\s*(?:#.*)?$')
+        } else { [System.Text.RegularExpressions.Match]::Empty }
+        if ($parentMatch.Success) {
+            $eventName = $parentMatch.Groups[1].Value
+            $parentLines = New-Object System.Collections.Generic.List[string]
+            $parentLines.Add($line)
+            while (($i + 1) -lt $lines.Count -and
+                ((-not $structuralLine[$i + 1]) -or $lines[$i + 1] -notmatch '^\s*\[\[?[^\]]+\]\]?') -and
+                $lines[$i + 1].Trim() -notin @('# peon-ping Codex hooks begin', '# peon-ping Codex hooks end')) {
+                $i++
+                $parentLines.Add($lines[$i])
+            }
+
+            $childBlocks = New-Object System.Collections.Generic.List[object]
+            while (($i + 1) -lt $lines.Count -and
+                $structuralLine[$i + 1] -and
+                $lines[$i + 1] -match "^\s*\[\[hooks\.$([regex]::Escape($eventName))\.hooks\]\]\s*(?:#.*)?$") {
+                $i++
+                $childLines = New-Object System.Collections.Generic.List[string]
+                $childLines.Add($lines[$i])
+                while (($i + 1) -lt $lines.Count -and
+                    ((-not $structuralLine[$i + 1]) -or $lines[$i + 1] -notmatch '^\s*\[\[?[^\]]+\]\]?') -and
+                    $lines[$i + 1].Trim() -notin @('# peon-ping Codex hooks begin', '# peon-ping Codex hooks end')) {
+                    $i++
+                    $childLines.Add($lines[$i])
+                }
+                $childBlocks.Add(@($childLines))
+            }
+
+            $remainingChildren = New-Object System.Collections.Generic.List[object]
+            $removedChild = $false
+            foreach ($childBlock in $childBlocks) {
+                $childText = @($childBlock | Where-Object {
+                    $_.Trim() -match '^command(?:_windows|Windows)?\s*='
+                }) -join $newline
+                if (Test-PeonCodexTextForInstall $childText $InstallRoot) {
+                    $removedChild = $true
+                } else {
+                    $remainingChildren.Add($childBlock)
+                }
+            }
+
+            if ((-not $removedChild) -or $remainingChildren.Count -gt 0) {
+                foreach ($parentLine in $parentLines) { $kept.Add($parentLine) }
+                foreach ($childBlock in $remainingChildren) {
+                    foreach ($childLine in $childBlock) { $kept.Add($childLine) }
+                }
+            }
+        } elseif ($line.Trim() -match '^notify\s*=') {
             $blockLines = New-Object System.Collections.Generic.List[string]
             $blockLines.Add($line)
             $balance = Get-PeonTomlBracketDelta $line
@@ -301,7 +364,75 @@ function Remove-PeonCodexConfigText([string]$Content, [string]$InstallRoot) {
             $kept.Add($line)
         }
     }
-    return ($kept -join "`n").TrimEnd()
+
+    # Codex may append its own tables before our legacy end marker. Remove
+    # only the marker lines for this install root, never the content between.
+    $markerStructuralLine = New-Object 'bool[]' $kept.Count
+    $multilineDelimiter = ""
+    for ($lineIndex = 0; $lineIndex -lt $kept.Count; $lineIndex++) {
+        $markerStructuralLine[$lineIndex] = -not $multilineDelimiter
+        if ($multilineDelimiter) {
+            if ($kept[$lineIndex].Contains($multilineDelimiter)) { $multilineDelimiter = "" }
+            continue
+        }
+        if ($kept[$lineIndex].TrimStart().StartsWith('#')) { continue }
+        foreach ($delimiter in @('"""', "'''")) {
+            $delimiterCount = ([regex]::Matches($kept[$lineIndex], [regex]::Escape($delimiter))).Count
+            if (($delimiterCount % 2) -eq 1) {
+                $multilineDelimiter = $delimiter
+                break
+            }
+        }
+    }
+    $withoutMarkers = New-Object System.Collections.Generic.List[string]
+    $insideTargetMarkers = $false
+    for ($i = 0; $i -lt $kept.Count; $i++) {
+        $line = $kept[$i]
+        if ($markerStructuralLine[$i] -and $line.Trim() -eq '# peon-ping Codex hooks begin') {
+            $next = $i + 1
+            while ($next -lt $kept.Count -and [string]::IsNullOrWhiteSpace($kept[$next])) { $next++ }
+            $markerInstallDir = if ($next -lt $kept.Count) {
+                Get-PeonCodexBlockInstallDir ("$line$newline$($kept[$next])")
+            } else { "" }
+            $isTargetMarker = $false
+            foreach ($installMarker in (Get-PeonCodexMarkers $InstallRoot)) {
+                if ([string]::Equals($markerInstallDir, $installMarker, [System.StringComparison]::OrdinalIgnoreCase)) {
+                    $isTargetMarker = $true
+                    break
+                }
+            }
+            if ($isTargetMarker) {
+                $insideTargetMarkers = $true
+                while (($i + 1) -lt $next) { $i++ }
+                $i = $next
+                continue
+            }
+        }
+        if ($insideTargetMarkers -and $markerStructuralLine[$i] -and $line.Trim() -eq '# peon-ping Codex hooks end') {
+            $insideTargetMarkers = $false
+            continue
+        }
+        $withoutMarkers.Add($line)
+    }
+    return ($withoutMarkers -join $newline).TrimEnd("`r", "`n")
+}
+
+function Set-PeonCodexConfigAtomic([string]$Path, [string]$Content) {
+    $directory = Split-Path -Parent $Path
+    $leaf = Split-Path -Leaf $Path
+    $tempPath = Join-Path $directory ".$leaf.peon-ping-$PID-$([guid]::NewGuid().ToString('N')).tmp"
+    $backupPath = "$tempPath.backup"
+    try {
+        Set-Content -Path $tempPath -Value $Content -Encoding UTF8
+        if (Test-Path $Path) {
+            [System.IO.File]::Replace($tempPath, $Path, $backupPath)
+        } else {
+            Move-Item -Path $tempPath -Destination $Path
+        }
+    } finally {
+        Remove-Item -Path $tempPath -Force -ErrorAction SilentlyContinue
+        Remove-Item -Path $backupPath -Force -ErrorAction SilentlyContinue
+    }
 }
 
 if (Test-Path $CodexConfigFile) {
@@ -310,12 +441,13 @@ if (Test-Path $CodexConfigFile) {
     try {
         $codexContent = Get-Content $CodexConfigFile -Raw
         $originalCodexContent = $codexContent
+        $codexNewline = if ($codexContent.Contains("`r`n")) { "`r`n" } else { "`n" }
 
         $codexContent = Remove-PeonCodexConfigText $codexContent $InstallDir
-        if ($codexContent) { $codexContent = "$codexContent`n" }
+        if ($codexContent) { $codexContent = "$codexContent$codexNewline" }
 
         if ($codexContent -ne $originalCodexContent) {
-            Set-Content -Path $CodexConfigFile -Value $codexContent -Encoding UTF8
+            Set-PeonCodexConfigAtomic $CodexConfigFile $codexContent
             Write-Host "  Removed Codex hooks from $CodexConfigFile" -ForegroundColor Green
         } else {
             Write-Host "  No peon-ping Codex hooks found" -ForegroundColor DarkGray

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -189,143 +189,17 @@ _remove_copilot_hooks() {
 _remove_codex_hooks() {
   local codex_config="$HOME/.codex/config.toml"
   [ -f "$codex_config" ] || return 0
-
-  CODEX_CONFIG_PATH="$codex_config" PEON_INSTALL_DIR="$INSTALL_DIR" python3 <<'PY'
-import os
-import re
-
-config_path = os.environ['CODEX_CONFIG_PATH']
-install_dir = os.environ['PEON_INSTALL_DIR']
-begin = '# peon-ping Codex hooks begin'
-end = '# peon-ping Codex hooks end'
-
-def normalize_codex_path(value):
-    value = str(value or '').strip().strip('"').strip("'")
-    value = value.replace('\\\\', '\\').replace('\\', '/')
-    return value.rstrip('/')
-
-def marker_variants(path):
-    variants = set()
-    if path:
-        variants.add(normalize_codex_path(path))
-    home = os.path.expanduser('~')
-    if path.startswith(home):
-        variants.add(normalize_codex_path('~' + path[len(home):]))
-    return {v for v in variants if v}
-
-install_markers = marker_variants(install_dir)
-adapter_markers = set()
-for adapter_name in ('codex.sh', 'codex.ps1'):
-    adapter_markers.update(marker_variants(os.path.join(install_dir, 'adapters', adapter_name)))
-
-_path_chars = set('ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789._~:/-')
-
-def text_has_path_token(text, path):
-    text = normalize_codex_path(text)
-    path = normalize_codex_path(path)
-    start = 0
-    while True:
-        idx = text.find(path, start)
-        if idx < 0:
-            return False
-        before = text[idx - 1] if idx > 0 else ''
-        after_idx = idx + len(path)
-        after = text[after_idx] if after_idx < len(text) else ''
-        before_ok = not before or before not in _path_chars
-        after_ok = not after or after not in _path_chars
-        if before_ok and after_ok:
-            return True
-        start = idx + 1
-
-def block_install_dir(text):
-    match = re.search(r'(?m)^\s*#\s*install_dir\s*=\s*(.*?)\s*$', text)
-    return normalize_codex_path(match.group(1)) if match else ''
-
-try:
-    with open(config_path) as f:
-        original = f.read()
-except Exception:
-    raise SystemExit(0)
-
-def is_current_peon_codex(text):
-    if 'peon-ping' not in text:
-        return False
-    if not re.search(r'adapters[\\/]+codex\.(sh|ps1)', text):
-        return False
-    explicit_install_dir = block_install_dir(text)
-    if explicit_install_dir:
-        return explicit_install_dir in install_markers
-    return any(text_has_path_token(text, adapter_path) for adapter_path in adapter_markers)
-
-def remove_current_managed_blocks(text):
-    def replace(match):
-        block = match.group(0)
-        return '\n' if is_current_peon_codex(block) else block
-    return re.sub(
-        r'(?ms)\n?# peon-ping Codex hooks begin.*?# peon-ping Codex hooks end\n?',
-        replace,
-        text,
-    )
-
-def bracket_delta(line):
-    delta = 0
-    quote = ''
-    escaped = False
-    for ch in line:
-        if quote:
-            if quote == '"' and escaped:
-                escaped = False
-                continue
-            if quote == '"' and ch == '\\':
-                escaped = True
-                continue
-            if ch == quote:
-                quote = ''
-            continue
-        if ch in ('"', "'"):
-            quote = ch
-        elif ch == '#':
-            break
-        elif ch == '[':
-            delta += 1
-        elif ch == ']':
-            delta -= 1
-    return delta
-
-def remove_current_legacy_notify(text):
-    lines = text.splitlines()
-    kept = []
-    i = 0
-    while i < len(lines):
-        line = lines[i]
-        stripped = line.strip()
-        if re.match(r'^notify\s*=', stripped):
-            block = [line]
-            balance = bracket_delta(line)
-            i += 1
-            while balance > 0 and i < len(lines):
-                block.append(lines[i])
-                balance += bracket_delta(lines[i])
-                i += 1
-            block_text = '\n'.join(block)
-            if is_current_peon_codex(block_text):
-                continue
-            kept.extend(block)
-            continue
-        kept.append(line)
-        i += 1
-    return '\n'.join(kept).rstrip()
-
-content = remove_current_managed_blocks(original)
-content = remove_current_legacy_notify(content)
-if content:
-    content += '\n'
-
-if content != original:
-    with open(config_path, 'w') as f:
-        f.write(content)
-    print('Removed Codex hooks from ~/.codex/config.toml')
-PY
+  local codex_config_helper="$INSTALL_DIR/scripts/codex-config.py"
+  if [ -f "$codex_config_helper" ]; then
+    python3 "$codex_config_helper" clean \
+      --config "$codex_config" \
+      --install-dir "$INSTALL_DIR"
+    echo "Removed Codex hooks from ~/.codex/config.toml"
+  else
+    echo "Error: cannot safely remove Codex hooks because scripts/codex-config.py is missing"
+    echo "Re-run the peon-ping installer to restore the helper, then uninstall again."
+    return 1
+  fi
 }
 
 echo "Removing peon hooks from settings.json..."


### PR DESCRIPTION
## Problem

Codex stable hooks in v2.34.0 invoke the adapter through an absolute installation path. If the runtime directory is removed, moved, or only partially updated while the hooks remain in `~/.codex/config.toml`, events such as `UserPromptSubmit` execute a missing script and return exit code 127, interrupting the Codex conversation.

The previous install/uninstall logic also treated everything between `# peon-ping Codex hooks begin/end` as exclusively owned by peon-ping. Codex may persist `[hooks.state]` and `[[skills.config]]` before the trailing marker, so reinstalling or uninstalling could accidentally delete the user's hook trust state and skill configuration.

This is a severe regression introduced by #549 in v2.34.0. It should be prioritized for merge and followed by a patch release.

## Root-cause fix

- Add a structured Codex config cleaner that removes only peon-ping hook sections belonging to the current installation root
- Make hook commands fail open when the adapter is missing on both Unix and Windows, so Codex sessions are never interrupted
- Update config atomically while preserving CRLF, multiline TOML, symlinked installation paths, other installation roots, and all adjacent configuration
- Forward stdin correctly on Windows and keep Bash/PowerShell behavior aligned
- Abort uninstallation safely when the helper is missing instead of falling back to unsafe range-based text deletion

## Verification

- Codex-related `tests/install.bats` cases: 8/8 passed
- `bats tests/codex.bats`: 19/19 passed
- Codex-related Pester cases: 12 passed, 1 expected Windows-only skip
- Real Codex config: all 7 hooks exit 0 when the runtime is missing
- Real reinstall: `hooks.state` and all 8 skill configurations are preserved
- Bash, Python, and PowerShell syntax checks plus `git diff --check` passed

Regression from #549.
