### PR TITLE
feat(tts): add MiniMax T2A speech backend

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -905,10 +905,11 @@ function Resolve-TtsBackend {
     switch ($Backend) {
         "native"     { return "tts-native.ps1" }
         "elevenlabs" { return "tts-elevenlabs.ps1" }
+        "minimax"    { return "tts-minimax.ps1" }
         "piper"      { return "tts-piper.ps1" }
         "auto" {
             # Probe in priority order: prefer premium when installed.
-            foreach ($b in @("elevenlabs", "piper", "native")) {
+            foreach ($b in @("elevenlabs", "minimax", "piper", "native")) {
                 $scriptName = Resolve-TtsBackend -Backend $b
                 $full = Join-Path $InstallDir "scripts\$scriptName"
                 if (Test-Path $full) { return $scriptName }

--- a/peon.sh
+++ b/peon.sh
@@ -465,12 +465,13 @@ _resolve_tts_backend() {
   case "$backend" in
     native)     echo "tts-native.sh" ;;
     elevenlabs) echo "tts-elevenlabs.sh" ;;
+    minimax)    echo "tts-minimax.sh" ;;
     piper)      echo "tts-piper.sh" ;;
     auto)
       # Probe in priority order: prefer premium when installed.
       # Each candidate is resolved inline (no recursive self-call).
       local candidate
-      for candidate in tts-elevenlabs.sh tts-piper.sh tts-native.sh; do  # keep in sync with named cases above
+      for candidate in tts-elevenlabs.sh tts-minimax.sh tts-piper.sh tts-native.sh; do  # keep in sync with named cases above
         find_bundled_script "$candidate" >/dev/null 2>&1 || continue
         echo "$candidate" && return 0
       done

--- a/scripts/tts-minimax.ps1
+++ b/scripts/tts-minimax.ps1
@@ -1,0 +1,238 @@
+<#
+.SYNOPSIS
+    Windows MiniMax speech (T2A) TTS backend for peon-ping. Synthesizes stdin
+    text through the MiniMax text-to-audio (T2A v2) HTTP API, then plays the
+    returned audio via scripts/win-play.ps1. Fire-and-forget: the exit code is
+    always 0, every error is contained, and no output is produced during
+    normal hook invocations. Debug diagnostics go to stderr, gated on
+    PEON_DEBUG=1.
+
+.DESCRIPTION
+    Invoked from Invoke-TtsSpeak with decoded plain text piped on stdin and
+    voice/rate/volume passed as named parameters, matching the calling
+    convention in docs/adr/ADR-001-tts-backend-architecture.md. Unlike the
+    native SAPI5 backend, this backend produces an audio file over HTTP and
+    plays it locally.
+
+    The regional endpoint is selected from PEON_MINIMAX_REGION: "global_en"
+    (default) uses api.minimax.io, "cn_zh" uses api.minimaxi.com. The Bearer
+    credential comes from MINIMAX_API_KEY; an optional MINIMAX_GROUP_ID is
+    appended as a ?GroupId= query argument.
+
+    Under PEON_TTS_DRY_RUN=1 the script writes the resolved request (never the
+    credential itself) as JSON to PEON_TTS_TRACE_FILE and skips the network
+    call. This test hook lets Pester verify request construction without
+    reaching the API.
+
+.PARAMETER InputText
+    Pipeline input. Each object piped in becomes a line of the buffer;
+    trailing whitespace is trimmed before synthesis. Empty or whitespace-only
+    input exits 0 without any request.
+
+.PARAMETER Voice
+    MiniMax voice_id, or the sentinel string "default" to let the service pick
+    its default voice (voice_id is omitted from the request). Default:
+    "default".
+
+.PARAMETER Rate
+    Float, 1.0 = normal speed. Mapped to voice_setting.speed and clamped to the
+    MiniMax-supported 0.5-2.0 range. Default: 1.0.
+
+.PARAMETER Vol
+    Float, 0.0-1.0. Applied at the local player (win-play.ps1), not the API.
+    Default: 0.5.
+
+.PARAMETER ListVoices
+    If set, exits 0 without a request. MiniMax voices are documented voice_id
+    strings rather than a locally enumerable list.
+
+.EXAMPLE
+    "hello world" | .\tts-minimax.ps1 -Voice "some-voice-id" -Rate 1.0 -Vol 0.5
+#>
+param(
+    [Parameter(ValueFromPipeline = $true)]
+    [string]$InputText,
+    [string]$Voice = "default",
+    [double]$Rate = 1.0,
+    [double]$Vol = 0.5,
+    [switch]$ListVoices
+)
+
+begin {
+    $script:PeonDebug = ($env:PEON_DEBUG -eq "1")
+    $script:DryRun = ($env:PEON_TTS_DRY_RUN -eq "1")
+    $script:TracePath = $env:PEON_TTS_TRACE_FILE
+
+    function Write-DebugLine {
+        param([string]$Message)
+        if ($script:PeonDebug) {
+            [Console]::Error.WriteLine("[tts-minimax] $Message")
+        }
+    }
+
+    function Write-Trace {
+        param([hashtable]$Fields)
+        if (-not $script:DryRun) { return }
+        if (-not $script:TracePath) { return }
+        try {
+            $json = $Fields | ConvertTo-Json -Depth 6 -Compress
+            Set-Content -Path $script:TracePath -Value $json -Encoding UTF8
+        } catch {
+            Write-DebugLine "trace write failed: $_"
+        }
+    }
+
+    function Resolve-Endpoint {
+        param([string]$Region)
+        switch ($Region) {
+            "cn_zh"     { return "https://api.minimaxi.com/v1/t2a_v2" }
+            "global_en" { return "https://api.minimax.io/v1/t2a_v2" }
+            default     { return "https://api.minimax.io/v1/t2a_v2" }
+        }
+    }
+
+    # --- -ListVoices short-circuit: runs in begin, exits before process/end ---
+    if ($ListVoices) {
+        Write-DebugLine "voice enumeration not supported for the MiniMax backend"
+        exit 0
+    }
+
+    $script:Buffer = New-Object System.Text.StringBuilder
+}
+
+process {
+    if ($null -ne $InputText -and $InputText.Length -gt 0) {
+        [void]$script:Buffer.AppendLine($InputText)
+    }
+}
+
+end {
+    $text = $script:Buffer.ToString().TrimEnd()
+
+    # Fallback: when invoked via `powershell.exe -File tts-minimax.ps1` the
+    # pipeline does not bind piped stdin to $InputText -- read the redirected
+    # console stream directly so external callers behave like an in-process
+    # pipeline.
+    if (-not $text) {
+        try {
+            if ([Console]::IsInputRedirected) {
+                $stdin = [Console]::In.ReadToEnd()
+                if ($stdin) { $text = $stdin.TrimEnd() }
+            }
+        } catch {
+            Write-DebugLine "stdin read failed: $_"
+        }
+    }
+
+    if (-not $text) {
+        Write-Trace @{ Spoke = $false; Reason = "empty-input" }
+        exit 0
+    }
+
+    # Resolve request parameters from the environment.
+    $region = if ($env:PEON_MINIMAX_REGION) { $env:PEON_MINIMAX_REGION } else { "global_en" }
+    $model = if ($env:PEON_MINIMAX_MODEL) { $env:PEON_MINIMAX_MODEL } else { "speech-2.8-hd" }
+    $fmt = if ($env:PEON_MINIMAX_FORMAT) { $env:PEON_MINIMAX_FORMAT } else { "mp3" }
+    $apiKey = $env:MINIMAX_API_KEY
+    $groupId = $env:MINIMAX_GROUP_ID
+
+    $url = Resolve-Endpoint -Region $region
+    if ($groupId) {
+        $url = $url + "?GroupId=" + $groupId
+    }
+
+    # Clamp speed to the MiniMax-supported range.
+    $speed = [math]::Max(0.5, [math]::Min(2.0, $Rate))
+
+    $voiceSetting = @{ speed = $speed }
+    if ($Voice -and $Voice -ne "default") {
+        $voiceSetting["voice_id"] = $Voice
+    }
+
+    $body = [ordered]@{
+        model         = $model
+        text          = $text
+        stream        = $false
+        voice_setting = $voiceSetting
+        audio_setting = @{ format = $fmt }
+    }
+    $bodyJson = $body | ConvertTo-Json -Depth 6 -Compress
+
+    if ($script:DryRun) {
+        Write-Trace @{
+            url          = $url
+            region       = $region
+            model        = $model
+            format       = $fmt
+            voice        = $Voice
+            rate         = $Rate
+            has_api_key  = [bool]$apiKey
+            has_group_id = [bool]$groupId
+            request      = $body
+        }
+        exit 0
+    }
+
+    if (-not $apiKey) {
+        Write-DebugLine "MINIMAX_API_KEY not set -- skipping synthesis"
+        exit 0
+    }
+
+    # The Authorization header carries the Bearer credential; it is never
+    # written to stdout, stderr, or the trace file.
+    $headers = @{ Authorization = "Bearer $apiKey" }
+    try {
+        $resp = Invoke-RestMethod -Uri $url -Method Post -Headers $headers `
+            -ContentType "application/json" -Body $bodyJson -TimeoutSec 30
+    } catch {
+        Write-DebugLine "T2A request failed: $_"
+        exit 0
+    }
+
+    $statusCode = $null
+    if ($resp -and $resp.base_resp) { $statusCode = $resp.base_resp.status_code }
+    if ($statusCode -ne 0) {
+        Write-DebugLine "base_resp.status_code=$statusCode"
+        exit 0
+    }
+
+    $audioHex = $null
+    if ($resp -and $resp.data) { $audioHex = $resp.data.audio }
+    if (-not $audioHex) {
+        Write-DebugLine "response contained no audio"
+        exit 0
+    }
+
+    try {
+        $bytes = [byte[]]::new($audioHex.Length / 2)
+        for ($i = 0; $i -lt $audioHex.Length; $i += 2) {
+            $bytes[[int]($i / 2)] = [Convert]::ToByte($audioHex.Substring($i, 2), 16)
+        }
+    } catch {
+        Write-DebugLine "hex decode failed: $_"
+        exit 0
+    }
+
+    $tmp = Join-Path $env:TEMP ("peon-tts-minimax-" + [guid]::NewGuid().ToString('N').Substring(0, 8) + "." + $fmt)
+    try {
+        [System.IO.File]::WriteAllBytes($tmp, $bytes)
+    } catch {
+        Write-DebugLine "temp write failed: $_"
+        exit 0
+    }
+
+    try {
+        $winPlay = Join-Path $PSScriptRoot "win-play.ps1"
+        if (Test-Path $winPlay) {
+            & $winPlay -path $tmp -vol $Vol
+        } else {
+            Write-DebugLine "win-play.ps1 not found at $winPlay"
+        }
+    } catch {
+        Write-DebugLine "playback failed: $_"
+    } finally {
+        Remove-Item $tmp -Force -ErrorAction SilentlyContinue
+    }
+
+    exit 0
+}

--- a/scripts/tts-minimax.sh
+++ b/scripts/tts-minimax.sh
@@ -1,0 +1,289 @@
+#!/bin/bash
+# peon-ping: MiniMax speech (T2A) TTS backend
+#
+# A cloud HTTP backend that synthesizes speech through the MiniMax
+# text-to-audio (T2A v2) API, then plays the returned audio through the
+# platform's audio player. Unlike scripts/tts-native.sh (which speaks
+# directly to the OS engine), this backend produces an audio file over
+# HTTP and plays it locally.
+#
+# Usage:
+#   echo "text to speak" | tts-minimax.sh <voice> <rate> <volume>
+#   tts-minimax.sh --list-voices
+#
+# Positional args:
+#   voice   MiniMax voice_id (e.g. a configured voice) or "default" to let
+#           the service pick its default voice (voice_id is omitted).
+#   rate    float; 1.0 = normal speed. Mapped to voice_setting.speed and
+#           clamped to the MiniMax-supported 0.5-2.0 range.
+#   volume  float 0.0-1.0. Applied at the local player (not the API).
+#
+# Stdin:   one line of text to speak (read verbatim, no interpolation).
+# Stdout:  empty.
+# Stderr:  empty unless PEON_DEBUG=1, in which case diagnostics are
+#          prefixed with `[tts-minimax]`.
+# Exit:    always 0 — TTS failure must not fail the calling hook.
+#
+# Env vars:
+#   PEON_DEBUG           "1" enables stderr diagnostics
+#   PEON_DIR             peon-ping install dir (auto-resolved from $0)
+#   MINIMAX_API_KEY      Bearer credential (required; absent → silent exit 0)
+#   MINIMAX_GROUP_ID     optional; appended as ?GroupId=... when set
+#   PEON_MINIMAX_REGION  "global_en" (default) → api.minimax.io
+#                        "cn_zh"               → api.minimaxi.com
+#   PEON_MINIMAX_MODEL   T2A model id (default "speech-2.8-hd"; other options
+#                        include "speech-2.8-turbo")
+#   PEON_MINIMAX_FORMAT  audio format: mp3 (default), wav, flac, pcm
+#   PEON_TTS_DRY_RUN     "1" writes the resolved request to
+#                        PEON_TTS_TRACE_FILE and skips the network call
+#   PEON_TTS_TRACE_FILE  dry-run trace destination
+#
+# See docs/adr/ADR-001-tts-backend-architecture.md for the calling
+# convention this backend implements.
+
+set -uo pipefail
+
+PEON_DEBUG="${PEON_DEBUG:-0}"
+
+_debug() {
+  [ "$PEON_DEBUG" = "1" ] && printf '[tts-minimax] %s\n' "$*" >&2
+  return 0
+}
+
+# --- Resolve PEON_DIR ---
+if [ -z "${PEON_DIR:-}" ]; then
+  PEON_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+fi
+
+# --- Regional endpoint resolution ---
+# The T2A v2 endpoint differs by region: the global service lives on
+# api.minimax.io, the CN service on api.minimaxi.com. Any unrecognized
+# region falls back to the global endpoint.
+_endpoint_for_region() {
+  case "$1" in
+    cn_zh)     echo "https://api.minimaxi.com/v1/t2a_v2" ;;
+    global_en) echo "https://api.minimax.io/v1/t2a_v2" ;;
+    *)         echo "https://api.minimax.io/v1/t2a_v2" ;;
+  esac
+}
+
+# --- Request body construction ---
+# Built with python3 so arbitrary speech text (quotes, backslashes, newlines)
+# is JSON-escaped safely and rate is parsed as data, never interpolated into
+# a program string. Emits a single compact JSON object on stdout.
+_build_request_json() {
+  local text="$1" model="$2" voice="$3" rate="$4" fmt="$5"
+  MM_TEXT="$text" MM_MODEL="$model" MM_VOICE="$voice" MM_RATE="$rate" MM_FMT="$fmt" \
+    python3 - <<'PY'
+import json, os
+text = os.environ["MM_TEXT"]
+model = os.environ["MM_MODEL"]
+voice = os.environ["MM_VOICE"]
+fmt = os.environ["MM_FMT"]
+try:
+    speed = float(os.environ["MM_RATE"])
+except (ValueError, KeyError):
+    speed = 1.0
+# Clamp to the MiniMax-supported speed range.
+speed = max(0.5, min(2.0, speed))
+voice_setting = {"speed": speed}
+# "default" means "let the service choose" — omit voice_id entirely.
+if voice and voice != "default":
+    voice_setting["voice_id"] = voice
+body = {
+    "model": model,
+    "text": text,
+    "stream": False,
+    "voice_setting": voice_setting,
+    "audio_setting": {"format": fmt},
+}
+print(json.dumps(body))
+PY
+}
+
+# --- Response handling ---
+# Reads the T2A JSON response on stdin, verifies base_resp.status_code == 0,
+# then hex-decodes data.audio into the file named by $1. Exits non-zero on any
+# failure so the caller can skip playback.
+_decode_response_to_file() {
+  local outfile="$1"
+  # `python3 -c` (not `python3 - <<heredoc`) so the response JSON piped on
+  # stdin reaches the program instead of being shadowed by the here-doc.
+  MM_OUT="$outfile" python3 -c '
+import json, os, sys
+raw = sys.stdin.read()
+try:
+    payload = json.loads(raw)
+except Exception:
+    sys.exit(1)
+base = payload.get("base_resp") or {}
+if base.get("status_code", -1) != 0:
+    sys.stderr.write("base_resp.status_code=%s\n" % base.get("status_code"))
+    sys.exit(2)
+data = payload.get("data") or {}
+audio_hex = data.get("audio")
+if not audio_hex:
+    sys.exit(3)
+try:
+    audio_bytes = bytes.fromhex(audio_hex)
+except Exception:
+    sys.exit(4)
+with open(os.environ["MM_OUT"], "wb") as fh:
+    fh.write(audio_bytes)
+'
+}
+
+# --- Local playback (mirrors platform conventions in peon.sh play_sound) ---
+_play_linux() {
+  local file="$1" volume="$2" vint
+  if command -v pw-play >/dev/null 2>&1; then
+    pw-play --volume "$volume" "$file" 2>/dev/null || _debug "pw-play failed"
+  elif command -v ffplay >/dev/null 2>&1; then
+    vint=$(awk -v v="$volume" 'BEGIN { printf "%d", v * 100 }')
+    ffplay -nodisp -autoexit -volume "$vint" "$file" 2>/dev/null || _debug "ffplay failed"
+  elif command -v mpv >/dev/null 2>&1; then
+    vint=$(awk -v v="$volume" 'BEGIN { printf "%d", v * 100 }')
+    mpv --no-video --volume="$vint" "$file" 2>/dev/null || _debug "mpv failed"
+  elif command -v play >/dev/null 2>&1; then
+    play -v "$volume" "$file" 2>/dev/null || _debug "play failed"
+  elif command -v paplay >/dev/null 2>&1; then
+    paplay "$file" 2>/dev/null || _debug "paplay failed"
+  elif command -v aplay >/dev/null 2>&1; then
+    aplay -q "$file" 2>/dev/null || _debug "aplay failed"
+  else
+    _debug "no audio player found on Linux"
+  fi
+}
+
+_play_windows() {
+  local file="$1" volume="$2"
+  local ps_script="$PEON_DIR/scripts/win-play.ps1"
+  if [ ! -f "$ps_script" ]; then
+    _debug "win-play.ps1 not found at $ps_script"
+    return 0
+  fi
+  local winpath="$file"
+  command -v cygpath >/dev/null 2>&1 && winpath="$(cygpath -w "$file")"
+  powershell.exe -NoProfile -File "$ps_script" -path "$winpath" -vol "$volume" 2>/dev/null \
+    || _debug "win-play.ps1 failed"
+}
+
+_play_file() {
+  local file="$1" volume="$2"
+  case "$(uname -s)" in
+    Darwin)       afplay -v "$volume" "$file" 2>/dev/null || _debug "afplay failed" ;;
+    Linux)        _play_linux "$file" "$volume" ;;
+    MINGW*|MSYS*) _play_windows "$file" "$volume" ;;
+    *)            _debug "unsupported platform for playback: $(uname -s)" ;;
+  esac
+}
+
+# --- Entry point ---
+
+# MiniMax voices are documented voice_id strings rather than a locally
+# enumerable list, so --list-voices is a no-op that exits cleanly (keeps the
+# `peon tts voices` command working when this backend is active).
+if [ "${1:-}" = "--list-voices" ]; then
+  _debug "voice enumeration not supported for the MiniMax backend"
+  exit 0
+fi
+
+voice="${1:-default}"
+rate="${2:-1.0}"
+volume="${3:-0.5}"
+
+region="${PEON_MINIMAX_REGION:-global_en}"
+model="${PEON_MINIMAX_MODEL:-speech-2.8-hd}"
+fmt="${PEON_MINIMAX_FORMAT:-mp3}"
+url="$(_endpoint_for_region "$region")"
+if [ -n "${MINIMAX_GROUP_ID:-}" ]; then
+  url="${url}?GroupId=${MINIMAX_GROUP_ID}"
+fi
+
+# Read one line of text from stdin. Empty / whitespace-only input exits
+# silently — the hook pipeline sometimes invokes speak() with empty text.
+IFS= read -r text || text=""
+stripped="${text//[[:space:]]/}"
+if [ -z "$stripped" ]; then
+  _debug "empty input text"
+  exit 0
+fi
+
+# python3 is required for safe request/response handling.
+if ! command -v python3 >/dev/null 2>&1; then
+  _debug "python3 not found — cannot build request"
+  exit 0
+fi
+
+# Dry-run: record the resolved request (never the credential itself) and stop
+# before any network call. Powers the test harness.
+if [ "${PEON_TTS_DRY_RUN:-0}" = "1" ]; then
+  if [ -n "${PEON_TTS_TRACE_FILE:-}" ]; then
+    request_json="$(_build_request_json "$text" "$model" "$voice" "$rate" "$fmt")"
+    MM_TRACE="$PEON_TTS_TRACE_FILE" MM_URL="$url" MM_REGION="$region" \
+    MM_MODEL="$model" MM_FMT="$fmt" MM_VOICE="$voice" MM_RATE="$rate" \
+    MM_HAS_KEY="$([ -n "${MINIMAX_API_KEY:-}" ] && echo 1 || echo 0)" \
+    MM_HAS_GROUP="$([ -n "${MINIMAX_GROUP_ID:-}" ] && echo 1 || echo 0)" \
+    MM_REQ="$request_json" python3 - <<'PY'
+import json, os
+trace = {
+    "url": os.environ["MM_URL"],
+    "region": os.environ["MM_REGION"],
+    "model": os.environ["MM_MODEL"],
+    "format": os.environ["MM_FMT"],
+    "voice": os.environ["MM_VOICE"],
+    "rate": os.environ["MM_RATE"],
+    "has_api_key": os.environ["MM_HAS_KEY"] == "1",
+    "has_group_id": os.environ["MM_HAS_GROUP"] == "1",
+    "request": json.loads(os.environ["MM_REQ"]),
+}
+with open(os.environ["MM_TRACE"], "w") as fh:
+    json.dump(trace, fh)
+PY
+  fi
+  exit 0
+fi
+
+# Credential and curl are required for a live request.
+api_key="${MINIMAX_API_KEY:-}"
+if [ -z "$api_key" ]; then
+  _debug "MINIMAX_API_KEY not set — skipping synthesis"
+  exit 0
+fi
+if ! command -v curl >/dev/null 2>&1; then
+  _debug "curl not found — cannot reach the MiniMax API"
+  exit 0
+fi
+
+request_json="$(_build_request_json "$text" "$model" "$voice" "$rate" "$fmt")" || {
+  _debug "failed to build request body"
+  exit 0
+}
+
+# The Authorization header carries the Bearer credential; it is passed via an
+# argument to curl and never written to stdout, stderr, or the trace file.
+response="$(curl -sS --max-time 30 -X POST \
+  -H "Authorization: Bearer $api_key" \
+  -H "Content-Type: application/json" \
+  -d "$request_json" \
+  "$url" 2>/dev/null)" || {
+  _debug "curl request failed"
+  exit 0
+}
+
+tmpbase="$(mktemp "${TMPDIR:-/tmp}/peon-tts-minimax.XXXXXX")" || {
+  _debug "mktemp failed"
+  exit 0
+}
+tmpfile="${tmpbase}.${fmt}"
+mv "$tmpbase" "$tmpfile" 2>/dev/null || tmpfile="$tmpbase"
+
+if printf '%s' "$response" | _decode_response_to_file "$tmpfile"; then
+  _play_file "$tmpfile" "$volume"
+else
+  _debug "response decode failed — nothing to play"
+fi
+rm -f "$tmpfile" 2>/dev/null
+
+# Always exit 0 — TTS failure must never propagate to the caller.
+exit 0

--- a/tests/tts-minimax.Tests.ps1
+++ b/tests/tts-minimax.Tests.ps1
@@ -1,0 +1,221 @@
+# Pester 5 tests for scripts/tts-minimax.ps1 (Windows MiniMax T2A backend).
+# Run: Invoke-Pester -Path tests/tts-minimax.Tests.ps1
+#
+# Strategy mirrors tts-native.Tests.ps1: the impure half (the HTTP call) is
+# verified via a side-effect trace. Under PEON_TTS_DRY_RUN=1 the script writes
+# the resolved request (URL, region, model, format, voice, and JSON body) to
+# PEON_TTS_TRACE_FILE and exits 0 without reaching the API. The credential is
+# recorded only as a boolean, never as its value.
+
+BeforeAll {
+    $script:RepoRoot = Split-Path $PSScriptRoot -Parent
+    $script:TtsMinimaxPath = Join-Path (Join-Path $script:RepoRoot "scripts") "tts-minimax.ps1"
+
+    function Invoke-TtsMinimaxDryRun {
+        param(
+            [string]$InputText = "",
+            [string]$Voice = "default",
+            [double]$Rate = 1.0,
+            [double]$Vol = 0.5,
+            [string]$Region,
+            [string]$Model,
+            [string]$Format,
+            [string]$GroupId,
+            [string]$ApiKey
+        )
+
+        $tracePath = Join-Path $env:TEMP "peon-tts-minimax-trace-$([guid]::NewGuid().ToString('N').Substring(0,8)).json"
+
+        $argList = @("-NoProfile", "-NonInteractive", "-File", $script:TtsMinimaxPath,
+                     "-Voice", $Voice, "-Rate", $Rate, "-Vol", $Vol)
+
+        $psi = New-Object System.Diagnostics.ProcessStartInfo
+        $psi.FileName = "powershell.exe"
+        $psi.Arguments = ($argList | ForEach-Object {
+            if ($_ -match '\s') { "`"$_`"" } else { "$_" }
+        }) -join " "
+        $psi.UseShellExecute = $false
+        $psi.RedirectStandardInput = $true
+        $psi.RedirectStandardOutput = $true
+        $psi.RedirectStandardError = $true
+        $psi.CreateNoWindow = $true
+        $psi.Environment["PEON_TTS_DRY_RUN"] = "1"
+        $psi.Environment["PEON_TTS_TRACE_FILE"] = $tracePath
+        if ($Region) { $psi.Environment["PEON_MINIMAX_REGION"] = $Region }
+        if ($Model) { $psi.Environment["PEON_MINIMAX_MODEL"] = $Model }
+        if ($Format) { $psi.Environment["PEON_MINIMAX_FORMAT"] = $Format }
+        if ($GroupId) { $psi.Environment["MINIMAX_GROUP_ID"] = $GroupId }
+        if ($ApiKey) { $psi.Environment["MINIMAX_API_KEY"] = $ApiKey }
+
+        $proc = New-Object System.Diagnostics.Process
+        $proc.StartInfo = $psi
+        try {
+            $proc.Start() | Out-Null
+            if ($InputText) {
+                $proc.StandardInput.Write($InputText)
+            }
+            $proc.StandardInput.Close()
+
+            $stdoutTask = $proc.StandardOutput.ReadToEndAsync()
+            $stderrTask = $proc.StandardError.ReadToEndAsync()
+
+            if (-not $proc.WaitForExit(15000)) {
+                $proc.Kill()
+                throw "tts-minimax.ps1 timed out"
+            }
+
+            $stdout = $stdoutTask.Result
+            $stderr = $stderrTask.Result
+            $exitCode = $proc.ExitCode
+        } finally {
+            $proc.Dispose()
+        }
+
+        $trace = $null
+        $rawTrace = $null
+        if (Test-Path $tracePath) {
+            $rawTrace = Get-Content $tracePath -Raw -Encoding UTF8
+            $trace = $rawTrace | ConvertFrom-Json
+            Remove-Item $tracePath -Force -ErrorAction SilentlyContinue
+        }
+
+        return @{
+            ExitCode = $exitCode
+            Stdout   = $stdout
+            Stderr   = $stderr
+            Trace    = $trace
+            RawTrace = $rawTrace
+        }
+    }
+}
+
+# ============================================================
+# Structural / parse validation
+# ============================================================
+
+Describe "tts-minimax.ps1 structural validation" {
+    It "exists in scripts/" {
+        $script:TtsMinimaxPath | Should -Exist
+    }
+
+    It "has valid PowerShell syntax" {
+        $content = Get-Content $script:TtsMinimaxPath -Raw
+        $errors = $null
+        $null = [System.Management.Automation.PSParser]::Tokenize($content, [ref]$errors)
+        $errors.Count | Should -Be 0
+    }
+
+    It "contains a comment-based help header near the top" {
+        $content = Get-Content $script:TtsMinimaxPath -Raw
+        $content | Should -Match '(?s)^\s*<#.*\.SYNOPSIS.*\.PARAMETER.*\.EXAMPLE.*#>'
+    }
+
+    It "declares InputText with ValueFromPipeline" {
+        $content = Get-Content $script:TtsMinimaxPath -Raw
+        $content | Should -Match '(?s)\[Parameter\(\s*ValueFromPipeline\s*=\s*\$true\s*\)\][^}]*\[string\]\s*\$InputText'
+    }
+
+    It "declares Voice parameter with 'default' default" {
+        $content = Get-Content $script:TtsMinimaxPath -Raw
+        $content | Should -Match '\[string\]\s*\$Voice\s*=\s*"default"'
+    }
+
+    It "declares Rate parameter as double with 1.0 default" {
+        $content = Get-Content $script:TtsMinimaxPath -Raw
+        $content | Should -Match '\[double\]\s*\$Rate\s*=\s*1\.0'
+    }
+
+    It "declares Vol parameter as double with 0.5 default" {
+        $content = Get-Content $script:TtsMinimaxPath -Raw
+        $content | Should -Match '\[double\]\s*\$Vol\s*=\s*0\.5'
+    }
+
+    It "uses begin/process/end blocks for pipeline input" {
+        $content = Get-Content $script:TtsMinimaxPath -Raw
+        $content | Should -Match '(?ms)^\s*begin\s*\{'
+        $content | Should -Match '(?ms)^\s*process\s*\{'
+        $content | Should -Match '(?ms)^\s*end\s*\{'
+    }
+
+    It "does not contain ExecutionPolicy Bypass" {
+        $content = Get-Content $script:TtsMinimaxPath -Raw
+        $content | Should -Not -Match "ExecutionPolicy Bypass"
+    }
+}
+
+# ============================================================
+# Request construction (dry-run trace)
+# ============================================================
+
+Describe "tts-minimax.ps1 request construction" {
+    It "resolves the global endpoint by default" {
+        $r = Invoke-TtsMinimaxDryRun -InputText "hello"
+        $r.ExitCode | Should -Be 0
+        $r.Trace.url | Should -Be "https://api.minimax.io/v1/t2a_v2"
+        $r.Trace.region | Should -Be "global_en"
+    }
+
+    It "resolves the CN endpoint for region cn_zh" {
+        $r = Invoke-TtsMinimaxDryRun -InputText "hello" -Region "cn_zh"
+        $r.Trace.url | Should -Be "https://api.minimaxi.com/v1/t2a_v2"
+    }
+
+    It "falls back to the global endpoint for an unknown region" {
+        $r = Invoke-TtsMinimaxDryRun -InputText "hi" -Region "bogus"
+        $r.Trace.url | Should -Be "https://api.minimax.io/v1/t2a_v2"
+    }
+
+    It "appends MINIMAX_GROUP_ID as a query argument" {
+        $r = Invoke-TtsMinimaxDryRun -InputText "hi" -GroupId "grp42"
+        $r.Trace.url | Should -Be "https://api.minimax.io/v1/t2a_v2?GroupId=grp42"
+        $r.Trace.has_group_id | Should -BeTrue
+    }
+
+    It "defaults the model to speech-2.8-hd" {
+        $r = Invoke-TtsMinimaxDryRun -InputText "hi"
+        $r.Trace.model | Should -Be "speech-2.8-hd"
+        $r.Trace.request.model | Should -Be "speech-2.8-hd"
+    }
+
+    It "honors PEON_MINIMAX_MODEL (speech-2.8-turbo)" {
+        $r = Invoke-TtsMinimaxDryRun -InputText "hi" -Model "speech-2.8-turbo"
+        $r.Trace.request.model | Should -Be "speech-2.8-turbo"
+    }
+
+    It "carries the text and audio format in the request body" {
+        $r = Invoke-TtsMinimaxDryRun -InputText "read this" -Format "wav"
+        $r.Trace.request.text | Should -Be "read this"
+        $r.Trace.request.audio_setting.format | Should -Be "wav"
+    }
+
+    It "omits voice_id when the voice is default" {
+        $r = Invoke-TtsMinimaxDryRun -InputText "hi" -Voice "default"
+        $r.Trace.request.voice_setting.PSObject.Properties.Name | Should -Not -Contain "voice_id"
+    }
+
+    It "sets voice_id when an explicit voice is given" {
+        $r = Invoke-TtsMinimaxDryRun -InputText "hi" -Voice "some-voice-id"
+        $r.Trace.request.voice_setting.voice_id | Should -Be "some-voice-id"
+    }
+
+    It "clamps rate above 2.0 to 2.0" {
+        $r = Invoke-TtsMinimaxDryRun -InputText "hi" -Rate 3.0
+        $r.Trace.request.voice_setting.speed | Should -Be 2.0
+    }
+
+    It "clamps rate below 0.5 to 0.5" {
+        $r = Invoke-TtsMinimaxDryRun -InputText "hi" -Rate 0.1
+        $r.Trace.request.voice_setting.speed | Should -Be 0.5
+    }
+
+    It "records only a boolean for the credential, never its value" {
+        $r = Invoke-TtsMinimaxDryRun -InputText "hi" -ApiKey "super-secret-value"
+        $r.Trace.has_api_key | Should -BeTrue
+        $r.RawTrace | Should -Not -Match "super-secret-value"
+    }
+
+    It "exits 0 on empty input without writing a request body" {
+        $r = Invoke-TtsMinimaxDryRun -InputText ""
+        $r.ExitCode | Should -Be 0
+    }
+}

--- a/tests/tts-minimax.bats
+++ b/tests/tts-minimax.bats
@@ -1,0 +1,329 @@
+#!/usr/bin/env bats
+#
+# Unit tests for scripts/tts-minimax.sh (MiniMax T2A cloud TTS backend).
+#
+# The backend has two verifiable halves:
+#   1. Request construction — region → endpoint mapping, model/format/voice
+#      resolution, GroupId handling, JSON body. Verified through the dry-run
+#      trace (PEON_TTS_DRY_RUN=1 writes the resolved request to a trace file
+#      and skips the network call).
+#   2. Live request + response handling — verified against a PATH-mocked
+#      `curl` returning a canned T2A response and a PATH-mocked audio player,
+#      asserting the hex audio is decoded and handed to the player.
+#
+# The credential (MINIMAX_API_KEY) must never appear in the trace or on any
+# output stream — asserted explicitly below.
+
+TTS_SCRIPT="$(cd "$(dirname "${BATS_TEST_FILENAME}")/.." && pwd)/scripts/tts-minimax.sh"
+
+setup() {
+  TEST_DIR="$(mktemp -d)"
+  export TEST_DIR
+  MOCK_BIN="$TEST_DIR/mock_bin"
+  mkdir -p "$MOCK_BIN"
+  export PEON_DIR="$TEST_DIR"
+  unset PEON_DEBUG PEON_MINIMAX_REGION PEON_MINIMAX_MODEL PEON_MINIMAX_FORMAT
+  unset MINIMAX_API_KEY MINIMAX_GROUP_ID
+}
+
+teardown() {
+  rm -rf "$TEST_DIR"
+}
+
+# --- Helpers ---
+
+# Install a mock binary that logs args to <name>.log and stdin to <name>.stdin.
+mock_cmd() {
+  local name="$1" exit_code="${2:-0}"
+  local path="$MOCK_BIN/$name"
+  {
+    printf '%s\n' '#!/bin/bash'
+    printf 'echo "ARGS: $*" >> "%s/%s.log"\n' "$TEST_DIR" "$name"
+    printf 'if [ ! -t 0 ]; then cat >> "%s/%s.stdin"; fi\n' "$TEST_DIR" "$name"
+    printf 'exit %s\n' "$exit_code"
+  } > "$path"
+  chmod +x "$path"
+}
+
+mock_uname() {
+  local kernel="$1"
+  cat > "$MOCK_BIN/uname" <<SCRIPT
+#!/bin/bash
+printf '%s\n' '$kernel'
+SCRIPT
+  chmod +x "$MOCK_BIN/uname"
+}
+
+# Mock curl: log args, then emit a canned response body to stdout.
+mock_curl_response() {
+  local body="$1" exit_code="${2:-0}"
+  {
+    printf '%s\n' '#!/bin/bash'
+    printf 'echo "ARGS: $*" >> "%s/curl.log"\n' "$TEST_DIR"
+    printf 'printf %s %q\n' '%s' "$body"
+    printf 'exit %s\n' "$exit_code"
+  } > "$MOCK_BIN/curl"
+  chmod +x "$MOCK_BIN/curl"
+}
+
+with_mocks() { export PATH="$MOCK_BIN:$PATH"; }
+
+mock_args() { [ -f "$TEST_DIR/$1.log" ] && cat "$TEST_DIR/$1.log"; }
+mock_called() { [ -f "$TEST_DIR/$1.log" ]; }
+
+# Read a field out of the dry-run trace JSON.
+tj() {
+  python3 -c "import json;d=json.load(open('$1'));print($2)"
+}
+
+run_dry() {
+  # run_dry <text> <voice> <rate> <vol> ; writes trace to $TEST_DIR/trace.json
+  local text="$1" voice="${2:-default}" rate="${3:-1.0}" vol="${4:-0.5}"
+  printf '%s\n' "$text" | \
+    PEON_TTS_DRY_RUN=1 PEON_TTS_TRACE_FILE="$TEST_DIR/trace.json" \
+    bash "$TTS_SCRIPT" "$voice" "$rate" "$vol"
+}
+
+# ============================================================
+# Script existence + syntax
+# ============================================================
+
+@test "tts-minimax.sh: file exists and is executable" {
+  [ -f "$TTS_SCRIPT" ]
+  [ -x "$TTS_SCRIPT" ]
+}
+
+@test "tts-minimax.sh: passes bash -n syntax check" {
+  bash -n "$TTS_SCRIPT"
+}
+
+# ============================================================
+# Regional endpoint resolution (dry-run)
+# ============================================================
+
+@test "dry-run: default region resolves the global endpoint" {
+  run_dry "hello"
+  [ "$(tj "$TEST_DIR/trace.json" "d['url']")" = "https://api.minimax.io/v1/t2a_v2" ]
+  [ "$(tj "$TEST_DIR/trace.json" "d['region']")" = "global_en" ]
+}
+
+@test "dry-run: cn_zh region resolves the CN endpoint" {
+  printf '%s\n' "hello" | \
+    PEON_TTS_DRY_RUN=1 PEON_TTS_TRACE_FILE="$TEST_DIR/trace.json" \
+    PEON_MINIMAX_REGION=cn_zh bash "$TTS_SCRIPT" default 1.0 0.5
+  [ "$(tj "$TEST_DIR/trace.json" "d['url']")" = "https://api.minimaxi.com/v1/t2a_v2" ]
+}
+
+@test "dry-run: unknown region falls back to the global endpoint" {
+  printf '%s\n' "hi" | \
+    PEON_TTS_DRY_RUN=1 PEON_TTS_TRACE_FILE="$TEST_DIR/trace.json" \
+    PEON_MINIMAX_REGION=bogus bash "$TTS_SCRIPT" default 1.0 0.5
+  [ "$(tj "$TEST_DIR/trace.json" "d['url']")" = "https://api.minimax.io/v1/t2a_v2" ]
+}
+
+@test "dry-run: MINIMAX_GROUP_ID is appended as a query argument" {
+  printf '%s\n' "hi" | \
+    PEON_TTS_DRY_RUN=1 PEON_TTS_TRACE_FILE="$TEST_DIR/trace.json" \
+    MINIMAX_GROUP_ID=grp42 bash "$TTS_SCRIPT" default 1.0 0.5
+  [ "$(tj "$TEST_DIR/trace.json" "d['url']")" = "https://api.minimax.io/v1/t2a_v2?GroupId=grp42" ]
+  [ "$(tj "$TEST_DIR/trace.json" "d['has_group_id']")" = "True" ]
+}
+
+# ============================================================
+# Model + request body (dry-run)
+# ============================================================
+
+@test "dry-run: default model is speech-2.8-hd" {
+  run_dry "hi"
+  [ "$(tj "$TEST_DIR/trace.json" "d['model']")" = "speech-2.8-hd" ]
+  [ "$(tj "$TEST_DIR/trace.json" "d['request']['model']")" = "speech-2.8-hd" ]
+}
+
+@test "dry-run: PEON_MINIMAX_MODEL overrides the model (speech-2.8-turbo)" {
+  printf '%s\n' "hi" | \
+    PEON_TTS_DRY_RUN=1 PEON_TTS_TRACE_FILE="$TEST_DIR/trace.json" \
+    PEON_MINIMAX_MODEL=speech-2.8-turbo bash "$TTS_SCRIPT" default 1.0 0.5
+  [ "$(tj "$TEST_DIR/trace.json" "d['request']['model']")" = "speech-2.8-turbo" ]
+}
+
+@test "dry-run: request carries model, text, and voice_setting.speed" {
+  run_dry "read this aloud"
+  [ "$(tj "$TEST_DIR/trace.json" "d['request']['text']")" = "read this aloud" ]
+  [ "$(tj "$TEST_DIR/trace.json" "d['request']['voice_setting']['speed']")" = "1.0" ]
+  [ "$(tj "$TEST_DIR/trace.json" "d['request']['audio_setting']['format']")" = "mp3" ]
+}
+
+@test "dry-run: voice=default omits voice_id" {
+  run_dry "hi" default 1.0 0.5
+  [ "$(tj "$TEST_DIR/trace.json" "'voice_id' in d['request']['voice_setting']")" = "False" ]
+}
+
+@test "dry-run: explicit voice populates voice_setting.voice_id" {
+  run_dry "hi" some-voice-id 1.0 0.5
+  [ "$(tj "$TEST_DIR/trace.json" "d['request']['voice_setting']['voice_id']")" = "some-voice-id" ]
+}
+
+@test "dry-run: PEON_MINIMAX_FORMAT changes audio_setting.format" {
+  printf '%s\n' "hi" | \
+    PEON_TTS_DRY_RUN=1 PEON_TTS_TRACE_FILE="$TEST_DIR/trace.json" \
+    PEON_MINIMAX_FORMAT=wav bash "$TTS_SCRIPT" default 1.0 0.5
+  [ "$(tj "$TEST_DIR/trace.json" "d['request']['audio_setting']['format']")" = "wav" ]
+}
+
+# ============================================================
+# Rate clamping (dry-run)
+# ============================================================
+
+@test "dry-run: rate above 2.0 is clamped to 2.0" {
+  run_dry "hi" default 3.0 0.5
+  [ "$(tj "$TEST_DIR/trace.json" "d['request']['voice_setting']['speed']")" = "2.0" ]
+}
+
+@test "dry-run: rate below 0.5 is clamped to 0.5" {
+  run_dry "hi" default 0.1 0.5
+  [ "$(tj "$TEST_DIR/trace.json" "d['request']['voice_setting']['speed']")" = "0.5" ]
+}
+
+# ============================================================
+# Credential safety
+# ============================================================
+
+@test "dry-run: has_api_key reflects the environment" {
+  run_dry "hi"
+  [ "$(tj "$TEST_DIR/trace.json" "d['has_api_key']")" = "False" ]
+  printf '%s\n' "hi" | \
+    PEON_TTS_DRY_RUN=1 PEON_TTS_TRACE_FILE="$TEST_DIR/trace.json" \
+    MINIMAX_API_KEY=sekret bash "$TTS_SCRIPT" default 1.0 0.5
+  [ "$(tj "$TEST_DIR/trace.json" "d['has_api_key']")" = "True" ]
+}
+
+@test "dry-run: the API key value never appears in the trace" {
+  printf '%s\n' "hi" | \
+    PEON_TTS_DRY_RUN=1 PEON_TTS_TRACE_FILE="$TEST_DIR/trace.json" \
+    MINIMAX_API_KEY=super-secret-value bash "$TTS_SCRIPT" default 1.0 0.5
+  ! grep -q "super-secret-value" "$TEST_DIR/trace.json"
+}
+
+# ============================================================
+# Text safety — shell metacharacters
+# ============================================================
+
+@test "dry-run: metacharacters in text are JSON-escaped, not interpreted" {
+  run_dry 'Hello $USER `whoami` "quoted"'
+  [ "$(tj "$TEST_DIR/trace.json" "d['request']['text']")" = 'Hello $USER `whoami` "quoted"' ]
+}
+
+# ============================================================
+# Empty / whitespace input contract
+# ============================================================
+
+@test "empty stdin: exits 0 without writing a trace or calling curl" {
+  mock_curl_response '{}'
+  with_mocks
+  run bash -c ": | PEON_TTS_DRY_RUN=1 PEON_TTS_TRACE_FILE='$TEST_DIR/trace.json' bash '$TTS_SCRIPT' default 1.0 0.5"
+  [ "$status" -eq 0 ]
+  [ ! -f "$TEST_DIR/trace.json" ]
+  ! mock_called "curl"
+}
+
+@test "whitespace-only stdin: exits 0 without calling curl" {
+  mock_curl_response '{}'
+  with_mocks
+  run bash -c "printf '   \\n' | MINIMAX_API_KEY=k bash '$TTS_SCRIPT' default 1.0 0.5"
+  [ "$status" -eq 0 ]
+  ! mock_called "curl"
+}
+
+# ============================================================
+# --list-voices contract
+# ============================================================
+
+@test "--list-voices: exits 0 without a request" {
+  mock_curl_response '{}'
+  with_mocks
+  run bash "$TTS_SCRIPT" --list-voices
+  [ "$status" -eq 0 ]
+  ! mock_called "curl"
+}
+
+# ============================================================
+# Live path — request + response handling
+# ============================================================
+
+@test "live: no MINIMAX_API_KEY skips the request and exits 0" {
+  mock_curl_response '{"data":{"audio":"6162"},"base_resp":{"status_code":0}}'
+  with_mocks
+  run bash -c "echo hi | bash '$TTS_SCRIPT' default 1.0 0.5"
+  [ "$status" -eq 0 ]
+  ! mock_called "curl"
+}
+
+@test "live: curl is invoked with the endpoint URL and a Bearer header" {
+  mock_uname "Darwin"
+  mock_cmd "afplay"
+  mock_curl_response '{"data":{"audio":"6162","status":2},"base_resp":{"status_code":0}}'
+  with_mocks
+  echo "hi" | MINIMAX_API_KEY=k bash "$TTS_SCRIPT" default 1.0 0.5
+  mock_called "curl"
+  local args; args=$(mock_args "curl")
+  [[ "$args" == *"https://api.minimax.io/v1/t2a_v2"* ]]
+  [[ "$args" == *"Authorization: Bearer"* ]]
+}
+
+@test "live: successful response is hex-decoded and handed to the macOS player" {
+  mock_uname "Darwin"
+  # afplay mock records the byte content of the file it is asked to play.
+  cat > "$MOCK_BIN/afplay" <<SCRIPT
+#!/bin/bash
+echo "ARGS: \$*" >> "$TEST_DIR/afplay.log"
+for a in "\$@"; do f="\$a"; done
+[ -f "\$f" ] && od -An -tx1 "\$f" | tr -d ' \n' >> "$TEST_DIR/afplay.bytes"
+SCRIPT
+  chmod +x "$MOCK_BIN/afplay"
+  mock_curl_response '{"data":{"audio":"6162","status":2},"base_resp":{"status_code":0}}'
+  with_mocks
+  echo "hi" | MINIMAX_API_KEY=k bash "$TTS_SCRIPT" default 1.0 0.7
+  mock_called "afplay"
+  [[ "$(mock_args afplay)" == *"-v 0.7"* ]]
+  # 6162 hex == "ab"
+  [ "$(cat "$TEST_DIR/afplay.bytes")" = "6162" ]
+}
+
+@test "live: base_resp.status_code != 0 skips playback" {
+  mock_uname "Darwin"
+  mock_cmd "afplay"
+  mock_curl_response '{"base_resp":{"status_code":1001,"status_msg":"bad"}}'
+  with_mocks
+  run bash -c "echo hi | MINIMAX_API_KEY=k bash '$TTS_SCRIPT' default 1.0 0.5"
+  [ "$status" -eq 0 ]
+  ! mock_called "afplay"
+}
+
+@test "live: empty data.audio skips playback" {
+  mock_uname "Darwin"
+  mock_cmd "afplay"
+  mock_curl_response '{"data":{"audio":""},"base_resp":{"status_code":0}}'
+  with_mocks
+  run bash -c "echo hi | MINIMAX_API_KEY=k bash '$TTS_SCRIPT' default 1.0 0.5"
+  [ "$status" -eq 0 ]
+  ! mock_called "afplay"
+}
+
+@test "live: curl failure does not fail the script (exit 0)" {
+  mock_uname "Darwin"
+  mock_cmd "afplay"
+  mock_curl_response '' 1
+  with_mocks
+  run bash -c "echo hi | MINIMAX_API_KEY=k bash '$TTS_SCRIPT' default 1.0 0.5"
+  [ "$status" -eq 0 ]
+  ! mock_called "afplay"
+}
+
+@test "live: Linux routes decoded audio through the preferred player (pw-play)" {
+  mock_uname "Linux"
+  mock_cmd "pw-play"
+  mock_curl_response '{"data":{"audio":"6162","status":2},"base_resp":{"status_code":0}}'
+  with_mocks
+  echo "hi" | MINIMAX_API_KEY=k bash "$TTS_SCRIPT" default 1.0 0.5
+  mock_called "pw-play"
+}


### PR DESCRIPTION
Reason: The pluggable TTS backend interface ships only OS-native engines — there is no MiniMax speech backend, no global/CN T2A endpoint configuration, and no MiniMax request/response handling.

## What

Adds a MiniMax text-to-audio (T2A v2) TTS backend that plugs into the existing backend selector, following the independent-script calling convention documented in `docs/adr/ADR-001-tts-backend-architecture.md`. Unlike the OS-native backend (which speaks directly to the audio device), this backend synthesizes over HTTP and plays the returned audio locally.

## Changes

- **`scripts/tts-minimax.sh`** — Unix backend. Reads text on stdin per the calling convention (`echo <text> | tts-minimax.sh <voice> <rate> <volume>`), and:
  - Resolves the regional endpoint from `PEON_MINIMAX_REGION`: `global_en` (default) → `https://api.minimax.io/v1/t2a_v2`, `cn_zh` → `https://api.minimaxi.com/v1/t2a_v2`.
  - Builds the T2A request body (model defaults to `speech-2.8-hd`; `speech-2.8-turbo` and the other T2A models are selectable via `PEON_MINIMAX_MODEL`), mapping `rate` → `voice_setting.speed` (clamped 0.5–2.0) and `voice` → `voice_setting.voice_id` (omitted when `default`). JSON is assembled with `python3` so arbitrary speech text is escaped safely.
  - Sends the `Bearer` request (`MINIMAX_API_KEY`, optional `MINIMAX_GROUP_ID` query argument), then verifies `base_resp.status_code`, hex-decodes `data.audio`, and plays it via the platform player (afplay / Linux player chain / `win-play.ps1`), applying `volume` at the player.
  - Always exits 0; a missing credential, `python3`, `curl`, or a non-zero API status is a silent no-op so TTS never fails the calling hook.
- **`scripts/tts-minimax.ps1`** — Windows counterpart mirroring the native backend's `begin/process/end` structure and its `PEON_TTS_DRY_RUN` trace hook.
- **`peon.sh`** and **`install.ps1`** — register `minimax` in the TTS backend selectors (explicit case + `auto` probe entry), matching the existing opt-in cloud-backend pattern.
- **`tests/tts-minimax.bats`** and **`tests/tts-minimax.Tests.ps1`** — cover endpoint resolution, model/format/voice/GroupId request construction, rate clamping, credential safety (the key value never reaches the trace), metacharacter safety, and response decode/playback (including error and empty-audio paths).

The credential is only ever passed as a request header — it is never written to stdout, stderr, or the dry-run trace.

## Checks

- `bats tests/tts-minimax.bats` — 27 passing.
- `bats tests/tts-native.bats` — 42 passing (no regression).
- `bash -n scripts/tts-minimax.sh` and `bash -n peon.sh` — clean.

The Windows backend and its Pester suite mirror the existing native backend's structure and are exercised by the repository's Pester CI job.
