### PR TITLE
fix: use `user-invocable` frontmatter key in skills (was `user_invocable`)

### DIFF
--- a/skills/peon-ping-config/SKILL.md
+++ b/skills/peon-ping-config/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: peon-ping-config
 description: Update peon-ping configuration — volume, pack rotation, categories, active pack, and other settings. Use when user wants to change peon-ping settings like volume, enable round-robin, add packs to rotation, toggle sound categories, or adjust any config.
-user_invocable: false
+user-invocable: false
 ---
 
 # peon-ping-config

--- a/skills/peon-ping-log/SKILL.md
+++ b/skills/peon-ping-log/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: peon-ping-log
 description: Log exercise reps for the Peon Trainer. Use when user says they did pushups, squats, or wants to log reps. Examples - "/peon-ping-log 25 pushups", "/peon-ping-log 30 squats", "log 50 pushups".
-user_invocable: true
+user-invocable: true
 ---
 
 # peon-ping-log

--- a/skills/peon-ping-rename/SKILL.md
+++ b/skills/peon-ping-rename/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: peon-ping-rename
 description: Rename the current Claude session for peon-ping notifications and terminal tab title. Use when user wants to give this session a custom name like "/peon-ping-rename Auth Refactor". Call with no argument to reset to auto-detect.
-user_invocable: true
+user-invocable: true
 license: MIT
 metadata:
   author: PeonPing

--- a/skills/peon-ping-toggle/SKILL.md
+++ b/skills/peon-ping-toggle/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: peon-ping-toggle
 description: Toggle peon-ping sound notifications on/off. Use when user wants to mute, unmute, pause, or resume peon sounds during a Claude Code session. Also handles config changes like volume, pack rotation, categories — any peon-ping setting.
-user_invocable: true
+user-invocable: true
 ---
 
 # peon-ping-toggle

--- a/skills/peon-ping-use/SKILL.md
+++ b/skills/peon-ping-use/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: peon-ping-use
 description: Set which voice pack (character voice) plays for the current chat session. Automatically enables session_override rotation mode if not already set. Use when user wants a specific character voice like GLaDOS, Peon, or Kerrigan for this conversation.
-user_invocable: true
+user-invocable: true
 license: MIT
 metadata:
   author: PeonPing


### PR DESCRIPTION
All five bundled skills declared the frontmatter key as `user_invocable`, but Claude Code reads `user-invocable`. The unrecognized key was silently ignored, so the intended visibility of each skill was never applied.