### PR TITLE
Fix click-to-focus in local tmux sessions: resolve the hosting terminal at click time

### DIFF
--- a/peon.sh
+++ b/peon.sh
@@ -751,11 +751,44 @@ play_sound() {
   esac
 }
 
+# --- Live tmux client context (click-to-focus) ---
+# Echoes "<bundle_id>|<client_tty>|<terminal_pid>" describing the client attached
+# to this pane's session at this instant — empty fields when nothing is attached,
+# and an empty bundle id off macOS. Memoized because both consumers below want a
+# slice of it and the lookup forks ps/lsappinfo a few times.
+_peon_tmux_client_context() {
+  if [ -n "${_PEON_TMUX_CTX_RESOLVED:-}" ]; then
+    printf '%s\n' "${_PEON_TMUX_CTX:-}"
+    return 0
+  fi
+  _PEON_TMUX_CTX_RESOLVED=1
+  _PEON_TMUX_CTX=""
+  { [ -n "${TMUX:-}" ] && [ -n "${TMUX_PANE:-}" ]; } || return 0
+  local _helper
+  _helper="$(find_bundled_script "local-focus.sh")" 2>/dev/null || return 0
+  [ -x "$_helper" ] || return 0
+  _PEON_TMUX_CTX="$("$_helper" --print-context "${TMUX%%,*}" "$TMUX_PANE" "" "$(command -v tmux 2>/dev/null)" 2>/dev/null)"
+  printf '%s\n' "$_PEON_TMUX_CTX"
+}
+
 # --- Terminal bundle ID detection (macOS click-to-focus) ---
 # Returns the macOS bundle identifier for the current terminal emulator,
 # or empty string if unknown. Used with terminal-notifier -activate and
 # mac-overlay.js click handler to focus the right terminal on notification click.
 _mac_terminal_bundle_id() {
+  # Inside tmux, ask tmux — not this process's environment. The env below names
+  # the emulator the session was FIRST attached from and never updates, so it
+  # goes stale the moment the terminal is restarted or the session is re-attached
+  # from another one, and it is empty for emulators that export no identity at
+  # all (kitty, alacritty). scripts/local-focus.sh derives the app from the
+  # client attached right now; see its header for the full rationale.
+  if [ -n "${TMUX:-}" ] && ! _is_cmux_session; then
+    local _live_bundle
+    _live_bundle="$(_peon_tmux_client_context)"
+    _live_bundle="${_live_bundle%%|*}"
+    [ -n "$_live_bundle" ] && { echo "$_live_bundle"; return; }
+  fi
+
   case "${TERM_PROGRAM:-}" in
     ghostty)
       if _is_cmux_session; then
@@ -787,6 +820,11 @@ _mac_terminal_bundle_id() {
         echo "com.googlecode.iterm2"
       elif [ -n "${WARP_IS_LOCAL_SHELL_SESSION:-}" ]; then
         echo "dev.warp.Warp-Stable"
+      elif [ -n "${KITTY_WINDOW_ID:-}" ] || [ -n "${KITTY_PID:-}" ]; then
+        # kitty and alacritty set no TERM_PROGRAM, so they only ever reach here.
+        echo "net.kovidgoyal.kitty"
+      elif [ -n "${ALACRITTY_WINDOW_ID:-}" ] || [ -n "${ALACRITTY_SOCKET:-}" ]; then
+        echo "org.alacritty"
       else
         echo ""
       fi ;;
@@ -920,7 +958,14 @@ _mac_bundle_id_from_pid() {
 _resolve_session_tty() {
   [ -n "${PEON_SESSION_TTY:-}" ] && return 0
   if [ -n "${TMUX:-}" ]; then
-    PEON_SESSION_TTY=$(tmux display-message -p '#{client_tty}' 2>/dev/null || true)
+    # Take the tty from the same deterministic client pick the click path uses:
+    # with several clients on one session, an untargeted `display-message`
+    # answers for whichever tmux considers current, which need not be ours.
+    PEON_SESSION_TTY="$(_peon_tmux_client_context)"
+    PEON_SESSION_TTY="${PEON_SESSION_TTY#*|}"
+    PEON_SESSION_TTY="${PEON_SESSION_TTY%%|*}"
+    [ -z "$PEON_SESSION_TTY" ] && \
+      PEON_SESSION_TTY=$(tmux display-message -p '#{client_tty}' 2>/dev/null || true)
   else
     # Walk the full process tree; keep the LAST (highest ancestor) tty found.
     # Claude Code spawns hooks from worker processes that may have their own
@@ -997,6 +1042,10 @@ send_notification() {
       export PEON_SYNC="0"
       [ "${PEON_TEST:-0}" = "1" ] && export PEON_SYNC="1"
       if [ "$PEON_PLATFORM" = "mac" ]; then
+        # Prime the live tmux client lookup here, in this shell: both consumers
+        # below run in command substitutions, where the memoization would die
+        # with the subshell and the lookup would run twice.
+        _peon_tmux_client_context >/dev/null
         export PEON_BUNDLE_ID="$(_mac_terminal_bundle_id)"
         export PEON_IDE_PID="$(_mac_ide_pid)"
         # Warp's per-session deep link; opening it on click focuses the exact tab.

--- a/scripts/local-focus.sh
+++ b/scripts/local-focus.sh
@@ -1,0 +1,253 @@
+#!/bin/bash
+# peon-ping: click-time focus helper for LOCAL tmux sessions (macOS).
+#
+# Usage:
+#   local-focus.sh <tmux-socket> <tmux-pane> [fallback-bundle-id] [tmux-bin]
+#       Click handler: raise the terminal that is showing this tmux session right
+#       now, then switch that client to the agent's own window/pane.
+#   local-focus.sh --print-context <tmux-socket> <tmux-pane> "" [tmux-bin]
+#       Print "<bundle_id>|<client_tty>|<terminal_pid>" for the notifier to use at
+#       notify time (empty fields when nothing is attached). No side effects.
+#
+# WHY the terminal is resolved at click time and not from the environment
+#
+# A hook only sees the environment its own process inherited, and a pane's
+# environment is frozen when the pane is created. The identity vars peon reads
+# (ITERM_SESSION_ID, GHOSTTY_RESOURCES_DIR, WARP_IS_LOCAL_SHELL_SESSION) therefore
+# name the emulator the tmux session was FIRST attached from — forever:
+#   - quit/restart the terminal, or attach the session from a different one, and
+#     the stored identity points at an app that is not showing this session, so
+#     the click raises the wrong window (or relaunches a quit app);
+#   - kitty and alacritty export no such var at all, so the identity comes out
+#     empty and the click raises nothing — the notification looks dead.
+# tmux is never stale: it knows which client is attached at this instant. So ask
+# tmux, then walk that client's process ancestry until an ancestor has a bundle
+# id — that ancestor is the hosting terminal, whichever emulator it happens to
+# be. Same discovery ssh-focus.sh does for relayed remote sessions.
+#
+# Constraints (mirrors ssh-focus.sh):
+#   - The overlay's click handler blocks on this: return fast, never prompt.
+#   - Runs under stock macOS /bin/bash 3.2 (BSD regex: interval upper bounds
+#     above 255 are invalid and silently never match — use unbounded +).
+#   - Only ever drive a tmux client that was positively identified.
+#   - Always exits 0.
+set -u
+
+MODE="click"
+if [ "${1:-}" = "--print-context" ]; then
+  MODE="context"
+  shift
+fi
+
+SOCK="${1:-}"
+PANE="${2:-}"
+FALLBACK_BUNDLE="${3:-}"
+TMUX_BIN_ARG="${4:-}"
+
+PEON_DIR="${PEON_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+
+_DBG_ON=""
+_dbg() {
+  if [ -z "$_DBG_ON" ]; then
+    # PEON_DEBUG is not exported by the hook, so honour config.json's `debug`
+    # too — otherwise the click path is undebuggable in normal use.
+    if [ "${PEON_DEBUG:-0}" = "1" ] || grep -q '"debug"[[:space:]]*:[[:space:]]*true' "$PEON_DIR/config.json" 2>/dev/null; then
+      _DBG_ON=1
+    else
+      _DBG_ON=0
+    fi
+  fi
+  [ "$_DBG_ON" = "1" ] || return 0
+  local d="$PEON_DIR/logs"
+  mkdir -p "$d" 2>/dev/null || return 0
+  printf '%s [local-focus] %s\n' "$(date '+%Y-%m-%dT%H:%M:%S')" "$*" \
+    >> "$d/peon-ping-$(date +%Y-%m-%d).log" 2>/dev/null || true
+}
+
+_bail() {
+  # context mode must still print a (empty) record so callers can parse blindly
+  [ "$MODE" = "context" ] && printf '||\n'
+  exit 0
+}
+
+# --- Validate inputs (both modes) ---
+[[ "$PANE" =~ ^%?[0-9]+$ ]] || { _dbg "bad pane=$PANE"; _bail; }
+[[ "$SOCK" =~ ^/[A-Za-z0-9._/-]+$ ]] || { _dbg "bad socket=$SOCK"; _bail; }
+
+# Which tmux to drive. The click runs under `bash -lc` from the overlay, whose
+# login PATH is whatever ~/.bash_profile happens to set — not the hook's PATH. On
+# a Mac that regularly means finding /usr/bin/tmux (3.5a) instead of the Homebrew
+# build the server actually runs, and a version-mismatched client on a live socket
+# just prints "lost server" and switches nothing. So the notifier pins the binary
+# it resolved at notify time, and PATH lookup is only the fallback.
+TMUX_BIN=""
+if [[ "$TMUX_BIN_ARG" =~ ^/[A-Za-z0-9._/-]+$ ]] && [ -x "$TMUX_BIN_ARG" ]; then
+  TMUX_BIN="$TMUX_BIN_ARG"
+else
+  TMUX_BIN="$(command -v tmux 2>/dev/null || true)"
+  if [ -z "$TMUX_BIN" ]; then
+    for _c in /opt/homebrew/bin/tmux /usr/local/bin/tmux /usr/bin/tmux; do
+      [ -x "$_c" ] && { TMUX_BIN="$_c"; break; }
+    done
+  fi
+fi
+[ -n "$TMUX_BIN" ] || { _dbg "no tmux binary found (arg=$TMUX_BIN_ARG)"; _bail; }
+
+TM=("$TMUX_BIN" -S "$SOCK")
+
+# --- Pick the client to focus ---
+# Prefer a client attached to this pane's own session; among those the most
+# recently active one is what the user is looking at (a session can carry several
+# clients — a second window, a phone over ssh). A client on a *different* session
+# is only a last resort: switch-client can still pull our session into it, but it
+# means yanking that client away from what it was showing, so it must never beat
+# a client that already has our session.
+_pick_client() {
+  local sess
+  sess="$("${TM[@]}" display-message -p -t "$PANE" '#{session_name}' 2>/dev/null)" || sess=""
+  "${TM[@]}" list-clients -F '#{client_activity}|#{client_pid}|#{client_tty}|#{client_session}' 2>/dev/null \
+    | awk -F'|' -v s="$sess" '
+        $2 == "" || $3 == "" { next }
+        {
+          # session name is the last field and may itself contain "|"
+          ses = $4; for (i = 5; i <= NF; i++) ses = ses "|" $i
+          if (s != "" && ses == s) {
+            if ($1 + 0 > best) { best = $1 + 0; bpid = $2; btty = $3 }
+          } else if ($1 + 0 > any) { any = $1 + 0; apid = $2; atty = $3 }
+        }
+        END {
+          if (btty != "") print bpid "|" btty
+          else if (atty != "") print apid "|" atty
+        }'
+}
+
+CLIENT_PID=""
+CLIENT_TTY=""
+_pc="$(_pick_client)"
+if [ -n "$_pc" ]; then
+  CLIENT_PID="${_pc%%|*}"
+  CLIENT_TTY="${_pc#*|}"
+fi
+
+# --- Derive the bundle id of a running app by PID (macOS lsappinfo) ---
+_bundle_from_pid() {
+  local pid="$1"
+  { [ -z "$pid" ] || [ "$pid" = "0" ]; } && return
+  lsappinfo info -only bundleid -app pid:"$pid" 2>/dev/null \
+    | sed -n 's/.*="\([^"]*\)".*/\1/p'
+}
+
+# Climb from the tmux client until an ancestor has a bundle id — that ancestor is
+# the terminal app (the client, shells and helper servers have none).
+TERM_PID=""
+TERM_BUNDLE=""
+if [ -n "$CLIENT_PID" ] && [ "$(uname -s)" = "Darwin" ]; then
+  p="$CLIENT_PID"
+  for _i in 1 2 3 4 5 6 7 8 9 10 11 12; do
+    p="$(ps -o ppid= -p "$p" 2>/dev/null | tr -d ' ')"
+    { [ -z "$p" ] || [ "$p" = "0" ] || [ "$p" = "1" ]; } && break
+    b="$(_bundle_from_pid "$p")"
+    if [ -n "$b" ]; then TERM_PID="$p"; TERM_BUNDLE="$b"; break; fi
+  done
+fi
+
+# The ancestry can dead-end at launchd: iTerm2 keeps its ptys in a detachable
+# iTermServer, and after iTerm2 restarts and re-adopts it that server's parent is
+# pid 1, not the new app. The notify-time guess is right in exactly that case
+# (same app, restarted), so fall back to it rather than raising nothing.
+if [ -z "$TERM_BUNDLE" ] && [ -n "$FALLBACK_BUNDLE" ]; then
+  TERM_BUNDLE="$FALLBACK_BUNDLE"
+  _dbg "ancestry gave no bundle; using fallback=$TERM_BUNDLE"
+fi
+
+_dbg "$MODE pane=$PANE tmux=$TMUX_BIN client_pid=$CLIENT_PID client_tty=$CLIENT_TTY term_pid=$TERM_PID bundle=$TERM_BUNDLE"
+
+if [ "$MODE" = "context" ]; then
+  printf '%s|%s|%s\n' "$TERM_BUNDLE" "$CLIENT_TTY" "$TERM_PID"
+  exit 0
+fi
+
+# --- Step 1: raise the terminal app ---
+# By PID when we have it (unambiguous, and works for any emulator); otherwise by
+# bundle id, matching a RUNNING app only — never `open -b`, which would launch a
+# terminal the user has quit and pop an empty window.
+if [ -n "$TERM_PID" ] || [ -n "$TERM_BUNDLE" ]; then
+  /usr/bin/osascript -l JavaScript -e '
+    function run(argv) {
+      ObjC.import("Cocoa");
+      var pid = parseInt(argv[0], 10);
+      if (pid > 0) {
+        var app = $.NSRunningApplication.runningApplicationWithProcessIdentifier(pid);
+        if (app && !app.isNil()) {
+          app.activateWithOptions($.NSApplicationActivateIgnoringOtherApps);
+          return;
+        }
+      }
+      var bid = argv[1];
+      if (!bid) return;
+      var apps = $.NSWorkspace.sharedWorkspace.runningApplications;
+      for (var i = 0; i < apps.count; i++) {
+        var a = apps.objectAtIndex(i);
+        var b = a.bundleIdentifier;
+        if (!b.isNil() && b.js === bid) {
+          a.activateWithOptions($.NSApplicationActivateIgnoringOtherApps);
+          return;
+        }
+      }
+    }' "${TERM_PID:-0}" "$TERM_BUNDLE" >/dev/null 2>&1 || true
+fi
+
+# --- Step 2: iTerm2 only — raise the exact window/tab hosting this client ---
+# Activating the app lands on its frontmost window, which may be a different tab.
+if [ "$TERM_BUNDLE" = "com.googlecode.iterm2" ] && [ -n "$CLIENT_TTY" ]; then
+  /usr/bin/osascript -l JavaScript -e '
+    function run(argv) {
+      var tty = argv[0];
+      var iTerm = Application("iTerm2");
+      var ws = iTerm.windows();
+      for (var w = 0; w < ws.length; w++) {
+        var ts = ws[w].tabs();
+        for (var t = 0; t < ts.length; t++) {
+          var ss = ts[t].sessions();
+          for (var s = 0; s < ss.length; s++) {
+            try {
+              if (ss[s].tty() !== tty) continue;
+              ts[t].select();
+              ss[s].select();
+              ws[w].index = 1;
+              iTerm.activate();
+              // AXRaise last, in its own guard: it needs Accessibility rights
+              // this process may not have, and a throw here must not cost us the
+              // activate above (which is what actually fronts the tab).
+              try {
+                var wn = ws[w].name();
+                var sw = Application("System Events").processes["iTerm2"].windows();
+                for (var i = 0; i < sw.length; i++) {
+                  if (sw[i].name() === wn) { sw[i].actions["AXRaise"].perform(); break; }
+                }
+              } catch (e2) {}
+              return;
+            } catch (e) {}
+          }
+        }
+      }
+    }' "$CLIENT_TTY" >/dev/null 2>&1 || true
+fi
+
+# --- Step 3: switch tmux to the agent's own window/pane ---
+# Target the client we identified (-c) instead of letting tmux guess: with more
+# than one client attached, an untargeted switch-client can move the wrong one.
+# One chained invocation so the three commands cannot interleave with a resize.
+if [ -n "$CLIENT_TTY" ]; then
+  "${TM[@]}" switch-client -c "$CLIENT_TTY" -t "$PANE" \; \
+             select-window -t "$PANE" \; \
+             select-pane -t "$PANE" >/dev/null 2>&1 \
+    || "${TM[@]}" select-window -t "$PANE" \; select-pane -t "$PANE" >/dev/null 2>&1 \
+    || _dbg "tmux switch failed pane=$PANE client=$CLIENT_TTY"
+else
+  # Nothing attached — there is no screen to switch. Selecting the window anyway
+  # would silently rearrange a detached session behind the user's back.
+  _dbg "no attached client; skipped tmux switch"
+fi
+
+exit 0

--- a/scripts/notify.sh
+++ b/scripts/notify.sh
@@ -119,6 +119,14 @@ _find_cmux_focus_helper() {
   return 1
 }
 
+_find_local_focus_helper() {
+  local p="$PEON_DIR/scripts/local-focus.sh"
+  [ -x "$p" ] && { echo "$p"; return 0; }
+  p="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/local-focus.sh"
+  [ -x "$p" ] && { echo "$p"; return 0; }
+  return 1
+}
+
 _find_cmux_workspace_field_helper() {
   local p="$PEON_DIR/scripts/cmux-workspace-field.sh"
   [ -f "$p" ] && { echo "$p"; return 0; }
@@ -317,7 +325,24 @@ case "$PEON_PLATFORM" in
     if [ -z "$click_command" ] && [ -n "${TMUX:-}" ] && [ -n "${TMUX_PANE:-}" ] && command -v tmux >/dev/null 2>&1; then
       _pp_tsock=$(printf '%q' "${TMUX%%,*}")
       _pp_tpane=$(printf '%q' "$TMUX_PANE")
-      click_command="tmux -S $_pp_tsock switch-client -t $_pp_tpane 2>/dev/null; tmux -S $_pp_tsock select-window -t $_pp_tpane 2>/dev/null; tmux -S $_pp_tsock select-pane -t $_pp_tpane 2>/dev/null"
+      _pp_local_focus=""
+      if [ "$PEON_PLATFORM" = "mac" ]; then
+        _pp_local_focus="$(_find_local_focus_helper)" 2>/dev/null || _pp_local_focus=""
+      fi
+      if [ -n "$_pp_local_focus" ]; then
+        # macOS: hand the whole click to local-focus.sh, which re-derives the
+        # hosting terminal from the tmux client attached at CLICK time (the user
+        # may have restarted or swapped terminals since this notification was
+        # posted), raises it, then switches that client to our pane. bundle_id
+        # rides along as the fallback for the one case tmux can't answer — see
+        # scripts/local-focus.sh.
+        # Pin the tmux binary resolved here: the click runs under `bash -lc`,
+        # where PATH may resolve a different (version-mismatched) tmux.
+        _pp_tmuxbin="$(command -v tmux 2>/dev/null || true)"
+        click_command="$(printf '%q %s %s %q %q' "$_pp_local_focus" "$_pp_tsock" "$_pp_tpane" "$bundle_id" "$_pp_tmuxbin")"
+      else
+        click_command="tmux -S $_pp_tsock switch-client -t $_pp_tpane 2>/dev/null; tmux -S $_pp_tsock select-window -t $_pp_tpane 2>/dev/null; tmux -S $_pp_tsock select-pane -t $_pp_tpane 2>/dev/null"
+      fi
     fi
     if [ -z "$click_command" ]; then
       click_command="$(_terminal_focus_click_command "$bundle_id" "${PEON_SESSION_TTY:-}")" || true


### PR DESCRIPTION
## Problem

Click-to-focus does nothing (or focuses the wrong app) for an agent running in a **local tmux session**, whenever the terminal is not the one the session was first attached from.

`_mac_terminal_bundle_id()` identifies the hosting terminal from the hook's own environment — `ITERM_SESSION_ID`, `GHOSTTY_RESOURCES_DIR`, `WARP_IS_LOCAL_SHELL_SESSION`. A pane's environment is frozen when the pane is created and can never be rewritten, so inside tmux that value names the emulator the session was **first** attached from, forever:

- Quit and reopen the terminal, or attach the session from a different one (two emulators side by side, a hotkey that swaps terminals), and the click activates an app that is not showing this session.
- kitty and alacritty set no `TERM_PROGRAM` and export none of the vars above, so the bundle id comes out **empty**: `activateBundle()` no-ops, no app is raised at all, and the notification looks dead.

tmux itself is never stale — it knows which client is attached at this instant. So this stops trusting the environment and asks tmux.

## What this does

New `scripts/local-focus.sh`, which `notify.sh` hands the whole click to on macOS when the agent is inside tmux:

1. Pick the client attached to the pane's session — most recently active wins when several are attached. A client on a *different* session is only a last resort, since switching it means yanking it away from what it was showing.
2. Walk that client's process ancestry until an ancestor has a bundle id. That ancestor is the hosting terminal, whatever emulator it happens to be — the same terminal-agnostic discovery `ssh-focus.sh` already does for relayed sessions.
3. Raise it: by PID when known, otherwise by bundle id, matching a **running** app only — never `open -b`, which would relaunch a terminal the user has quit and pop an empty window.
4. iTerm2 only: select the exact window/tab whose tty matches the client.
5. `switch-client -c <that client> -t <pane>` + `select-window` + `select-pane`, chained. Targeting the identified client matters: with more than one client attached, an untargeted `switch-client` can move the wrong one.

The same helper answers `--print-context`, so notify time also gets the live bundle id and client tty (memoized in `peon.sh` — one lookup per event, ~85 ms). The notify-time id still rides along as the click-time fallback for the one case tmux cannot answer: iTerm2 keeps its ptys in a detachable `iTermServer` whose parent becomes launchd once the app restarts, dead-ending the ancestry walk — and there the env guess is right, because it is the same app.

Two smaller fixes in the same path:

- **The tmux binary is now pinned by the caller.** The click runs under `bash -lc`, whose login PATH need not contain the tmux the server actually runs — `env -i /bin/bash -lc 'command -v tmux'` on macOS finds no tmux at all, and a version-mismatched client on a live socket just prints `lost server` and switches nothing. Both callers pass the binary they resolved; PATH lookup is the fallback.
- **iTerm2's `AXRaise` moved last, in its own guard.** It needs Accessibility rights the calling process may not have, and a throw there used to also cost the `iTerm.activate()` that actually fronts the tab.

`_mac_terminal_bundle_id()` also learns kitty and alacritty for the env fallback, which is what a **non**-tmux session in those terminals hits.

Behaviour outside macOS, outside tmux, and for cmux/IDE terminals is unchanged; the previous bare-tmux click command remains the fallback when the helper is missing.

## Verified on macOS 15 / tmux 3.7b

| Case | Result |
|---|---|
| tmux client hosted by **kitty** (empty bundle id before this change) | resolves `net.kovidgoyal.kitty` + app pid; click raises kitty and switches the client `@0/%0` → `@1/%1` |
| tmux client hosted by **iTerm2**, app restarted since the pane was created | resolves the **live** iTerm2 pid, not the stale `ITERM_SESSION_ID` from the previous instance |
| Detached session / malformed socket or pane id | prints an empty context, touches nothing — a detached session is never silently rearranged |
| Full path, real notification | `peon notifications test` → overlay gets `local-focus.sh <socket> %108 com.googlecode.iterm2 /opt/homebrew/bin/tmux` |
| That exact click command under `env -i /bin/bash -lc` (worst-case PATH) | pane `%105` → `%108`, iTerm2 frontmost |

## Relationship to #562

Independent — they can merge in either order. #562 (relay click-to-focus for remote ssh) touches `relay.sh`, `scripts/ssh-focus.sh`, `scripts/mac-overlay.js`; this touches `scripts/notify.sh` and the new helper. The only shared file is `peon.sh`, where the two sets of hunks are unrelated and auto-merge cleanly (verified by cherry-picking this commit onto `main` with #562 absent: no conflicts).

This does not need #562's overlay change either: upstream registers the click handler on `bundleId || idePid > 0 || persistent`, and after this change the bundle id in a tmux session is live and non-empty for any emulator, so the handler registers as before.
