### PR TITLE
fix(opencode): debounce UserPromptSubmit + remove redundant SessionStart double-fire

### DIFF
--- a/adapters/opencode/peon-ping.ts
+++ b/adapters/opencode/peon-ping.ts
@@ -63,6 +63,7 @@ export const PeonPingPlugin: Plugin = async ({ directory }) => {
   const sessionId = `oc-${Date.now()}`
   const subagentSessionIds = new Set<string>()
   const busySessions = new Set<string>()
+  let lastSessionStart = 0
 
   function firePeon(event: string): void {
     const payload = JSON.stringify({
@@ -100,6 +101,7 @@ export const PeonPingPlugin: Plugin = async ({ directory }) => {
             break
           }
           setTabTitle(`${projectName}: ready`)
+          lastSessionStart = Date.now()
           firePeon("SessionStart")
           break
         }
@@ -148,8 +150,10 @@ export const PeonPingPlugin: Plugin = async ({ directory }) => {
           if (statusType === "busy" || statusType === "running") {
             if (sid && !busySessions.has(sid)) {
               busySessions.add(sid)
-              setTabTitle(`${projectName}: working`)
-              firePeon("UserPromptSubmit")
+              if (Date.now() - lastSessionStart > 3000) {
+                setTabTitle(`${projectName}: working`)
+                firePeon("UserPromptSubmit")
+              }
             }
           } else {
             if (sid) busySessions.delete(sid)

--- a/adapters/opencode/peon-ping.ts
+++ b/adapters/opencode/peon-ping.ts
@@ -88,10 +88,7 @@ export const PeonPingPlugin: Plugin = async ({ directory }) => {
     return !!sid && subagentSessionIds.has(sid)
   }
 
-  setTimeout(() => {
-    setTabTitle(`${projectName}: ready`)
-    firePeon("SessionStart")
-  }, 100)
+  setTabTitle(`${projectName}: ready`)
 
   return {
     event: async ({ event }) => {

--- a/adapters/opencode/peon-ping.ts
+++ b/adapters/opencode/peon-ping.ts
@@ -62,6 +62,7 @@ export const PeonPingPlugin: Plugin = async ({ directory }) => {
   const cwd = directory || process.cwd()
   const sessionId = `oc-${Date.now()}`
   const subagentSessionIds = new Set<string>()
+  let isBusy = false
 
   function firePeon(event: string): void {
     const payload = JSON.stringify({
@@ -121,6 +122,7 @@ export const PeonPingPlugin: Plugin = async ({ directory }) => {
         case "session.idle": {
           const sid = (event as any).properties?.sessionID
           if (isSubagent(sid)) break
+          isBusy = false
           setTabTitle(`\u25cf ${projectName}: done`)
           firePeon("Stop")
           break
@@ -129,6 +131,7 @@ export const PeonPingPlugin: Plugin = async ({ directory }) => {
         case "session.error": {
           const sid = (event as any).properties?.sessionID
           if (isSubagent(sid)) break
+          isBusy = false
           setTabTitle(`\u25cf ${projectName}: error`)
           firePeon("PostToolUseFailure")
           break
@@ -146,8 +149,13 @@ export const PeonPingPlugin: Plugin = async ({ directory }) => {
           const status = event.properties?.status
           const statusType = typeof status === "object" ? (status as any)?.type : status
           if (statusType === "busy" || statusType === "running") {
-            setTabTitle(`${projectName}: working`)
-            firePeon("UserPromptSubmit")
+            if (!isBusy) {
+              isBusy = true
+              setTabTitle(`${projectName}: working`)
+              firePeon("UserPromptSubmit")
+            }
+          } else {
+            isBusy = false
           }
           break
         }

--- a/adapters/opencode/peon-ping.ts
+++ b/adapters/opencode/peon-ping.ts
@@ -62,7 +62,7 @@ export const PeonPingPlugin: Plugin = async ({ directory }) => {
   const cwd = directory || process.cwd()
   const sessionId = `oc-${Date.now()}`
   const subagentSessionIds = new Set<string>()
-  let isBusy = false
+  const busySessions = new Set<string>()
 
   function firePeon(event: string): void {
     const payload = JSON.stringify({
@@ -122,7 +122,7 @@ export const PeonPingPlugin: Plugin = async ({ directory }) => {
         case "session.idle": {
           const sid = (event as any).properties?.sessionID
           if (isSubagent(sid)) break
-          isBusy = false
+          if (sid) busySessions.delete(sid)
           setTabTitle(`\u25cf ${projectName}: done`)
           firePeon("Stop")
           break
@@ -131,7 +131,7 @@ export const PeonPingPlugin: Plugin = async ({ directory }) => {
         case "session.error": {
           const sid = (event as any).properties?.sessionID
           if (isSubagent(sid)) break
-          isBusy = false
+          if (sid) busySessions.delete(sid)
           setTabTitle(`\u25cf ${projectName}: error`)
           firePeon("PostToolUseFailure")
           break
@@ -149,13 +149,13 @@ export const PeonPingPlugin: Plugin = async ({ directory }) => {
           const status = event.properties?.status
           const statusType = typeof status === "object" ? (status as any)?.type : status
           if (statusType === "busy" || statusType === "running") {
-            if (!isBusy) {
-              isBusy = true
+            if (sid && !busySessions.has(sid)) {
+              busySessions.add(sid)
               setTabTitle(`${projectName}: working`)
               firePeon("UserPromptSubmit")
             }
           } else {
-            isBusy = false
+            if (sid) busySessions.delete(sid)
           }
           break
         }


### PR DESCRIPTION
## Context

I've just migrated from Claude Code to OpenCode, and while I loved the PeonPing experience in Claude Code, it's been a "nightmare" with OpenCode: all the (sub)agents throw sounds at me at the same time 😅

I've tried to enable the `suppress_subagent_complete` and `suppress_delegate_sessions` settings, but it didn't help.

GLM 5.2 came with the fix I'm proposing in this PR. Happy to rework/refine it if you find any issue. Cheers!

## Problem

OpenCode fires multiple `session.status: busy` events per interaction. The adapter forwarded each one as `UserPromptSubmit`, hitting peon.sh's spam threshold (3 events / 10s) and triggering `user.spam` sounds repeatedly — even with `suppress_subagent_complete` and `suppress_delegate_sessions` enabled (those only affect subagent/delegate sessions, not the main session).

Additionally, the adapter had **two** `SessionStart` fire points that raced past the cooldown timer:
1. A `setTimeout(..., 100)` fallback from before `session.created` was reliable
2. The `session.created` event handler

Both fired on session start, causing a double sound.

Even after removing the `setTimeout`, a second double sound remained: `session.created` (SessionStart) and `session.status(busy)` (UserPromptSubmit) fire back-to-back. `firePeon()` spawns detached `bash` processes (`proc.unref()`), so both `peon.sh` invocations race on `.state.json` — the second reads stale state before the first writes `session_start_times`, defeating peon.sh's 3s replay suppression.

Related closed issues that fixed adjacent problems but left this gap:
- #458 — fixed config sync (categories not propagating)
- #336 — fixed subagent suppression via parentID tracking

## Fix

1. **Debounce `UserPromptSubmit`** (227005d): Added a `busySessions` Set in the adapter that tracks whether the session is already in busy state. `UserPromptSubmit` now only fires on the **first** transition to `busy` — subsequent `busy` events during the same interaction are silently skipped. The set resets on `session.idle`, `session.error`, or any non-busy status.

2. **Track busy state per sessionID** (9e48d5c): Changed from a global boolean flag to per-`sessionID` tracking via the `busySessions` Set, so concurrent sessions don't interfere.

3. **Remove redundant `SessionStart`** (07e9b07): Removed the legacy `setTimeout` that fired `SessionStart` 100ms after plugin load. The `session.created` event handler already fires it, so the `setTimeout` was a double-fire. The `setTabTitle` call is kept inline (runs immediately on load).

4. **Suppress `UserPromptSubmit` within 3s of `SessionStart`** (11dde28): Track `lastSessionStart` timestamp in-process. Skip `UserPromptSubmit` if it arrives within 3s of `SessionStart`, mirroring peon.sh's replay suppression but at the plugin level where there's no race on `.state.json`.

## Verification

```bash
peon debug on
# ... use opencode for a few interactions ...
peon logs --last 50
# Before: multiple [route] category=user.spam per interaction + double SessionStart sound
# After: only ONE [route] category=user.spam (or none if under threshold) + single SessionStart sound
peon debug off
```

## Changes

- `adapters/opencode/peon-ping.ts`:
  - Added `busySessions` Set to track active busy sessions and gate `UserPromptSubmit`
  - Reset busy session state on `session.idle`, `session.error`, and non-busy status
  - Removed redundant `setTimeout` that double-fired `SessionStart` alongside `session.created`
  - Added `lastSessionStart` timestamp; skip `UserPromptSubmit` within 3s of `SessionStart`