### PR TITLE
fix(windows): bound the peon.ps1 stdin read so the hook cannot hang

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -430,9 +430,12 @@ param(
     [Parameter(ValueFromRemainingArguments)]$ExtraArgs = @()
 )
 
-# 8-second self-timeout safety net — kills this process if anything blocks unexpectedly.
+# 8-second self-timeout safety net: kills this process if anything blocks unexpectedly.
 # Uses System.Timers.Timer (not Forms.Timer) so it works in headless PowerShell without a message pump.
-# Must fire before ANY I/O (config read, state read, stdin read).
+# Scope: Register-ObjectEvent runs its action on the pipeline thread the next time that
+# thread goes idle, so this covers work that is slow but still executing statements. It
+# cannot interrupt a thread parked inside one blocking call, which is why the stdin read
+# further down bounds itself instead of relying on this timer.
 if (-not $Command) {
     $safetyTimer = New-Object System.Timers.Timer
     $safetyTimer.Interval = 8000
@@ -2503,14 +2506,22 @@ if (-not $config.enabled) {
 $_activePack = Get-ActivePack $config
 & $peonLog 'config' @{ loaded = $ConfigPath; volume = [string]$config.volume; pack = $_activePack; enabled = 'True' }
 
-# Read hook input from stdin (StreamReader with UTF-8 auto-strips BOM on Windows)
+# Read hook input from stdin (StreamReader with UTF-8 auto-strips BOM on Windows).
+# Bounded at 2s, matching the `timeout 2 cat` guard peon.sh uses for the same reason:
+# a host can open the stdin pipe and never close the write end, and a synchronous
+# ReadToEnd() then parks this thread for the life of the process. The safety timer at
+# the top of this script cannot rescue that case, so on timeout leave $hookInput empty
+# and fall through to the no-input guard below, which exits 0.
 $hookInput = ""
 try {
     if (-not [Console]::IsInputRedirected) { exit 0 }
     $stream = [Console]::OpenStandardInput()
     $reader = New-Object System.IO.StreamReader($stream, [System.Text.Encoding]::UTF8)
-    $hookInput = $reader.ReadToEnd()
-    $reader.Close()
+    $readTask = $reader.ReadToEndAsync()
+    if ($readTask.Wait(2000)) {
+        $hookInput = $readTask.Result
+        $reader.Close()
+    }
 } catch {
     exit 0
 }

--- a/tests/install-ps1-hook-rewrite.Tests.ps1
+++ b/tests/install-ps1-hook-rewrite.Tests.ps1
@@ -123,3 +123,87 @@ Describe "install.ps1 Copilot CLI camelCase fallback" {
         $content | Should -Match 'elseif \(\$event\.sessionId\) \{ \$event\.sessionId \}'
     }
 }
+
+Describe "install.ps1 hook stdin read is bounded" {
+    # A host can hand the hook a stdin pipe and never close the write end. A plain
+    # ReadToEnd() then parks the pipeline thread for the life of the process, and the
+    # 8-second safety timer cannot help: Register-ObjectEvent runs its action on that
+    # same blocked thread. peon.sh has guarded this since #445 with `timeout 2 cat`;
+    # these tests hold the PowerShell path to the same bound.
+
+    BeforeAll {
+        # Lift the hook body out of the here-string that install.ps1 writes to peon.ps1.
+        $lines = Get-Content $script:InstallPs1
+        $startLine = ($lines | Select-String -Pattern '^\$hookScript = @' | Select-Object -First 1).LineNumber
+        $endLine = ($lines | Select-String -Pattern "^'@" | Where-Object { $_.LineNumber -gt $startLine } | Select-Object -First 1).LineNumber
+        $script:HookBody = $lines[$startLine..($endLine - 2)] -join "`n"
+    }
+
+    # Asserted as booleans rather than `$HookBody | Should -Match`, so a failure reports
+    # one line instead of dumping the whole 3000-line hook body into the CI log.
+    It "uses a timed async read rather than a blocking ReadToEnd" {
+        ($script:HookBody -match '\$readTask = \$reader\.ReadToEndAsync\(\)') |
+            Should -BeTrue -Because 'the stdin read must not block indefinitely'
+        ($script:HookBody -match '\$readTask\.Wait\(2000\)') |
+            Should -BeTrue -Because 'the read is bounded at 2s, matching peon.sh'
+    }
+
+    It "no longer calls ReadToEnd() unbounded in the hook body" {
+        ($script:HookBody -match '\$reader\.ReadToEnd\(\)') |
+            Should -BeFalse -Because 'the unbounded read is what wedged the process'
+    }
+
+    It "exits instead of hanging when stdin never closes" {
+        # The bug is an indefinite hang, so the ceiling only has to separate "bounded"
+        # from "forever". Bound is 2s plus interpreter startup.
+        $sandbox = Join-Path ([System.IO.Path]::GetTempPath()) "peon-stdin-$([guid]::NewGuid().ToString('N'))"
+        New-Item -ItemType Directory -Path $sandbox -Force | Out-Null
+        $peon = Join-Path $sandbox 'peon.ps1'
+        $proc = $null
+        try {
+            Set-Content -Path $peon -Value $script:HookBody -Encoding UTF8
+            Copy-Item (Join-Path $script:RepoRoot 'config.json') (Join-Path $sandbox 'config.json') -Force
+
+            $psi = [System.Diagnostics.ProcessStartInfo]::new('powershell.exe',
+                "-NoProfile -NonInteractive -File `"$peon`"")
+            $psi.RedirectStandardInput = $true
+            $psi.UseShellExecute = $false
+            $proc = [System.Diagnostics.Process]::Start($psi)
+
+            # Write the payload a host sends, then hold the write end open.
+            $proc.StandardInput.Write('{"hook_event_name":"SessionStart","session_id":"pester-stdin"}')
+            $proc.StandardInput.Flush()
+
+            $proc.WaitForExit(20000) | Should -BeTrue -Because 'the hook must not block forever on a stdin pipe that never closes'
+        } finally {
+            if ($proc -and -not $proc.HasExited) { $proc.Kill(); $proc.WaitForExit(5000) | Out-Null }
+            Remove-Item $sandbox -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    It "still reads the payload when stdin closes normally" {
+        $sandbox = Join-Path ([System.IO.Path]::GetTempPath()) "peon-stdin-$([guid]::NewGuid().ToString('N'))"
+        New-Item -ItemType Directory -Path $sandbox -Force | Out-Null
+        $peon = Join-Path $sandbox 'peon.ps1'
+        $proc = $null
+        try {
+            Set-Content -Path $peon -Value $script:HookBody -Encoding UTF8
+            Copy-Item (Join-Path $script:RepoRoot 'config.json') (Join-Path $sandbox 'config.json') -Force
+
+            $psi = [System.Diagnostics.ProcessStartInfo]::new('powershell.exe',
+                "-NoProfile -NonInteractive -File `"$peon`"")
+            $psi.RedirectStandardInput = $true
+            $psi.UseShellExecute = $false
+            $proc = [System.Diagnostics.Process]::Start($psi)
+
+            $proc.StandardInput.Write('{"hook_event_name":"SessionStart","session_id":"pester-stdin"}')
+            $proc.StandardInput.Close()
+
+            $proc.WaitForExit(20000) | Should -BeTrue
+            $proc.ExitCode | Should -Be 0
+        } finally {
+            if ($proc -and -not $proc.HasExited) { $proc.Kill(); $proc.WaitForExit(5000) | Out-Null }
+            Remove-Item $sandbox -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+}


### PR DESCRIPTION
## Problem

The hook that `install.ps1` generates as `peon.ps1` reads its event payload with a synchronous `ReadToEnd()`. If a host opens the stdin pipe but never closes the write end, that call parks the pipeline thread and the process never exits. In practice this leaves orphaned `powershell.exe` processes, each with a headless `conhost.exe`, sitting at around 100 MB. Claude Code force-kills the hook at its own timeout, which hides the leak; hosts that do not force-kill leak one process per event.

The 8-second safety timer was meant to cover exactly this, and it cannot. `Register-ObjectEvent` queues its action to the runspace, and PowerShell runs that action on the pipeline thread the next time the thread goes idle. During `ReadToEnd()` the pipeline thread is blocked inside a synchronous native call, so the timer elapses and the handler never runs.

## Change

Bound the read with `ReadToEndAsync()` and a 2000 ms `Wait`, the same bound `peon.sh` has used since #445. `Task.Wait(ms)` returns even while the pipe stays open, and the abandoned read sits on a background thread that does not keep the process alive. On timeout `$hookInput` stays empty and falls through to the existing `if (-not $hookInput) { exit 0 }` guard, so the normal exit path and its logging are unchanged.

The safety timer stays. It does still fire for work that is slow but progressing, and the `.tmp` cleanup in `Read-StateWithRetry` exists to mop up after its `Exit(1)`. What was wrong was its comment, which claimed it fires before any I/O including the stdin read, so the comment now states the scope it actually has.

## Verification

Windows 11, Windows PowerShell 5.1. Driving the generated hook with stdin redirected and the write end deliberately held open:

| scenario | before | after |
|---|---|---|
| pipe never closed | still running at 12s, ~97 MB | exits 0 after ~3.1s |
| normal EOF | exits 0, ~1.1s | exits 0, ~1.1s |

Four Pester cases added to `tests/install-ps1-hook-rewrite.Tests.ps1`, next to the existing guards on the generated hook body. Three fail on `main` and pass with this change; the fourth covers the normal EOF path, which passes either way and is there to catch a regression in the happy path.

Full Pester run: 891 passed, 1 failed. That one failure (`peon-engine.Tests.ps1`, "accepts StateOverrides") reproduces unchanged on a clean checkout of `main`. It compares a parsed `[datetime]` against a UTC literal, so it fails in any non-UTC timezone and is unrelated to this change. The BATS suite is untouched by a PowerShell-only change.

## Not included

`install.ps1` writes the same unbounded `[Console]::In.ReadToEnd()` into the Codex hook command string (around line 4054). Same failure shape, different code path. Left alone to keep this diff to the reported bug, happy to follow up if you want it covered too.

Fixes #568
