### PR TITLE
fix(opencode): notify when questions need input

### DIFF
--- a/adapters/opencode/peon-ping.ts
+++ b/adapters/opencode/peon-ping.ts
@@ -19,6 +19,7 @@
  *   session.idle                 → Stop
  *   session.error                → PostToolUseFailure
  *   permission.asked             → PermissionRequest
+ *   question(.v2).asked          → Notification (elicitation_dialog)
  *
  * Requires peon-ping installed: brew install PeonPing/tap/peon-ping
  *   or: curl -fsSL peonping.com/install | bash
@@ -29,6 +30,8 @@ import * as path from "node:path"
 import * as os from "node:os"
 import { spawn } from "node:child_process"
 import type { Plugin } from "@opencode-ai/plugin"
+
+const MAX_PENDING_QUESTION_IDS = 100
 
 const PEON_SH_PATHS = [
   path.join(os.homedir(), ".claude", "hooks", "peon-ping", "peon.sh"),
@@ -65,11 +68,12 @@ export const PeonPingPlugin: Plugin = async ({ directory }) => {
   const subagentSessionIds = new Set<string>()
   const busySessions = new Set<string>()
   let lastSessionStart = 0
+  const pendingQuestionIds = new Set<string>()
 
-  function firePeon(event: string): void {
+  function firePeon(event: string, notificationType = ""): void {
     const payload = JSON.stringify({
       hook_event_name: event,
-      notification_type: "",
+      notification_type: notificationType,
       cwd,
       session_id: sessionId,
       permission_mode: "",
@@ -140,6 +144,31 @@ export const PeonPingPlugin: Plugin = async ({ directory }) => {
         case "permission.asked": {
           setTabTitle(`\u25cf ${projectName}: needs approval`)
           firePeon("PermissionRequest")
+          break
+        }
+
+        case "question.asked":
+        case "question.v2.asked": {
+          const properties = (event as any).properties
+          if (isSubagent(properties?.sessionID)) break
+          const requestId = properties?.id
+          if (typeof requestId !== "string" || pendingQuestionIds.has(requestId)) break
+          if (pendingQuestionIds.size >= MAX_PENDING_QUESTION_IDS) {
+            pendingQuestionIds.delete(pendingQuestionIds.values().next().value!)
+          }
+          pendingQuestionIds.add(requestId)
+          setTabTitle(`\u25cf ${projectName}: needs input`)
+          firePeon("Notification", "elicitation_dialog")
+          break
+        }
+
+        case "question.replied":
+        case "question.rejected":
+        case "question.v2.replied":
+        case "question.v2.rejected": {
+          const properties = (event as any).properties
+          const requestId = properties?.requestID ?? properties?.id
+          if (typeof requestId === "string") pendingQuestionIds.delete(requestId)
           break
         }
 

--- a/adapters/opencode/peon-ping.ts
+++ b/adapters/opencode/peon-ping.ts
@@ -19,6 +19,7 @@
  *   session.idle                 → Stop
  *   session.error                → PostToolUseFailure
  *   permission.asked             → PermissionRequest
+ *   question(.v2).asked          → Notification (elicitation_dialog)
  *
  * Requires peon-ping installed: brew install PeonPing/tap/peon-ping
  *   or: curl -fsSL peonping.com/install | bash
@@ -29,6 +30,8 @@ import * as path from "node:path"
 import * as os from "node:os"
 import { spawn } from "node:child_process"
 import type { Plugin } from "@opencode-ai/plugin"
+
+const MAX_PENDING_QUESTION_IDS = 100
 
 const PEON_SH_PATHS = [
   path.join(os.homedir(), ".claude", "hooks", "peon-ping", "peon.sh"),
@@ -62,11 +65,12 @@ export const PeonPingPlugin: Plugin = async ({ directory }) => {
   const cwd = directory || process.cwd()
   const sessionId = `oc-${Date.now()}`
   const subagentSessionIds = new Set<string>()
+  const pendingQuestionIds = new Set<string>()
 
-  function firePeon(event: string): void {
+  function firePeon(event: string, notificationType = ""): void {
     const payload = JSON.stringify({
       hook_event_name: event,
-      notification_type: "",
+      notification_type: notificationType,
       cwd,
       session_id: sessionId,
       permission_mode: "",
@@ -137,6 +141,31 @@ export const PeonPingPlugin: Plugin = async ({ directory }) => {
         case "permission.asked": {
           setTabTitle(`\u25cf ${projectName}: needs approval`)
           firePeon("PermissionRequest")
+          break
+        }
+
+        case "question.asked":
+        case "question.v2.asked": {
+          const properties = (event as any).properties
+          if (isSubagent(properties?.sessionID)) break
+          const requestId = properties?.id
+          if (typeof requestId !== "string" || pendingQuestionIds.has(requestId)) break
+          if (pendingQuestionIds.size >= MAX_PENDING_QUESTION_IDS) {
+            pendingQuestionIds.delete(pendingQuestionIds.values().next().value!)
+          }
+          pendingQuestionIds.add(requestId)
+          setTabTitle(`\u25cf ${projectName}: needs input`)
+          firePeon("Notification", "elicitation_dialog")
+          break
+        }
+
+        case "question.replied":
+        case "question.rejected":
+        case "question.v2.replied":
+        case "question.v2.rejected": {
+          const properties = (event as any).properties
+          const requestId = properties?.requestID ?? properties?.id
+          if (typeof requestId === "string") pendingQuestionIds.delete(requestId)
           break
         }
 

--- a/tests/opencode-peon-ping.test.ts
+++ b/tests/opencode-peon-ping.test.ts
@@ -1,0 +1,165 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+const stdin = {
+  write: vi.fn(),
+  end: vi.fn(),
+}
+const spawnedProcess = {
+  stdin,
+  unref: vi.fn(),
+}
+
+vi.mock("node:fs", () => ({
+  existsSync: vi.fn(() => true),
+}))
+
+vi.mock("node:child_process", () => ({
+  spawn: vi.fn(() => spawnedProcess),
+}))
+
+import { spawn } from "node:child_process"
+import { PeonPingPlugin } from "../adapters/opencode/peon-ping.js"
+
+async function createEventHandler() {
+  const plugin = await PeonPingPlugin({ directory: "/tmp/example-project" } as any)
+  return plugin.event!
+}
+
+function payloads(): Array<Record<string, unknown>> {
+  return stdin.write.mock.calls.map(([payload]) => JSON.parse(payload))
+}
+
+describe("PeonPingPlugin question events", () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.clearAllMocks()
+    vi.spyOn(process.stdout, "write").mockImplementation(() => true)
+  })
+
+  afterEach(() => {
+    vi.clearAllTimers()
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it("dispatches a private elicitation notification for question.asked", async () => {
+    const event = await createEventHandler()
+    const sensitiveText = "SENTINEL_SECRET_QUESTION_V1"
+
+    await event({
+      event: {
+        type: "question.asked",
+        properties: {
+          id: "question-request-v1",
+          sessionID: "primary-session",
+          questions: [{ question: sensitiveText, options: [{ label: "Secret option" }] }],
+        },
+      },
+    } as any)
+
+    expect(payloads()).toEqual([{
+      hook_event_name: "Notification",
+      notification_type: "elicitation_dialog",
+      cwd: "/tmp/example-project",
+      session_id: expect.stringMatching(/^oc-\d+$/),
+      permission_mode: "",
+      source: "opencode",
+    }])
+    expect(stdin.write.mock.calls[0][0]).not.toContain(sensitiveText)
+    expect(stdin.write.mock.calls[0][0]).not.toContain("question-request-v1")
+  })
+
+  it("dispatches a private elicitation notification for question.v2.asked", async () => {
+    const event = await createEventHandler()
+    const sensitiveText = "SENTINEL_SECRET_QUESTION_V2"
+
+    await event({
+      event: {
+        type: "question.v2.asked",
+        properties: {
+          id: "question-request-v2",
+          sessionID: "primary-session",
+          questions: [{ question: sensitiveText, options: ["Never serialize me"] }],
+        },
+      },
+    } as any)
+
+    expect(payloads()[0]).toMatchObject({
+      hook_event_name: "Notification",
+      notification_type: "elicitation_dialog",
+    })
+    expect(stdin.write.mock.calls[0][0]).not.toContain(sensitiveText)
+    expect(stdin.write.mock.calls[0][0]).not.toContain("question-request-v2")
+  })
+
+  it("suppresses duplicate v1 and v2 representations with the same id", async () => {
+    const event = await createEventHandler()
+    const properties = { id: "same-question", sessionID: "primary-session", questions: [] }
+
+    await event({ event: { type: "question.asked", properties } } as any)
+    await event({ event: { type: "question.v2.asked", properties } } as any)
+
+    expect(spawn).toHaveBeenCalledTimes(1)
+  })
+
+  it("bounds pending question ids and evicts the oldest request", async () => {
+    const event = await createEventHandler()
+
+    for (let id = 0; id <= 100; id += 1) {
+      await event({
+        event: {
+          type: "question.asked",
+          properties: { id: `question-${id}`, sessionID: "primary-session", questions: [] },
+        },
+      } as any)
+    }
+    await event({
+      event: {
+        type: "question.v2.asked",
+        properties: { id: "question-0", sessionID: "primary-session", questions: [] },
+      },
+    } as any)
+
+    expect(spawn).toHaveBeenCalledTimes(102)
+  })
+
+  it("suppresses question notifications from tracked subagent sessions", async () => {
+    const event = await createEventHandler()
+
+    await event({
+      event: {
+        type: "session.created",
+        properties: { info: { id: "subagent-session", parentID: "primary-session" } },
+      },
+    } as any)
+    await event({
+      event: {
+        type: "question.asked",
+        properties: { id: "subagent-question", sessionID: "subagent-session", questions: [] },
+      },
+    } as any)
+
+    expect(spawn).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    "question.replied",
+    "question.rejected",
+    "question.v2.replied",
+    "question.v2.rejected",
+  ])("cleans deduplication state on %s", async (settledType) => {
+    const event = await createEventHandler()
+    const properties = { id: "reusable-question", sessionID: "primary-session", questions: [] }
+
+    await event({ event: { type: "question.asked", properties } } as any)
+    await event({
+      event: {
+        type: settledType,
+        properties: { requestID: "reusable-question", sessionID: "primary-session" },
+      },
+    } as any)
+    await event({ event: { type: "question.v2.asked", properties } } as any)
+
+    expect(spawn).toHaveBeenCalledTimes(2)
+  })
+})


### PR DESCRIPTION
## Problem

The OpenCode adapter handles permission prompts but ignores `question.asked` and `question.v2.asked`. When an agent calls the question tool, PeonPing therefore sends no `input.required` notification or mobile push.

## Fix

- map both OpenCode question event variants to PeonPing `Notification` with `notification_type: elicitation_dialog`
- suppress tracked subagent questions
- deduplicate legacy/v2 representations by bounded request ID state and clean it when requests settle
- keep question text, options, and request IDs out of the PeonPing payload
- add focused tests for dispatch, privacy, deduplication, bounds, subagents, and cleanup

## Verification

- `npm test --prefix adapters/opencode` — 58/58 passed
- `bats tests/opencode.bats` — 9/9 passed
- isolated OpenCode 1.18.16 E2E — real `question.asked` reached PeonPing as `input.required` and published `question: Question pending` to a disposable ntfy topic
- privacy check — sentinel question text appeared in the OpenCode event but not in the PeonPing payload or ntfy message
- `git diff --check` — clean