### PR TITLE
feat: add Grok Build adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+### Added
+- **Grok Build adapter.** Grok's hook stdin is camelCase (`hookEventName`, `sessionId`) with snake_case event values (`session_start`, `stop`), so calling `peon.sh` directly stays silent. `adapters/grok.sh` and `adapters/grok.ps1` translate that envelope to CESP. When `~/.grok` exists, `install.sh` / `install.ps1` write `~/.grok/hooks/peon-ping.json` for `SessionStart`, `UserPromptSubmit`, `Stop`, `StopFailure`, `Notification`, subagent start/stop, `PostToolUseFailure`, and `PreCompact`. Noisy per-tool hooks stay unregistered. Session-end `Stop` fires (`reason: shutdown` / `channel_closed`) are treated as cleanup, not a completion chime. `run_terminal_command` failures map to Bash so `task.error` still plays. Stop-gate stdout is discarded so a chime cannot keep the agent working.
+
 ## v2.36.0 (2026-08-09)
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,7 @@ IDE triggers hook → `peon.sh` reads JSON stdin → single Python call maps eve
 - **`adapters/kiro.sh`** — Translates Kiro CLI (Amazon) events to CESP JSON
 - **`adapters/windsurf.sh`** — Translates Windsurf Cascade hook events to CESP JSON
 - **`adapters/antigravity.sh`** — Filesystem watcher for Google Antigravity agent events
+- **`adapters/grok.sh`** — Translates Grok Build camelCase hook events to CESP JSON
 
 All adapters have native Windows PowerShell (`.ps1`) counterparts alongside the bash originals. Windows adapters pipe CESP JSON to `peon.ps1` instead of `peon.sh`. Filesystem watchers (amp, antigravity, kimi) use .NET `FileSystemWatcher` instead of fswatch/inotifywait.
 

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@
 ![macOS](https://img.shields.io/badge/macOS-blue) ![WSL2](https://img.shields.io/badge/WSL2-blue) ![Linux](https://img.shields.io/badge/Linux-blue) ![Windows](https://img.shields.io/badge/Windows-blue) ![MSYS2](https://img.shields.io/badge/MSYS2-blue) ![SSH](https://img.shields.io/badge/SSH-blue)
 ![License](https://img.shields.io/badge/license-MIT-green)
 
-![Claude Code](https://img.shields.io/badge/Claude_Code-hook-ffab01) ![Amp](https://img.shields.io/badge/Amp-adapter-ffab01) ![Gemini CLI](https://img.shields.io/badge/Gemini_CLI-adapter-ffab01) ![GitHub Copilot](https://img.shields.io/badge/GitHub_Copilot-adapter-ffab01) ![Codex](https://img.shields.io/badge/Codex-adapter-ffab01) ![Cursor](https://img.shields.io/badge/Cursor-adapter-ffab01) ![OpenCode](https://img.shields.io/badge/OpenCode-adapter-ffab01) ![Kilo CLI](https://img.shields.io/badge/Kilo_CLI-adapter-ffab01) ![Kiro](https://img.shields.io/badge/Kiro-adapter-ffab01) ![Kimi Code](https://img.shields.io/badge/Kimi_Code-adapter-ffab01) ![Windsurf](https://img.shields.io/badge/Windsurf-adapter-ffab01) ![Antigravity](https://img.shields.io/badge/Antigravity-adapter-ffab01) ![OpenClaw](https://img.shields.io/badge/OpenClaw-adapter-ffab01) ![Rovo Dev CLI](https://img.shields.io/badge/Rovo_Dev_CLI-adapter-ffab01) ![DeepAgents](https://img.shields.io/badge/DeepAgents-adapter-ffab01) ![oh-my-pi](https://img.shields.io/badge/oh--my--pi-adapter-ffab01) ![Qwen Code](https://img.shields.io/badge/Qwen_Code-adapter-ffab01) ![iFlow CLI](https://img.shields.io/badge/iFlow_CLI-adapter-ffab01) ![Trae](https://img.shields.io/badge/Trae-adapter-ffab01) ![Kiro IDE](https://img.shields.io/badge/Kiro_IDE-adapter-ffab01) ![ECA](https://img.shields.io/badge/ECA-adapter-ffab01)
+![Claude Code](https://img.shields.io/badge/Claude_Code-hook-ffab01) ![Amp](https://img.shields.io/badge/Amp-adapter-ffab01) ![Gemini CLI](https://img.shields.io/badge/Gemini_CLI-adapter-ffab01) ![GitHub Copilot](https://img.shields.io/badge/GitHub_Copilot-adapter-ffab01) ![Codex](https://img.shields.io/badge/Codex-adapter-ffab01) ![Grok Build](https://img.shields.io/badge/Grok_Build-adapter-ffab01) ![Cursor](https://img.shields.io/badge/Cursor-adapter-ffab01) ![OpenCode](https://img.shields.io/badge/OpenCode-adapter-ffab01) ![Kilo CLI](https://img.shields.io/badge/Kilo_CLI-adapter-ffab01) ![Kiro](https://img.shields.io/badge/Kiro-adapter-ffab01) ![Kimi Code](https://img.shields.io/badge/Kimi_Code-adapter-ffab01) ![Windsurf](https://img.shields.io/badge/Windsurf-adapter-ffab01) ![Antigravity](https://img.shields.io/badge/Antigravity-adapter-ffab01) ![OpenClaw](https://img.shields.io/badge/OpenClaw-adapter-ffab01) ![Rovo Dev CLI](https://img.shields.io/badge/Rovo_Dev_CLI-adapter-ffab01) ![DeepAgents](https://img.shields.io/badge/DeepAgents-adapter-ffab01) ![oh-my-pi](https://img.shields.io/badge/oh--my--pi-adapter-ffab01) ![Qwen Code](https://img.shields.io/badge/Qwen_Code-adapter-ffab01) ![iFlow CLI](https://img.shields.io/badge/iFlow_CLI-adapter-ffab01) ![Trae](https://img.shields.io/badge/Trae-adapter-ffab01) ![Kiro IDE](https://img.shields.io/badge/Kiro_IDE-adapter-ffab01) ![ECA](https://img.shields.io/badge/ECA-adapter-ffab01)
 
 **Game character voice lines + visual overlay notifications when your AI coding agent needs attention — or let the agent pick its own sound via MCP.**
 
-AI coding agents don't notify you when they finish or need permission. You tab away, lose focus, and waste 15 minutes getting back into flow. peon-ping fixes this with voice lines and bold on-screen banners from Warcraft, StarCraft, Portal, Zelda, and more — works with **Claude Code**, **Amp**, **GitHub Copilot**, **Codex**, **Cursor**, **OpenCode**, **Kilo CLI**, **Kiro**, **Kimi Code**, **Windsurf**, **Google Antigravity**, **Rovo Dev CLI**, **DeepAgents**, **Qwen Code**, **iFlow CLI**, **Trae**, **Kiro IDE**, **ECA**, and any MCP client.
+AI coding agents don't notify you when they finish or need permission. You tab away, lose focus, and waste 15 minutes getting back into flow. peon-ping fixes this with voice lines and bold on-screen banners from Warcraft, StarCraft, Portal, Zelda, and more — works with **Claude Code**, **Amp**, **GitHub Copilot**, **Codex**, **Grok Build**, **Cursor**, **OpenCode**, **Kilo CLI**, **Kiro**, **Kimi Code**, **Windsurf**, **Google Antigravity**, **Rovo Dev CLI**, **DeepAgents**, **Qwen Code**, **iFlow CLI**, **Trae**, **Kiro IDE**, **ECA**, and any MCP client.
 
 **See it in action** &rarr; [peonping.com](https://peonping.com/)
 
@@ -726,6 +726,7 @@ peon-ping works with any agentic IDE that supports hooks. Adapters translate IDE
 | **Gemini CLI** | Adapter | Add hooks pointing to `adapters/gemini.sh` (or `.ps1` on Windows) ([setup](#gemini-cli-setup)) |
 | **GitHub Copilot CLI** | Built-in (auto-detect) | `install.sh` / `install.ps1` auto-registers hooks at `~/.copilot/hooks/peon-ping.json` if `~/.copilot` exists. Per-repo manual wiring also available via `adapters/copilot.sh` / `.ps1` ([setup](#github-copilot-cli-setup)) |
 | **OpenAI Codex** | Built-in (auto-detect) | `install.sh` / `install.ps1` auto-registers stable hooks in `~/.codex/config.toml` if `~/.codex` exists. The adapter is also available for manual wiring ([setup](#openai-codex-setup)) |
+| **Grok Build** | Built-in (auto-detect) | `install.sh` / `install.ps1` auto-register hooks at `~/.grok/hooks/peon-ping.json` if `~/.grok` exists. The adapter is also available for manual wiring ([setup](#grok-build-setup)) |
 | **Cursor** | Built-in | `curl \| bash`, `peon-ping-setup`, or Windows `install.ps1` auto-detect and register hooks. On Windows, enable **Settings → Features → Third-party skills** so Cursor loads `~/.claude/settings.json` for SessionStart/Stop sounds. |
 | **OpenCode** | Adapter | `bash adapters/opencode.sh` / `powershell adapters/opencode.ps1` ([setup](#opencode-setup)) |
 | **Kilo CLI** | Adapter | `bash adapters/kilo.sh` / `powershell adapters/kilo.ps1` ([setup](#kilo-cli-setup)) |
@@ -770,6 +771,22 @@ The registered Codex events are `SessionStart`, `UserPromptSubmit`, `PermissionR
 3. Restart Codex if it was already running during installation.
 
 peon-ping writes inline hooks to `~/.codex/config.toml` instead of creating `hooks.json`, matching the [Codex hooks documentation](https://developers.openai.com/codex/hooks) guidance to avoid mixing both hook representations in the same config layer. Legacy `notify` wiring still works as a fallback, but new installs should use the stable hooks path.
+
+### Grok Build setup
+
+Grok Build sends camelCase hook payloads (`hookEventName`, `sessionId`, `notificationType`) with snake_case event values (`session_start`, `stop`). That is not what `peon.sh` reads natively, so peon-ping ships `adapters/grok.sh` (and `grok.ps1` on Windows) instead of pointing Grok at `peon.sh` directly.
+
+If `~/.grok` already exists, the Unix and Windows installers write `~/.grok/hooks/peon-ping.json` automatically. If you install Grok Build later, re-run the peon-ping installer.
+
+Registered events: `SessionStart`, `SessionEnd`, `UserPromptSubmit`, `Stop`, `StopFailure`, `Notification`, `SubagentStart`, `SubagentStop`, `PostToolUseFailure`, and `PreCompact`. `PreToolUse`, `PostToolUse`, `PostCompact`, and `PermissionDenied` are left unregistered — per-tool hooks are too noisy. Session-end `Stop` fires (`reason: shutdown` or `channel_closed`) are treated as cleanup, not a completion chime. Shell failures arrive as `toolName: run_terminal_command` and are rewritten to Bash so `task.error` still plays.
+
+**Setup:**
+
+1. Install the peon-ping runtime (`curl | bash`, Homebrew + `peon-ping-setup`, or `install.ps1`).
+
+2. If Grok was already running, reload hooks with `/hooks` then `r`, or start a new session. Project hooks need `/hooks-trust` once; `~/.grok/hooks/` is always trusted.
+
+Grok can also scan `~/.claude/settings.json`. Those Claude hooks still call `peon.sh` with Grok's camelCase envelope, so they stay silent. The native `~/.grok/hooks/peon-ping.json` file is the one that actually plays sounds. To hide the unused Claude entries from Grok's `/hooks` list, set `[compat.claude] hooks = false` in `~/.grok/config.toml`.
 
 ### Amp setup
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -6,7 +6,7 @@
 ![macOS](https://img.shields.io/badge/macOS-blue) ![WSL2](https://img.shields.io/badge/WSL2-blue) ![Linux](https://img.shields.io/badge/Linux-blue) ![Windows](https://img.shields.io/badge/Windows-blue) ![MSYS2](https://img.shields.io/badge/MSYS2-blue) ![SSH](https://img.shields.io/badge/SSH-blue)
 ![License](https://img.shields.io/badge/license-MIT-green)
 
-![Claude Code](https://img.shields.io/badge/Claude_Code-hook-ffab01) ![Amp](https://img.shields.io/badge/Amp-adapter-ffab01) ![Gemini CLI](https://img.shields.io/badge/Gemini_CLI-adapter-ffab01) ![GitHub Copilot](https://img.shields.io/badge/GitHub_Copilot-adapter-ffab01) ![Codex](https://img.shields.io/badge/Codex-adapter-ffab01) ![Cursor](https://img.shields.io/badge/Cursor-adapter-ffab01) ![OpenCode](https://img.shields.io/badge/OpenCode-adapter-ffab01) ![Kilo CLI](https://img.shields.io/badge/Kilo_CLI-adapter-ffab01) ![Kiro](https://img.shields.io/badge/Kiro-adapter-ffab01) ![Kimi Code](https://img.shields.io/badge/Kimi_Code-adapter-ffab01) ![Windsurf](https://img.shields.io/badge/Windsurf-adapter-ffab01) ![Antigravity](https://img.shields.io/badge/Antigravity-adapter-ffab01) ![OpenClaw](https://img.shields.io/badge/OpenClaw-adapter-ffab01) ![Rovo Dev CLI](https://img.shields.io/badge/Rovo_Dev_CLI-adapter-ffab01) ![DeepAgents](https://img.shields.io/badge/DeepAgents-adapter-ffab01) ![oh-my-pi](https://img.shields.io/badge/oh--my--pi-adapter-ffab01)
+![Claude Code](https://img.shields.io/badge/Claude_Code-hook-ffab01) ![Amp](https://img.shields.io/badge/Amp-adapter-ffab01) ![Gemini CLI](https://img.shields.io/badge/Gemini_CLI-adapter-ffab01) ![GitHub Copilot](https://img.shields.io/badge/GitHub_Copilot-adapter-ffab01) ![Codex](https://img.shields.io/badge/Codex-adapter-ffab01) ![Grok Build](https://img.shields.io/badge/Grok_Build-adapter-ffab01) ![Cursor](https://img.shields.io/badge/Cursor-adapter-ffab01) ![OpenCode](https://img.shields.io/badge/OpenCode-adapter-ffab01) ![Kilo CLI](https://img.shields.io/badge/Kilo_CLI-adapter-ffab01) ![Kiro](https://img.shields.io/badge/Kiro-adapter-ffab01) ![Kimi Code](https://img.shields.io/badge/Kimi_Code-adapter-ffab01) ![Windsurf](https://img.shields.io/badge/Windsurf-adapter-ffab01) ![Antigravity](https://img.shields.io/badge/Antigravity-adapter-ffab01) ![OpenClaw](https://img.shields.io/badge/OpenClaw-adapter-ffab01) ![Rovo Dev CLI](https://img.shields.io/badge/Rovo_Dev_CLI-adapter-ffab01) ![DeepAgents](https://img.shields.io/badge/DeepAgents-adapter-ffab01) ![oh-my-pi](https://img.shields.io/badge/oh--my--pi-adapter-ffab01)
 
 **AIコーディングエージェントが注意を必要とする時に、ゲームキャラクターのボイスライン＋ビジュアルオーバーレイ通知を再生 — またはMCPでエージェント自身にサウンドを選ばせることも可能。**
 
@@ -616,6 +616,7 @@ peon-ping はフックをサポートする任意のエージェント型 IDE �
 | **Gemini CLI** | アダプター | `adapters/gemini.sh`（Windows では `.ps1`）を指すフックを追加（[セットアップ](#gemini-cli-セットアップ)） |
 | **GitHub Copilot** | アダプター | `.github/hooks/hooks.json` に `adapters/copilot.sh`（または `.ps1`）を指すフックを追加（[セットアップ](#github-copilot-セットアップ)） |
 | **OpenAI Codex** | 組み込み（自動検出） | `~/.codex` が存在する場合、`install.sh` / `install.ps1` が `~/.codex/config.toml` に stable hooks を自動登録。アダプターの手動接続も可能（[セットアップ](#openai-codex-セットアップ)） |
+| **Grok Build** | 組み込み（自動検出） | `~/.grok` が存在する場合、`install.sh` / `install.ps1` が `~/.grok/hooks/peon-ping.json` にフックを自動登録。アダプターの手動接続も可能（[セットアップ](#grok-build-セットアップ)） |
 | **Cursor** | 組み込み | `curl \| bash`、`peon-ping-setup`、または Windows `install.ps1` が自動検出して登録。Windows では **設定 → 機能 → サードパーティスキル** を有効にして、Cursor が `~/.claude/settings.json` を読み込み SessionStart/Stop サウンドを再生するようにしてください。 |
 | **OpenCode** | アダプター | `bash adapters/opencode.sh` / `powershell adapters/opencode.ps1`（[セットアップ](#opencode-セットアップ)） |
 | **Kilo CLI** | アダプター | `bash adapters/kilo.sh` / `powershell adapters/kilo.ps1`（[セットアップ](#kilo-cli-セットアップ)） |
@@ -635,6 +636,14 @@ peon-ping はフックをサポートする任意のエージェント型 IDE �
 Codex サポートは stable Codex hooks API と peon-ping アダプターを使用します。`~/.codex` がすでに存在する場合、Unix / Windows インストーラーは `~/.codex/config.toml` に peon 管理の設定ブロックを自動で追加します。Codex を後からインストールした場合は、peon-ping インストーラーを再実行してください。
 
 登録される Codex イベントは `SessionStart`、`UserPromptSubmit`、`PermissionRequest`、`PreCompact`、`SubagentStart`、`SubagentStop`、`Stop` です。`SessionStart` は `startup`、`resume`、`clear` にだけマッチします。Codex のコンテキスト圧縮は `PreCompact` で扱うため、compact 起点の `SessionStart` はスキップします。`PreToolUse`、`PostToolUse`、`PostCompact` は意図的に登録しません。Codex には失敗専用の別 hook がなく、成功したツール hook は peon-ping には多すぎるため、Codex アダプターは `PostToolUse` を無視します。
+
+### Grok Build セットアップ
+
+Grok Build のフック入力は camelCase（`hookEventName`、`sessionId`）で、イベント値は snake_case（`session_start`、`stop`）です。`peon.sh` はその形式を直接読めないため、`adapters/grok.sh`（Windows では `grok.ps1`）を使います。
+
+`~/.grok` が既にあれば、インストーラーが `~/.grok/hooks/peon-ping.json` を自動で書き込みます。Grok Build を後から入れた場合は peon-ping インストーラーを再実行してください。
+
+登録イベント: `SessionStart`、`SessionEnd`、`UserPromptSubmit`、`Stop`、`StopFailure`、`Notification`、`SubagentStart`、`SubagentStop`、`PostToolUseFailure`、`PreCompact`。セッション終了時の `Stop`（`shutdown` / `channel_closed`）は完了音ではなくクリーンアップとして扱います。既に起動中の Grok では `/hooks` のあと `r` で再読み込みするか、新しいセッションを開いてください。
 
 **セットアップ：**
 

--- a/README_ko.md
+++ b/README_ko.md
@@ -6,7 +6,7 @@
 ![macOS](https://img.shields.io/badge/macOS-blue) ![WSL2](https://img.shields.io/badge/WSL2-blue) ![Linux](https://img.shields.io/badge/Linux-blue) ![Windows](https://img.shields.io/badge/Windows-blue) ![MSYS2](https://img.shields.io/badge/MSYS2-blue) ![SSH](https://img.shields.io/badge/SSH-blue)
 ![License](https://img.shields.io/badge/license-MIT-green)
 
-![Claude Code](https://img.shields.io/badge/Claude_Code-hook-ffab01) ![Amp](https://img.shields.io/badge/Amp-adapter-ffab01) ![Gemini CLI](https://img.shields.io/badge/Gemini_CLI-adapter-ffab01) ![GitHub Copilot](https://img.shields.io/badge/GitHub_Copilot-adapter-ffab01) ![Codex](https://img.shields.io/badge/Codex-adapter-ffab01) ![Cursor](https://img.shields.io/badge/Cursor-adapter-ffab01) ![OpenCode](https://img.shields.io/badge/OpenCode-adapter-ffab01) ![Kilo CLI](https://img.shields.io/badge/Kilo_CLI-adapter-ffab01) ![Kiro](https://img.shields.io/badge/Kiro-adapter-ffab01) ![Windsurf](https://img.shields.io/badge/Windsurf-adapter-ffab01) ![Antigravity](https://img.shields.io/badge/Antigravity-adapter-ffab01) ![OpenClaw](https://img.shields.io/badge/OpenClaw-adapter-ffab01) ![oh-my-pi](https://img.shields.io/badge/oh--my--pi-adapter-ffab01)
+![Claude Code](https://img.shields.io/badge/Claude_Code-hook-ffab01) ![Amp](https://img.shields.io/badge/Amp-adapter-ffab01) ![Gemini CLI](https://img.shields.io/badge/Gemini_CLI-adapter-ffab01) ![GitHub Copilot](https://img.shields.io/badge/GitHub_Copilot-adapter-ffab01) ![Codex](https://img.shields.io/badge/Codex-adapter-ffab01) ![Grok Build](https://img.shields.io/badge/Grok_Build-adapter-ffab01) ![Cursor](https://img.shields.io/badge/Cursor-adapter-ffab01) ![OpenCode](https://img.shields.io/badge/OpenCode-adapter-ffab01) ![Kilo CLI](https://img.shields.io/badge/Kilo_CLI-adapter-ffab01) ![Kiro](https://img.shields.io/badge/Kiro-adapter-ffab01) ![Windsurf](https://img.shields.io/badge/Windsurf-adapter-ffab01) ![Antigravity](https://img.shields.io/badge/Antigravity-adapter-ffab01) ![OpenClaw](https://img.shields.io/badge/OpenClaw-adapter-ffab01) ![oh-my-pi](https://img.shields.io/badge/oh--my--pi-adapter-ffab01)
 
 **AI 코딩 에이전트가 관심을 요청할 때 게임 캐릭터 음성 + 시각 오버레이 알림을 재생하거나, MCP를 통해 에이전트가 직접 효과음을 선택할 수 있습니다.**
 
@@ -322,6 +322,7 @@ peon-ping은 훅을 지원하는 모든 에이전트 기반 IDE에서 동작합�
 | **Gemini CLI** | 어댑터 | `~/.gemini/settings.json`에 `adapters/gemini.sh` 훅 추가 ([설정](#gemini-cli-설정)) |
 | **GitHub Copilot** | 어댑터 | `.github/hooks/hooks.json`에 `adapters/copilot.sh` 훅 추가 ([설정](#github-copilot-설정)) |
 | **OpenAI Codex** | 내장(자동 감지) | `~/.codex`가 있으면 `install.sh` / `install.ps1`이 `~/.codex/config.toml`에 stable hooks를 자동 등록. 수동 어댑터 연결도 가능 ([설정](#openai-codex-설정)) |
+| **Grok Build** | 내장(자동 감지) | `~/.grok`가 있으면 `install.sh` / `install.ps1`이 `~/.grok/hooks/peon-ping.json`에 훅을 자동 등록. 수동 어댑터 연결도 가능 ([설정](#grok-build-설정)) |
 | **Cursor** | 내장 | `curl \| bash` 또는 `peon-ping-setup`이 자동 감지 후 Cursor 훅 등록 |
 | **OpenCode** | 어댑터 | `curl -fsSL https://raw.githubusercontent.com/PeonPing/peon-ping/main/adapters/opencode.sh \| bash` ([설정](#opencode-설정)) |
 | **Kilo CLI** | 어댑터 | `curl -fsSL https://raw.githubusercontent.com/PeonPing/peon-ping/main/adapters/kilo.sh \| bash` ([설정](#kilo-cli-설정)) |
@@ -336,6 +337,14 @@ peon-ping은 훅을 지원하는 모든 에이전트 기반 IDE에서 동작합�
 `~/.codex`가 이미 있으면 Unix/Windows 설치 관리자가 `~/.codex/config.toml`에 peon-ping 관리 stable hooks 블록을 자동으로 추가합니다. Codex를 나중에 설치했다면 peon-ping 설치 관리자를 다시 실행하세요.
 
 등록되는 이벤트는 `SessionStart`, `UserPromptSubmit`, `PermissionRequest`, `PreCompact`, `SubagentStart`, `SubagentStop`, `Stop`입니다. `SessionStart`는 `startup`, `resume`, `clear`에만 매칭되며, 압축 흐름은 `PreCompact`가 처리합니다. `PreToolUse`, `PostToolUse`, `PostCompact`는 등록하지 않으며, Codex 어댑터는 `PostToolUse`를 무시합니다. Codex가 요청하면 `/hooks`에서 peon-ping 명령을 검토하고 신뢰 처리하세요.
+
+### Grok Build 설정
+
+Grok Build 훅 입력은 camelCase(`hookEventName`, `sessionId`)이고 이벤트 값은 snake_case(`session_start`, `stop`)입니다. `peon.sh`는 이 형식을 바로 읽지 못하므로 `adapters/grok.sh`(Windows는 `grok.ps1`)를 사용합니다.
+
+`~/.grok`가 이미 있으면 설치 관리자가 `~/.grok/hooks/peon-ping.json`을 자동으로 씁니다. Grok Build를 나중에 설치했다면 peon-ping 설치 관리자를 다시 실행하세요.
+
+등록 이벤트: `SessionStart`, `SessionEnd`, `UserPromptSubmit`, `Stop`, `StopFailure`, `Notification`, `SubagentStart`, `SubagentStop`, `PostToolUseFailure`, `PreCompact`. 세션 종료 `Stop`(`shutdown` / `channel_closed`)은 완료음이 아니라 정리로 처리합니다. 이미 실행 중인 Grok에서는 `/hooks` 후 `r`로 다시 읽거나 새 세션을 여세요.
 
 **설정 방법:**
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -6,11 +6,11 @@
 ![macOS](https://img.shields.io/badge/macOS-blue) ![WSL2](https://img.shields.io/badge/WSL2-blue) ![Linux](https://img.shields.io/badge/Linux-blue) ![Windows](https://img.shields.io/badge/Windows-blue) ![MSYS2](https://img.shields.io/badge/MSYS2-blue) ![SSH](https://img.shields.io/badge/SSH-blue)
 ![License](https://img.shields.io/badge/license-MIT-green)
 
-![Claude Code](https://img.shields.io/badge/Claude_Code-hook-ffab01) ![Amp](https://img.shields.io/badge/Amp-adapter-ffab01) ![Gemini CLI](https://img.shields.io/badge/Gemini_CLI-adapter-ffab01) ![GitHub Copilot](https://img.shields.io/badge/GitHub_Copilot-adapter-ffab01) ![Codex](https://img.shields.io/badge/Codex-adapter-ffab01) ![Cursor](https://img.shields.io/badge/Cursor-adapter-ffab01) ![OpenCode](https://img.shields.io/badge/OpenCode-adapter-ffab01) ![Kilo CLI](https://img.shields.io/badge/Kilo_CLI-adapter-ffab01) ![Kiro](https://img.shields.io/badge/Kiro-adapter-ffab01) ![Kimi Code](https://img.shields.io/badge/Kimi_Code-adapter-ffab01) ![Windsurf](https://img.shields.io/badge/Windsurf-adapter-ffab01) ![Antigravity](https://img.shields.io/badge/Antigravity-adapter-ffab01) ![OpenClaw](https://img.shields.io/badge/OpenClaw-adapter-ffab01) ![Rovo Dev CLI](https://img.shields.io/badge/Rovo_Dev_CLI-adapter-ffab01) ![DeepAgents](https://img.shields.io/badge/DeepAgents-adapter-ffab01) ![oh-my-pi](https://img.shields.io/badge/oh--my--pi-adapter-ffab01) ![Qwen Code](https://img.shields.io/badge/Qwen_Code-adapter-ffab01) ![iFlow CLI](https://img.shields.io/badge/iFlow_CLI-adapter-ffab01) ![Trae](https://img.shields.io/badge/Trae-adapter-ffab01) ![Kiro IDE](https://img.shields.io/badge/Kiro_IDE-adapter-ffab01) ![ECA](https://img.shields.io/badge/ECA-adapter-ffab01)
+![Claude Code](https://img.shields.io/badge/Claude_Code-hook-ffab01) ![Amp](https://img.shields.io/badge/Amp-adapter-ffab01) ![Gemini CLI](https://img.shields.io/badge/Gemini_CLI-adapter-ffab01) ![GitHub Copilot](https://img.shields.io/badge/GitHub_Copilot-adapter-ffab01) ![Codex](https://img.shields.io/badge/Codex-adapter-ffab01) ![Grok Build](https://img.shields.io/badge/Grok_Build-adapter-ffab01) ![Cursor](https://img.shields.io/badge/Cursor-adapter-ffab01) ![OpenCode](https://img.shields.io/badge/OpenCode-adapter-ffab01) ![Kilo CLI](https://img.shields.io/badge/Kilo_CLI-adapter-ffab01) ![Kiro](https://img.shields.io/badge/Kiro-adapter-ffab01) ![Kimi Code](https://img.shields.io/badge/Kimi_Code-adapter-ffab01) ![Windsurf](https://img.shields.io/badge/Windsurf-adapter-ffab01) ![Antigravity](https://img.shields.io/badge/Antigravity-adapter-ffab01) ![OpenClaw](https://img.shields.io/badge/OpenClaw-adapter-ffab01) ![Rovo Dev CLI](https://img.shields.io/badge/Rovo_Dev_CLI-adapter-ffab01) ![DeepAgents](https://img.shields.io/badge/DeepAgents-adapter-ffab01) ![oh-my-pi](https://img.shields.io/badge/oh--my--pi-adapter-ffab01) ![Qwen Code](https://img.shields.io/badge/Qwen_Code-adapter-ffab01) ![iFlow CLI](https://img.shields.io/badge/iFlow_CLI-adapter-ffab01) ![Trae](https://img.shields.io/badge/Trae-adapter-ffab01) ![Kiro IDE](https://img.shields.io/badge/Kiro_IDE-adapter-ffab01) ![ECA](https://img.shields.io/badge/ECA-adapter-ffab01)
 
 **当你的 AI 编程助手需要关注时，播放游戏角色语音 + 显示视觉覆盖通知 — 或通过 MCP 让 AI 自行选择音效。**
 
-AI 编程助手完成任务或需要权限时不会通知你。你切换标签页、失去焦点，然后浪费 15 分钟重新进入状态。peon-ping 通过魔兽争霸、星际争霸、传送门、塞尔达等游戏的角色语音和醒目的屏幕横幅来解决这个问题 — 支持 **Claude Code**、**Amp**、**Gemini CLI**、**GitHub Copilot**、**Codex**、**Cursor**、**OpenCode**、**Kilo CLI**、**Kiro**、**Kimi Code**、**Windsurf**、**Google Antigravity**、**Rovo Dev CLI**、**DeepAgents**、**Qwen Code**、**iFlow CLI**、**Trae**、**Kiro IDE**、**ECA** 及任何 MCP 客户端.
+AI 编程助手完成任务或需要权限时不会通知你。你切换标签页、失去焦点，然后浪费 15 分钟重新进入状态。peon-ping 通过魔兽争霸、星际争霸、传送门、塞尔达等游戏的角色语音和醒目的屏幕横幅来解决这个问题 — 支持 **Claude Code**、**Amp**、**Gemini CLI**、**GitHub Copilot**、**Codex**、**Grok Build**、**Cursor**、**OpenCode**、**Kilo CLI**、**Kiro**、**Kimi Code**、**Windsurf**、**Google Antigravity**、**Rovo Dev CLI**、**DeepAgents**、**Qwen Code**、**iFlow CLI**、**Trae**、**Kiro IDE**、**ECA** 及任何 MCP 客户端.
 
 **查看演示** &rarr; [peonping.com](https://peonping.com/)
 
@@ -616,6 +616,7 @@ peon-ping 适用于任何支持钩子的代理式 IDE。适配器将 IDE 特定�
 | **Gemini CLI** | 适配器 | 添加指向 `adapters/gemini.sh`（Windows 用 `.ps1`）的钩子（[设置](#gemini-cli-设置)） |
 | **GitHub Copilot CLI** | 内置（自动检测） | 当 `~/.copilot` 存在时，`install.sh` / `install.ps1` 自动在 `~/.copilot/hooks/peon-ping.json` 注册钩子。也可通过 `adapters/copilot.sh` / `.ps1` 进行逐仓库手动配置（[设置](#github-copilot-cli-设置)） |
 | **OpenAI Codex** | 内置（自动检测） | 如果 `~/.codex` 存在，`install.sh` / `install.ps1` 会自动在 `~/.codex/config.toml` 注册 stable hooks。也可手动接入适配器（[设置](#openai-codex-设置)） |
+| **Grok Build** | 内置（自动检测） | 如果 `~/.grok` 存在，`install.sh` / `install.ps1` 会自动在 `~/.grok/hooks/peon-ping.json` 注册钩子。也可手动接入适配器（[设置](#grok-build-设置)） |
 | **Cursor** | 内置 | `curl \| bash`、`peon-ping-setup` 或 Windows `install.ps1` 自动检测并注册钩子。在 Windows 上，请在 **设置 → 功能 → 第三方技能** 中启用，以便 Cursor 加载 `~/.claude/settings.json` 以播放 SessionStart/Stop 音效。 |
 | **OpenCode** | 适配器 | `bash adapters/opencode.sh` / `powershell adapters/opencode.ps1`（[设置](#opencode-设置)） |
 | **Kilo CLI** | 适配器 | `bash adapters/kilo.sh` / `powershell adapters/kilo.ps1`（[设置](#kilo-cli-设置)） |
@@ -640,6 +641,16 @@ peon-ping 适用于任何支持钩子的代理式 IDE。适配器将 IDE 特定�
 Codex 支持使用 stable Codex hooks API 和 peon-ping 适配器。如果 `~/.codex` 已存在，Unix 和 Windows 安装器会自动向 `~/.codex/config.toml` 写入 peon 管理的配置块。如果你先安装了 peon-ping、之后才安装 Codex，请重新运行 peon-ping 安装器。
 
 默认注册的 Codex 事件包括 `SessionStart`、`UserPromptSubmit`、`PermissionRequest`、`PreCompact`、`SubagentStart`、`SubagentStop` 和 `Stop`。`SessionStart` 只匹配 `startup`、`resume` 和 `clear`；Codex 的上下文压缩由 `PreCompact` 处理，因此会跳过 compact 触发的 `SessionStart`。`PreToolUse`、`PostToolUse` 和 `PostCompact` 会刻意跳过；Codex 适配器会忽略 `PostToolUse`，因为 Codex 没有单独的失败专用 hook，而成功工具调用 hook 对 peon-ping 来说过于频繁。
+
+### Grok Build 设置
+
+Grok Build 的 hook 负载是 camelCase（`hookEventName`、`sessionId`、`notificationType`），事件值是 snake_case（`session_start`、`stop`），`peon.sh` 无法直接识别。因此 peon-ping 提供 `adapters/grok.sh`（Windows 上为 `grok.ps1`）。
+
+如果 `~/.grok` 已存在，Unix 和 Windows 安装器会自动写入 `~/.grok/hooks/peon-ping.json`。如果你先装了 peon-ping、之后才装 Grok Build，请重新运行安装器。
+
+默认注册的事件：`SessionStart`、`SessionEnd`、`UserPromptSubmit`、`Stop`、`StopFailure`、`Notification`、`SubagentStart`、`SubagentStop`、`PostToolUseFailure`、`PreCompact`。`PreToolUse`、`PostToolUse`、`PostCompact` 和 `PermissionDenied` 不会注册。会话结束时的 `Stop`（`reason: shutdown` / `channel_closed`）只做清理，不会播放完成音。shell 失败的 `toolName` 是 `run_terminal_command`，适配器会改写成 Bash，这样 `task.error` 仍会响。
+
+若 Grok 会话已经在跑，用 `/hooks` 然后按 `r` 重载，或新开一个会话。Grok 也会扫描 `~/.claude/settings.json` 里的 hook，但那些调用带着 Grok 的 camelCase 负载，`peon.sh` 会静音；真正发声的是 `~/.grok/hooks/peon-ping.json`。若不想在 `/hooks` 里看到那批静音的 Claude 条目，可在 `~/.grok/config.toml` 里设置 `[compat.claude] hooks = false`。
 
 **设置步骤：**
 

--- a/adapters/grok.ps1
+++ b/adapters/grok.ps1
@@ -1,0 +1,145 @@
+# peon-ping adapter for Grok Build (Windows)
+# Translates Grok Build hook events into peon.ps1 stdin JSON.
+#
+# Grok sends camelCase stdin (hookEventName, sessionId, notificationType)
+# with snake_case event values (session_start, stop, notification).
+#
+# Setup: re-run install.ps1 after Grok Build creates ~/.grok, or point
+#   Grok's hooks at this script.
+
+$ErrorActionPreference = "SilentlyContinue"
+
+$PeonDir = if ($env:CLAUDE_PEON_DIR) { $env:CLAUDE_PEON_DIR }
+           else { Join-Path $env:USERPROFILE ".claude\hooks\peon-ping" }
+
+$PeonScript = Join-Path $PeonDir "peon.ps1"
+if (-not (Test-Path $PeonScript)) { exit 0 }
+
+$inputJson = $null
+try {
+    if ([Console]::IsInputRedirected) {
+        $stream = [Console]::OpenStandardInput()
+        $reader = New-Object System.IO.StreamReader($stream, [System.Text.Encoding]::UTF8)
+        $raw = $reader.ReadToEnd()
+        $reader.Close()
+        if ($raw) { $inputJson = $raw | ConvertFrom-Json }
+    }
+} catch { if ($env:PEON_DEBUG -eq "1") { Write-Warning "peon-ping: [grok] ConvertFrom-Json failed: $_" } }
+
+function Get-Field($obj, [string]$name) {
+    if ($null -eq $obj) { return $null }
+    return $obj.PSObject.Properties[$name].Value
+}
+
+function First-NonEmpty {
+    foreach ($value in $args) {
+        if ($null -eq $value) { continue }
+        $text = "$value".Trim()
+        if ($text) { return $text }
+    }
+    return ""
+}
+
+$rawEvent = First-NonEmpty $env:GROK_HOOK_EVENT (Get-Field $inputJson "hookEventName") (Get-Field $inputJson "hook_event_name") (Get-Field $inputJson "event")
+$eventKey = $rawEvent.ToString().Trim().ToLower().Replace("-", "_")
+$notifType = (First-NonEmpty (Get-Field $inputJson "notificationType") (Get-Field $inputJson "notification_type") (Get-Field $inputJson "type")).ToLower()
+$reason = (First-NonEmpty (Get-Field $inputJson "reason") (Get-Field $inputJson "stopReason") (Get-Field $inputJson "stop_reason")).ToLower()
+
+if ($eventKey -in @(
+    "pre_tool_use", "pretooluse",
+    "post_tool_use", "posttooluse",
+    "post_compact", "postcompact",
+    "permission_denied", "permissiondenied"
+)) {
+    exit 0
+}
+
+$mapped = $null
+$ntype = ""
+
+if ($eventKey -in @("session_start", "sessionstart")) {
+    $mapped = "SessionStart"
+} elseif ($eventKey -in @("session_end", "sessionend")) {
+    $mapped = "SessionEnd"
+} elseif ($eventKey -in @("user_prompt_submit", "userpromptsubmit")) {
+    $mapped = "UserPromptSubmit"
+} elseif ($eventKey -in @("subagent_start", "subagentstart")) {
+    $mapped = "SubagentStart"
+} elseif ($eventKey -in @("subagent_stop", "subagentstop", "subagent_end", "subagentend")) {
+    $mapped = "SubagentStop"
+} elseif ($eventKey -in @("pre_compact", "precompact")) {
+    $mapped = "PreCompact"
+} elseif ($eventKey -in @("post_tool_use_failure", "posttoolusefailure", "stop_failure", "stopfailure")) {
+    $mapped = "PostToolUseFailure"
+} elseif ($eventKey -eq "notification") {
+    if ($notifType -in @("permission_prompt", "permission", "approval_required")) {
+        $mapped = "PermissionRequest"
+        $ntype = "permission_prompt"
+    } elseif ($notifType -in @("idle_prompt", "idle")) {
+        $mapped = "Notification"
+        $ntype = "idle_prompt"
+    } elseif ($notifType -in @("elicitation_dialog", "elicitation", "question")) {
+        $mapped = "Notification"
+        $ntype = "elicitation_dialog"
+    } else {
+        exit 0
+    }
+} elseif ($eventKey -eq "stop") {
+    if ($reason -in @("channel_closed", "shutdown")) {
+        $mapped = "SessionEnd"
+    } elseif ($reason -and $reason -ne "end_turn") {
+        exit 0
+    } else {
+        $mapped = "Stop"
+    }
+} else {
+    exit 0
+}
+
+$rawSid = First-NonEmpty (Get-Field $inputJson "sessionId") (Get-Field $inputJson "session_id") $env:GROK_SESSION_ID "$PID"
+$safeSid = ($rawSid -replace '[^A-Za-z0-9._:-]', '-').Trim('-')
+if (-not $safeSid) { $safeSid = "$PID" }
+$sessionId = if ($safeSid.StartsWith("grok-")) { $safeSid } else { "grok-$safeSid" }
+
+$cwd = First-NonEmpty (Get-Field $inputJson "cwd") (Get-Field $inputJson "workspaceRoot") (Get-Field $inputJson "workspace_root") $env:GROK_WORKSPACE_ROOT $PWD.Path
+
+$payload = @{
+    hook_event_name   = $mapped
+    notification_type = $ntype
+    cwd               = $cwd
+    session_id        = $sessionId
+    permission_mode   = (First-NonEmpty (Get-Field $inputJson "permissionMode") (Get-Field $inputJson "permission_mode"))
+    source            = "grok"
+}
+
+$agentId = First-NonEmpty (Get-Field $inputJson "agentId") (Get-Field $inputJson "agent_id") (Get-Field $inputJson "subagentId") (Get-Field $inputJson "subagent_id")
+if ($agentId) { $payload["agent_id"] = $agentId }
+
+$agentType = First-NonEmpty (Get-Field $inputJson "agentType") (Get-Field $inputJson "agent_type") (Get-Field $inputJson "subagentType") (Get-Field $inputJson "subagent_type")
+if ($agentType) { $payload["agent_type"] = $agentType }
+
+$summary = First-NonEmpty (Get-Field $inputJson "lastAssistantMessage") (Get-Field $inputJson "last_assistant_message") (Get-Field $inputJson "transcript_summary") (Get-Field $inputJson "summary")
+if ($summary) {
+    $payload["last_assistant_message"] = $summary
+    $payload["transcript_summary"] = $summary
+}
+
+if ($mapped -eq "PostToolUseFailure") {
+    $tn = First-NonEmpty (Get-Field $inputJson "toolName") (Get-Field $inputJson "tool_name") (Get-Field $inputJson "tool")
+    $shellTools = @("bash", "run_terminal_command", "shell")
+    if ((-not $tn) -or ($tn.ToLower() -in $shellTools) -or ($eventKey -in @("stop_failure", "stopfailure"))) {
+        $payload["tool_name"] = "Bash"
+    } else {
+        $payload["tool_name"] = $tn
+    }
+    $err = First-NonEmpty (Get-Field $inputJson "errorDetails") (Get-Field $inputJson "error_details") (Get-Field $inputJson "error") (Get-Field $inputJson "message") $summary
+    if (-not $err) { $err = "Grok event: $rawEvent" }
+    $payload["error"] = $err
+}
+
+$payloadJson = $payload | ConvertTo-Json -Compress
+
+# Discard peon.ps1 stdout so a Stop gate can never parse a chime as a decision.
+$payloadJson | powershell -NoProfile -NonInteractive -File $PeonScript >$null 2>$null
+
+exit 0

--- a/adapters/grok.sh
+++ b/adapters/grok.sh
@@ -1,0 +1,262 @@
+#!/bin/bash
+# peon-ping adapter for Grok Build
+# Translates Grok Build hook events into peon.sh stdin JSON.
+#
+# Grok sends camelCase stdin (hookEventName, sessionId, notificationType)
+# with snake_case event values (session_start, stop, notification). peon.sh
+# expects Claude-style PascalCase hook_event_name. This adapter translates
+# and then calls peon.sh.
+#
+# Setup: if ~/.grok already exists, install.sh / install.ps1 write
+#   ~/.grok/hooks/peon-ping.json automatically. Re-run the installer after
+#   installing Grok Build, or point Grok's hooks at this script by hand.
+#
+# Grok's Stop / SubagentStop hooks are stop-gates: anything that looks like
+# decision JSON on stdout can keep the agent working. peon.sh output is
+# discarded so a chime can never be parsed as a gate decision.
+
+set -euo pipefail
+
+PEON_DIR="${CLAUDE_PEON_DIR:-${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/peon-ping}"
+PEON_SH="$PEON_DIR/peon.sh"
+[ -f "$PEON_SH" ] || exit 0
+
+if [ -t 0 ]; then
+  GROK_STDIN=""
+else
+  GROK_STDIN="$(cat)"
+fi
+
+MAPPED_JSON="$(
+  _GROK_STDIN="$GROK_STDIN" python3 - <<'PY'
+import json
+import os
+import re
+import sys
+
+
+def first_non_empty(*values):
+    for value in values:
+        if value is None:
+            continue
+        if isinstance(value, str):
+            if value.strip():
+                return value.strip()
+        else:
+            return value
+    return ""
+
+
+raw_stdin = os.environ.get("_GROK_STDIN", "").strip()
+event_data = {}
+if raw_stdin:
+    try:
+        parsed = json.loads(raw_stdin)
+        if isinstance(parsed, dict):
+            event_data = parsed
+    except Exception:
+        event_data = {}
+
+raw_event = first_non_empty(
+    os.environ.get("GROK_HOOK_EVENT", ""),
+    event_data.get("hookEventName", ""),
+    event_data.get("hook_event_name", ""),
+    event_data.get("event", ""),
+)
+event_key = str(raw_event).strip().lower().replace("-", "_")
+
+notif_type = str(
+    first_non_empty(
+        event_data.get("notificationType", ""),
+        event_data.get("notification_type", ""),
+        event_data.get("type", ""),
+    )
+).strip().lower()
+
+reason = str(
+    first_non_empty(
+        event_data.get("reason", ""),
+        event_data.get("stopReason", ""),
+        event_data.get("stop_reason", ""),
+    )
+).strip().lower()
+
+# Per-tool hooks are too noisy. Completion / error / attention events
+# are the ones peon-ping has sounds for.
+if event_key in (
+    "pre_tool_use",
+    "pretooluse",
+    "post_tool_use",
+    "posttooluse",
+    "post_compact",
+    "postcompact",
+    "permission_denied",
+    "permissiondenied",
+):
+    sys.exit(0)
+
+if event_key in ("session_start", "sessionstart"):
+    mapped_event = "SessionStart"
+    mapped_ntype = ""
+elif event_key in ("session_end", "sessionend"):
+    mapped_event = "SessionEnd"
+    mapped_ntype = ""
+elif event_key in ("user_prompt_submit", "userpromptsubmit"):
+    mapped_event = "UserPromptSubmit"
+    mapped_ntype = ""
+elif event_key in ("subagent_start", "subagentstart"):
+    mapped_event = "SubagentStart"
+    mapped_ntype = ""
+elif event_key in ("subagent_stop", "subagentstop", "subagent_end", "subagentend"):
+    mapped_event = "SubagentStop"
+    mapped_ntype = ""
+elif event_key in ("pre_compact", "precompact"):
+    mapped_event = "PreCompact"
+    mapped_ntype = ""
+elif event_key in ("post_tool_use_failure", "posttoolusefailure"):
+    mapped_event = "PostToolUseFailure"
+    mapped_ntype = ""
+elif event_key in ("stop_failure", "stopfailure"):
+    mapped_event = "PostToolUseFailure"
+    mapped_ntype = ""
+elif event_key in ("notification",):
+    if notif_type in ("permission_prompt", "permission", "approval_required"):
+        mapped_event = "PermissionRequest"
+        mapped_ntype = "permission_prompt"
+    elif notif_type in ("idle_prompt", "idle"):
+        mapped_event = "Notification"
+        mapped_ntype = "idle_prompt"
+    elif notif_type in ("elicitation_dialog", "elicitation", "question"):
+        mapped_event = "Notification"
+        mapped_ntype = "elicitation_dialog"
+    elif notif_type in ("task_complete", "turn_complete"):
+        # Stop already covers genuine turn completion.
+        sys.exit(0)
+    else:
+        sys.exit(0)
+elif event_key in ("stop",):
+    # Grok also fires observe-only Stop at session end. Only chime on a
+    # real turn completion; treat session teardown as SessionEnd.
+    if reason in ("channel_closed", "shutdown"):
+        mapped_event = "SessionEnd"
+        mapped_ntype = ""
+    elif reason and reason != "end_turn":
+        sys.exit(0)
+    else:
+        mapped_event = "Stop"
+        mapped_ntype = ""
+else:
+    sys.exit(0)
+
+cwd = str(
+    first_non_empty(
+        event_data.get("cwd", ""),
+        event_data.get("workspaceRoot", ""),
+        event_data.get("workspace_root", ""),
+        os.environ.get("GROK_WORKSPACE_ROOT", ""),
+        os.environ.get("CLAUDE_PROJECT_DIR", ""),
+        os.environ.get("PWD", ""),
+        "/",
+    )
+)
+
+raw_session_id = str(
+    first_non_empty(
+        event_data.get("sessionId", ""),
+        event_data.get("session_id", ""),
+        os.environ.get("GROK_SESSION_ID", ""),
+        os.getpid(),
+    )
+)
+safe_session_id = re.sub(r"[^A-Za-z0-9._:-]", "-", raw_session_id).strip("-")
+if not safe_session_id:
+    safe_session_id = str(os.getpid())
+if safe_session_id.startswith("grok-"):
+    session_id = safe_session_id
+else:
+    session_id = f"grok-{safe_session_id}"
+
+payload = {
+    "hook_event_name": mapped_event,
+    "notification_type": mapped_ntype,
+    "cwd": cwd,
+    "session_id": session_id,
+    "permission_mode": str(
+        first_non_empty(
+            event_data.get("permissionMode", ""),
+            event_data.get("permission_mode", ""),
+            "",
+        )
+    ),
+    "source": "grok",
+}
+
+agent_id = first_non_empty(
+    event_data.get("agentId", ""),
+    event_data.get("agent_id", ""),
+    event_data.get("subagentId", ""),
+    event_data.get("subagent_id", ""),
+)
+if isinstance(agent_id, str) and agent_id:
+    payload["agent_id"] = agent_id[:80]
+
+agent_type = first_non_empty(
+    event_data.get("agentType", ""),
+    event_data.get("agent_type", ""),
+    event_data.get("subagentType", ""),
+    event_data.get("subagent_type", ""),
+)
+if isinstance(agent_type, str) and agent_type:
+    payload["agent_type"] = agent_type[:80]
+
+summary = first_non_empty(
+    event_data.get("lastAssistantMessage", ""),
+    event_data.get("last_assistant_message", ""),
+    event_data.get("transcript_summary", ""),
+    event_data.get("summary", ""),
+)
+if isinstance(summary, str) and summary:
+    payload["last_assistant_message"] = summary[:120]
+    payload["transcript_summary"] = summary[:120]
+
+tool_name = first_non_empty(
+    event_data.get("toolName", ""),
+    event_data.get("tool_name", ""),
+    event_data.get("tool", ""),
+)
+shell_tools = {"bash", "run_terminal_command", "shell"}
+if mapped_event == "PostToolUseFailure":
+    if str(tool_name).strip().lower() in shell_tools or event_key in ("stop_failure", "stopfailure"):
+        payload["tool_name"] = "Bash"
+    elif isinstance(tool_name, str) and tool_name:
+        payload["tool_name"] = tool_name[:64]
+    else:
+        payload["tool_name"] = "Bash"
+elif isinstance(tool_name, str) and tool_name:
+    payload["tool_name"] = tool_name[:64]
+
+error = first_non_empty(
+    event_data.get("errorDetails", ""),
+    event_data.get("error_details", ""),
+    event_data.get("error", ""),
+    event_data.get("message", ""),
+    summary,
+)
+if mapped_event == "PostToolUseFailure":
+    if not error:
+        error = f"Grok event: {raw_event or event_key}"
+    payload["error"] = str(error)[:180]
+
+print(json.dumps(payload))
+PY
+)" || MAPPED_JSON=""
+
+if [ -n "${MAPPED_JSON:-}" ]; then
+  # Discard peon.sh stdout so Stop/SubagentStop can never be parsed as a
+  # gate decision. SessionStart keeps stderr so update notices still surface.
+  if printf '%s' "$MAPPED_JSON" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("hook_event_name",""))' 2>/dev/null | grep -qx 'SessionStart'; then
+    printf '%s' "$MAPPED_JSON" | bash "$PEON_SH" >/dev/null || true
+  else
+    printf '%s' "$MAPPED_JSON" | bash "$PEON_SH" >/dev/null 2>&1 || true
+  fi
+fi

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -2,7 +2,7 @@
 
 > Game character voice lines + visual overlay notifications when your AI coding agent needs attention.
 
-peon-ping plays voice lines and shows bold on-screen overlay banners from Warcraft, StarCraft, Portal, Zelda, and 90+ other games when your AI coding agent finishes a task, needs permission, or hits an error. Works with Claude Code, Amp, GitHub Copilot, Cursor, OpenCode, Codex, Kiro, Kimi Code, Windsurf, DeepAgents, Qwen Code, iFlow CLI, Trae, Kiro IDE, ECA, and any MCP-compatible AI agent.
+peon-ping plays voice lines and shows bold on-screen overlay banners from Warcraft, StarCraft, Portal, Zelda, and 90+ other games when your AI coding agent finishes a task, needs permission, or hits an error. Works with Claude Code, Amp, GitHub Copilot, Cursor, OpenCode, Codex, Grok Build, Kiro, Kimi Code, Windsurf, DeepAgents, Qwen Code, iFlow CLI, Trae, Kiro IDE, ECA, and any MCP-compatible AI agent.
 
 ## Links
 
@@ -68,6 +68,7 @@ MCP resources: `peon-ping://catalog`, `peon-ping://pack/{name}`
 - Gemini CLI (adapter)
 - GitHub Copilot CLI (built-in: install.sh and install.ps1 auto-register PascalCase hooks at ~/.copilot/hooks/peon-ping.json when ~/.copilot exists, no per-repo setup needed; PascalCase event names trigger the VS Code-compatible payload format that peon.sh/peon.ps1 reads natively. Per-repo wiring also available via adapters/copilot.sh / .ps1 with .github/hooks/hooks.json. Skips postToolUse to avoid debounce flooding; correctly maps agentStop -> Stop. Requires PowerShell 7+ on Windows.)
 - OpenAI Codex (built-in auto-detect: install.sh and install.ps1 register stable hooks in ~/.codex/config.toml when ~/.codex exists; registered events are SessionStart, UserPromptSubmit, PermissionRequest, PreCompact, SubagentStart, SubagentStop, and Stop. SessionStart matches startup/resume/clear only; compaction is handled by PreCompact. PreToolUse, PostToolUse, and PostCompact are intentionally not registered; PostToolUse is ignored because Codex has no separate failure-only hook.)
+- Grok Build (built-in auto-detect: install.sh and install.ps1 write ~/.grok/hooks/peon-ping.json when ~/.grok exists, pointing at adapters/grok.sh or grok.ps1. Grok stdin is camelCase with snake_case event values, so peon.sh cannot be invoked directly. Registered events: SessionStart, SessionEnd, UserPromptSubmit, Stop, StopFailure, Notification, SubagentStart, SubagentStop, PostToolUseFailure, PreCompact. Session-end Stop (reason shutdown/channel_closed) is treated as SessionEnd. run_terminal_command failures map to Bash for task.error. Stop-gate stdout is discarded.)
 - Cursor
 - OpenCode
 - Kilo CLI

--- a/install.ps1
+++ b/install.ps1
@@ -511,12 +511,14 @@ function Normalize-IdeId {
         "trae" { return "trae" }
         "kiro-ide" { return "kiro-ide" }
         "eca" { return "eca" }
+        "grok" { return "grok" }
+        "grok-build" { return "grok" }
         default { return $key }
     }
 }
 
 function Get-KnownIdeIds {
-    return @("claude", "codex", "cursor", "opencode", "kilo", "kiro", "gemini", "copilot", "windsurf", "kimi", "antigravity", "amp", "deepagents", "openclaw", "rovodev")
+    return @("claude", "codex", "cursor", "opencode", "kilo", "kiro", "gemini", "copilot", "windsurf", "kimi", "antigravity", "amp", "deepagents", "openclaw", "rovodev", "grok")
 }
 
 function Expand-UserPath {
@@ -577,6 +579,7 @@ function Detect-SessionIde {
         "iflow-" = "iflow"
         "trae-" = "trae"
         "eca-" = "eca"
+        "grok-" = "grok"
     }
     foreach ($prefix in $prefixes.Keys) {
         if ($sid.StartsWith($prefix)) { return $prefixes[$prefix] }
@@ -2589,6 +2592,7 @@ $ideDisplayNames = @{
     'trae' = 'Trae'
     'kiro-ide' = 'Kiro IDE'
     'eca' = 'ECA'
+    'grok' = 'Grok Build'
 }
 $ideLabel = ''
 if ($sessionIde) {
@@ -3409,7 +3413,8 @@ $adapterFiles = @(
     "codex.ps1", "gemini.ps1", "copilot.ps1", "windsurf.ps1",
     "kiro.ps1", "openclaw.ps1", "amp.ps1", "antigravity.ps1",
     "kimi.ps1", "opencode.ps1", "kilo.ps1", "deepagents.ps1",
-    "qwen.ps1", "iflow.ps1", "trae.ps1", "kiro-ide.ps1", "eca.ps1"
+    "qwen.ps1", "iflow.ps1", "trae.ps1", "kiro-ide.ps1", "eca.ps1",
+    "grok.ps1"
 )
 
 $sourceAdaptersDir = Join-Path $ScriptDir "adapters"
@@ -3760,6 +3765,56 @@ if ((-not $Local) -and (Test-Path $CopilotDir)) {
     New-Item -ItemType Directory -Path $CopilotHooksDir -Force | Out-Null
     $copilotData | ConvertTo-Json -Depth 10 | Set-Content $CopilotHooksFile -Encoding UTF8
     Write-Host "  Copilot CLI hooks registered for: $($copilotEvents -join ', ')" -ForegroundColor Green
+}
+
+# --- Register Grok Build hooks if ~/.grok exists ---
+# Wires user-level hooks at %USERPROFILE%\.grok\hooks\peon-ping.json
+# pointing at adapters/grok.ps1. Grok's stdin is camelCase with snake_case
+# event values, so peon.ps1 cannot be invoked directly.
+$GrokDir = Join-Path $env:USERPROFILE ".grok"
+$GrokHooksDir = Join-Path $GrokDir "hooks"
+$GrokHooksFile = Join-Path $GrokHooksDir "peon-ping.json"
+$GrokAdapter = Join-Path $adaptersDir "grok.ps1"
+
+if ((-not $Local) -and (Test-Path $GrokDir)) {
+    Write-Host ""
+    Write-Host "Detected Grok Build installation, registering hooks..."
+
+    if (Test-Path $GrokAdapter) {
+        $grokHookCmd = "powershell -NoProfile -NonInteractive -File `"$GrokAdapter`""
+        $grokEvents = @(
+            "SessionStart", "SessionEnd", "UserPromptSubmit", "Stop", "StopFailure",
+            "Notification", "SubagentStart", "SubagentStop", "PostToolUseFailure",
+            "PreCompact"
+        )
+        $grokHooks = [ordered]@{}
+        foreach ($evt in $grokEvents) {
+            $grokHooks[$evt] = @(
+                [PSCustomObject]@{
+                    hooks = @(
+                        [PSCustomObject]@{
+                            type    = "command"
+                            command = $grokHookCmd
+                            timeout = 10
+                        }
+                    )
+                }
+            )
+        }
+        $grokData = [PSCustomObject]@{
+            hooks = [PSCustomObject]$grokHooks
+        }
+
+        New-Item -ItemType Directory -Path $GrokHooksDir -Force | Out-Null
+        $grokData | ConvertTo-Json -Depth 10 | Set-Content $GrokHooksFile -Encoding UTF8
+        Write-Host "  Grok Build hooks registered for: $($grokEvents -join ', ')" -ForegroundColor Green
+        Write-Host "  Reload hooks in a running Grok session (/hooks then r) or start a new one." -ForegroundColor Yellow
+    } else {
+        if (Test-Path $GrokHooksFile) {
+            Remove-Item -Path $GrokHooksFile -Force -ErrorAction SilentlyContinue
+        }
+        Write-Host "  Warning: Grok adapter is missing; stale peon-ping hooks were removed instead of registered." -ForegroundColor Yellow
+    }
 }
 
 # --- Register OpenAI Codex hooks if ~/.codex exists ---

--- a/install.sh
+++ b/install.sh
@@ -669,6 +669,7 @@ else
   curl -fsSL "$REPO_BASE/adapters/trae.sh" -o "$INSTALL_DIR/adapters/trae.sh" 2>/dev/null || true
   curl -fsSL "$REPO_BASE/adapters/kiro-ide.sh" -o "$INSTALL_DIR/adapters/kiro-ide.sh" 2>/dev/null || true
   curl -fsSL "$REPO_BASE/adapters/eca.sh" -o "$INSTALL_DIR/adapters/eca.sh" 2>/dev/null || true
+  curl -fsSL "$REPO_BASE/adapters/grok.sh" -o "$INSTALL_DIR/adapters/grok.sh" 2>/dev/null || true
   mkdir -p "$INSTALL_DIR/scripts"
   curl -fsSL "$REPO_BASE/scripts/hook-handle-use.sh" -o "$INSTALL_DIR/scripts/hook-handle-use.sh" 2>/dev/null || true
   curl -fsSL "$REPO_BASE/scripts/codex-config.py" -o "$INSTALL_DIR/scripts/codex-config.py"
@@ -1460,6 +1461,57 @@ with open(hooks_file, 'w') as f:
 
 print('Copilot CLI hooks registered for: ' + ', '.join(events))
 "
+fi
+
+# --- Register Grok Build hooks if ~/.grok exists ---
+# Wires user-level hooks at ~/.grok/hooks/peon-ping.json pointing at
+# adapters/grok.sh. Grok's stdin is camelCase with snake_case event
+# values, so peon.sh cannot be invoked directly.
+GROK_DIR="$HOME/.grok"
+GROK_HOOKS_DIR="$GROK_DIR/hooks"
+GROK_HOOKS_FILE="$GROK_HOOKS_DIR/peon-ping.json"
+GROK_ADAPTER="$INSTALL_DIR/adapters/grok.sh"
+
+if [ "$LOCAL_MODE" != true ] && [ -d "$GROK_DIR" ]; then
+  echo ""
+  echo "Detected Grok Build installation, registering hooks..."
+
+  if [ -f "$GROK_ADAPTER" ]; then
+    mkdir -p "$GROK_HOOKS_DIR"
+    python3 -c "
+import json, os
+
+hooks_file = '$(py_path "$GROK_HOOKS_FILE")'
+adapter = '$(py_path "$GROK_ADAPTER")'
+
+events = [
+    'SessionStart', 'SessionEnd', 'UserPromptSubmit', 'Stop', 'StopFailure',
+    'Notification', 'SubagentStart', 'SubagentStop', 'PostToolUseFailure',
+    'PreCompact',
+]
+
+hooks = {}
+for evt in events:
+    hooks[evt] = [{
+        'hooks': [{
+            'type': 'command',
+            'command': adapter,
+            'timeout': 10,
+        }]
+    }]
+
+os.makedirs(os.path.dirname(hooks_file), exist_ok=True)
+with open(hooks_file, 'w') as f:
+    json.dump({'hooks': hooks}, f, indent=2)
+    f.write('\n')
+
+print('Grok Build hooks registered for: ' + ', '.join(events))
+print('Reload hooks in a running Grok session (/hooks then r) or start a new one.')
+"
+  else
+    rm -f "$GROK_HOOKS_FILE"
+    echo "Warning: Grok adapter is missing; stale peon-ping hooks were removed instead of registered."
+  fi
 fi
 
 # --- Register OpenAI Codex hooks if ~/.codex exists ---

--- a/peon.sh
+++ b/peon.sh
@@ -1565,6 +1565,8 @@ IDE_ALIASES = {
     'open_claw': 'openclaw',
     'rovodev': 'rovodev',
     'rovo': 'rovodev',
+    'grok': 'grok',
+    'grok-build': 'grok',
 }
 
 def normalize_ide_id(value):
@@ -1880,6 +1882,21 @@ if os.path.isdir(codex_dir):
         ides.append(('OpenAI Codex', codex_dir, 'installed'))
     else:
         ides.append(('OpenAI Codex', codex_dir, 'detected (not set up)'))
+
+grok_dir = os.path.join(home, '.grok')
+grok_hooks = os.path.join(grok_dir, 'hooks', 'peon-ping.json')
+if os.path.isdir(grok_dir):
+    grok_installed = False
+    if os.path.isfile(grok_hooks):
+        try:
+            grok_text = open(grok_hooks).read()
+            grok_installed = 'grok.sh' in grok_text or 'grok.ps1' in grok_text
+        except Exception:
+            grok_installed = False
+    if grok_installed:
+        ides.append(('Grok Build', grok_dir, 'installed'))
+    else:
+        ides.append(('Grok Build', grok_dir, 'detected (not set up)'))
 
 if ides:
     for name, path, st in ides:
@@ -2696,9 +2713,10 @@ IDE_ALIASES = {
     'kimi': 'kimi', 'antigravity': 'antigravity', 'amp': 'amp', 'deepagents': 'deepagents',
     'deep-agents': 'deepagents', 'deep_agents': 'deepagents', 'openclaw': 'openclaw',
     'open-claw': 'openclaw', 'open_claw': 'openclaw', 'rovodev': 'rovodev', 'rovo': 'rovodev',
+    'grok': 'grok', 'grok-build': 'grok',
 }
 KNOWN_IDES = ['claude', 'codex', 'cursor', 'opencode', 'kilo', 'kiro', 'gemini', 'copilot', 'windsurf',
-              'kimi', 'antigravity', 'amp', 'deepagents', 'openclaw', 'rovodev']
+              'kimi', 'antigravity', 'amp', 'deepagents', 'openclaw', 'rovodev', 'grok']
 
 def normalize_ide_id(value):
     raw = str(value or '').strip().lower()
@@ -2766,6 +2784,7 @@ IDE_ALIASES = {
     'kimi': 'kimi', 'antigravity': 'antigravity', 'amp': 'amp', 'deepagents': 'deepagents',
     'deep-agents': 'deepagents', 'deep_agents': 'deepagents', 'openclaw': 'openclaw',
     'open-claw': 'openclaw', 'open_claw': 'openclaw', 'rovodev': 'rovodev', 'rovo': 'rovodev',
+    'grok': 'grok', 'grok-build': 'grok',
 }
 
 def normalize_ide_id(value):
@@ -2807,9 +2826,10 @@ IDE_ALIASES = {
     'kimi': 'kimi', 'antigravity': 'antigravity', 'amp': 'amp', 'deepagents': 'deepagents',
     'deep-agents': 'deepagents', 'deep_agents': 'deepagents', 'openclaw': 'openclaw',
     'open-claw': 'openclaw', 'open_claw': 'openclaw', 'rovodev': 'rovodev', 'rovo': 'rovodev',
+    'grok': 'grok', 'grok-build': 'grok',
 }
 KNOWN_IDES = ['claude', 'codex', 'cursor', 'opencode', 'kilo', 'kiro', 'gemini', 'copilot', 'windsurf',
-              'kimi', 'antigravity', 'amp', 'deepagents', 'openclaw', 'rovodev']
+              'kimi', 'antigravity', 'amp', 'deepagents', 'openclaw', 'rovodev', 'grok']
 
 def normalize_ide_id(value):
     raw = str(value or '').strip().lower()
@@ -5338,6 +5358,8 @@ IDE_ALIASES = {
     'trae': 'trae',
     'kiro-ide': 'kiro-ide',
     'eca': 'eca',
+    'grok': 'grok',
+    'grok-build': 'grok',
 }
 
 def normalize_ide_id(value):
@@ -5375,6 +5397,7 @@ def detect_session_ide(source_value, event_payload, session_value):
         ('iflow-', 'iflow'),
         ('trae-', 'trae'),
         ('eca-', 'eca'),
+        ('grok-', 'grok'),
     )
     for prefix, ide in prefix_map:
         if sid.startswith(prefix):
@@ -5403,6 +5426,7 @@ IDE_DISPLAY_NAMES = {
     'trae': 'Trae',
     'kiro-ide': 'Kiro IDE',
     'eca': 'ECA',
+    'grok': 'Grok Build',
 }
 
 def display_ide_name(ide_id):

--- a/tests/adapters-windows.Tests.ps1
+++ b/tests/adapters-windows.Tests.ps1
@@ -162,6 +162,49 @@ Describe "Category A: Codex Adapter" {
     }
 }
 
+Describe "Category A: Grok Adapter" {
+    BeforeAll {
+        $script:grokContent = Get-Content (Join-Path $script:AdaptersDir "grok.ps1") -Raw
+    }
+
+    It "maps session_start to SessionStart" {
+        $script:grokContent | Should -Match 'session_start'
+        $script:grokContent | Should -Match '\$mapped = "SessionStart"'
+    }
+
+    It "maps stop end_turn to Stop" {
+        $script:grokContent | Should -Match 'end_turn'
+        $script:grokContent | Should -Match '\$mapped = "Stop"'
+    }
+
+    It "maps permission_prompt to PermissionRequest" {
+        $script:grokContent | Should -Match 'permission_prompt'
+        $script:grokContent | Should -Match '\$mapped = "PermissionRequest"'
+    }
+
+    It "maps pre_compact to PreCompact" {
+        $script:grokContent | Should -Match 'pre_compact'
+        $script:grokContent | Should -Match '\$mapped = "PreCompact"'
+    }
+
+    It "keeps PreToolUse and PostToolUse silent" {
+        $script:grokContent | Should -Match 'pre_tool_use'
+        $script:grokContent | Should -Match 'post_tool_use'
+        $script:grokContent | Should -Match 'exit 0'
+    }
+
+    It "prefixes session ids with grok-" {
+        $script:grokContent | Should -Match 'grok-\$safeSid'
+        $script:grokContent | Should -Match 'source\s+= "grok"'
+    }
+
+    It "pipes JSON to peon.ps1 and discards stdout" {
+        $script:grokContent | Should -Match 'peon\.ps1'
+        $script:grokContent | Should -Match 'ConvertTo-Json'
+        $script:grokContent | Should -Match '>\s*\$null'
+    }
+}
+
 Describe "Category A: Gemini Adapter" {
     BeforeAll {
         $script:geminiContent = Get-Content (Join-Path $script:AdaptersDir "gemini.ps1") -Raw

--- a/tests/grok.bats
+++ b/tests/grok.bats
@@ -1,0 +1,157 @@
+#!/usr/bin/env bats
+
+load setup.bash
+
+setup() {
+  setup_test_env
+  unset GROK_HOOK_EVENT GROK_SESSION_ID GROK_WORKSPACE_ROOT
+
+  GROK_SH="${PEON_SH%/peon.sh}/adapters/grok.sh"
+
+  # Adapter resolves peon.sh via CLAUDE_PEON_DIR
+  ln -sf "$PEON_SH" "$TEST_DIR/peon.sh"
+}
+
+teardown() {
+  teardown_test_env
+}
+
+run_grok() {
+  local json="${1-}"
+  export PEON_TEST=1
+  if [ -n "$json" ]; then
+    echo "$json" | bash "$GROK_SH" 2>"$TEST_DIR/stderr.log"
+  else
+    bash "$GROK_SH" 2>"$TEST_DIR/stderr.log"
+  fi
+  GROK_EXIT=$?
+  GROK_STDERR=$(cat "$TEST_DIR/stderr.log" 2>/dev/null)
+  sleep 0.3
+}
+
+@test "adapter script has valid bash syntax" {
+  run bash -n "$GROK_SH"
+  [ "$status" -eq 0 ]
+}
+
+@test "session_start maps to session.start and plays greeting" {
+  run_grok '{"hookEventName":"session_start","sessionId":"s1"}'
+  [ "$GROK_EXIT" -eq 0 ]
+  afplay_was_called
+  sound=$(afplay_sound)
+  [[ "$sound" == *"/packs/peon/sounds/Hello"* ]]
+}
+
+@test "stop end_turn maps to task.complete and plays completion sound" {
+  run_grok '{"hookEventName":"stop","sessionId":"s1","reason":"end_turn"}'
+  [ "$GROK_EXIT" -eq 0 ]
+  afplay_was_called
+  sound=$(afplay_sound)
+  [[ "$sound" == *"/packs/peon/sounds/Done"* ]]
+}
+
+@test "stop without reason still plays completion sound" {
+  run_grok '{"hookEventName":"stop","sessionId":"s-plain"}'
+  [ "$GROK_EXIT" -eq 0 ]
+  afplay_was_called
+  sound=$(afplay_sound)
+  [[ "$sound" == *"/packs/peon/sounds/Done"* ]]
+}
+
+@test "session-end Stop is silent" {
+  run_grok '{"hookEventName":"stop","sessionId":"s1","reason":"shutdown"}'
+  [ "$GROK_EXIT" -eq 0 ]
+  ! afplay_was_called
+}
+
+@test "permission_prompt maps to input.required and plays permission sound" {
+  run_grok '{"hookEventName":"notification","sessionId":"s1","notificationType":"permission_prompt"}'
+  [ "$GROK_EXIT" -eq 0 ]
+  afplay_was_called
+  sound=$(afplay_sound)
+  [[ "$sound" == *"/packs/peon/sounds/Perm"* ]]
+}
+
+@test "idle_prompt maps to task.complete and plays completion sound" {
+  run_grok '{"hookEventName":"notification","sessionId":"s-idle","notificationType":"idle_prompt"}'
+  [ "$GROK_EXIT" -eq 0 ]
+  afplay_was_called
+  sound=$(afplay_sound)
+  [[ "$sound" == *"/packs/peon/sounds/Done"* ]]
+}
+
+@test "pre_compact maps to resource.limit and plays limit sound" {
+  run_grok '{"hookEventName":"pre_compact","sessionId":"s1"}'
+  [ "$GROK_EXIT" -eq 0 ]
+  afplay_was_called
+  sound=$(afplay_sound)
+  [[ "$sound" == *"/packs/peon/sounds/Limit"* ]]
+}
+
+@test "shell PostToolUseFailure plays error sound" {
+  run_grok '{"hookEventName":"post_tool_use_failure","sessionId":"s1","toolName":"run_terminal_command","errorDetails":"exit 1"}'
+  [ "$GROK_EXIT" -eq 0 ]
+  afplay_was_called
+  sound=$(afplay_sound)
+  [[ "$sound" == *"/packs/peon/sounds/Error"* ]]
+}
+
+@test "StopFailure plays error sound" {
+  run_grok '{"hookEventName":"stop_failure","sessionId":"s-fail","error":"rate_limit"}'
+  [ "$GROK_EXIT" -eq 0 ]
+  afplay_was_called
+  sound=$(afplay_sound)
+  [[ "$sound" == *"/packs/peon/sounds/Error"* ]]
+}
+
+@test "SubagentStart is silent" {
+  run_grok '{"hookEventName":"subagent_start","sessionId":"s1","agentId":"a1"}'
+  [ "$GROK_EXIT" -eq 0 ]
+  ! afplay_was_called
+}
+
+@test "PreToolUse is silent" {
+  run_grok '{"hookEventName":"pre_tool_use","sessionId":"s1","toolName":"read_file"}'
+  [ "$GROK_EXIT" -eq 0 ]
+  ! afplay_was_called
+}
+
+@test "PostToolUse is silent" {
+  run_grok '{"hookEventName":"post_tool_use","sessionId":"s1"}'
+  [ "$GROK_EXIT" -eq 0 ]
+  ! afplay_was_called
+}
+
+@test "PostCompact is silent" {
+  run_grok '{"hookEventName":"post_compact","sessionId":"s1"}'
+  [ "$GROK_EXIT" -eq 0 ]
+  ! afplay_was_called
+}
+
+@test "UserPromptSubmit plays no sound" {
+  run_grok '{"hookEventName":"user_prompt_submit","sessionId":"s1"}'
+  [ "$GROK_EXIT" -eq 0 ]
+  ! afplay_was_called
+}
+
+@test "stdin sessionId and cwd are forwarded with grok session prefix" {
+  run_grok '{"hookEventName":"stop","reason":"end_turn","cwd":"/tmp/grok-proj","sessionId":"sess-42"}'
+  [ "$GROK_EXIT" -eq 0 ]
+  /usr/bin/python3 -c "
+import json
+state = json.load(open('$TEST_DIR/.state.json'))
+last = state.get('last_active', {})
+assert last.get('session_id') == 'grok-sess-42', last
+assert last.get('cwd') == '/tmp/grok-proj', last
+"
+}
+
+@test "GROK_HOOK_EVENT env is used when stdin has no event name" {
+  export GROK_HOOK_EVENT=session_start
+  export GROK_SESSION_ID=env-sid
+  run_grok '{"cwd":"/tmp/from-env"}'
+  [ "$GROK_EXIT" -eq 0 ]
+  afplay_was_called
+  sound=$(afplay_sound)
+  [[ "$sound" == *"/packs/peon/sounds/Hello"* ]]
+}

--- a/tests/install.bats
+++ b/tests/install.bats
@@ -138,6 +138,39 @@ print('OK')
 "
 }
 
+@test "fresh install registers Grok Build hooks when ~/.grok exists" {
+  mkdir -p "$TEST_HOME/.grok"
+  bash "$CLONE_DIR/install.sh"
+  [ -f "$TEST_HOME/.grok/hooks/peon-ping.json" ]
+  /usr/bin/python3 -c "
+import json
+data = json.load(open('$TEST_HOME/.grok/hooks/peon-ping.json'))
+hooks = data.get('hooks', {})
+for event in ['SessionStart', 'UserPromptSubmit', 'Stop', 'Notification', 'PostToolUseFailure', 'PreCompact']:
+    assert event in hooks, f'{event} not in grok hooks'
+    cmds = [h.get('command','') for entry in hooks[event] for h in entry.get('hooks',[])]
+    assert any('adapters/grok.sh' in c for c in cmds), f'grok.sh not registered for {event}: {cmds}'
+assert 'PreToolUse' not in hooks
+assert 'PostToolUse' not in hooks
+print('OK')
+"
+}
+
+@test "--local install does not modify user Grok hooks" {
+  mkdir -p "$TEST_HOME/.grok"
+  cd "$PROJECT_DIR"
+  bash "$CLONE_DIR/install.sh" --local
+  [ ! -f "$TEST_HOME/.grok/hooks/peon-ping.json" ]
+}
+
+@test "uninstall removes Grok Build hooks" {
+  mkdir -p "$TEST_HOME/.grok"
+  bash "$CLONE_DIR/install.sh"
+  [ -f "$TEST_HOME/.grok/hooks/peon-ping.json" ]
+  bash "$INSTALL_DIR/uninstall.sh"
+  [ ! -f "$TEST_HOME/.grok/hooks/peon-ping.json" ]
+}
+
 @test "fresh install registers Codex stable hooks when ~/.codex exists" {
   mkdir -p "$TEST_HOME/.codex"
   cat > "$TEST_HOME/.codex/config.toml" <<TOML

--- a/uninstall.ps1
+++ b/uninstall.ps1
@@ -152,6 +152,20 @@ if (Test-Path $CursorHooksFile) {
     }
 }
 
+# --- Remove Grok Build hooks ---
+$GrokHooksFile = Join-Path $env:USERPROFILE ".grok\hooks\peon-ping.json"
+
+if (Test-Path $GrokHooksFile) {
+    Write-Host ""
+    Write-Host "Removing Grok Build hooks..."
+    try {
+        Remove-Item -Path $GrokHooksFile -Force
+        Write-Host "  Removed $GrokHooksFile" -ForegroundColor Green
+    } catch {
+        Write-Host "  Warning: Could not remove ${GrokHooksFile}: $_" -ForegroundColor Yellow
+    }
+}
+
 # --- Remove GitHub Copilot CLI hooks ---
 $CopilotHooksFile = Join-Path $env:USERPROFILE ".copilot\hooks\peon-ping.json"
 

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -185,6 +185,14 @@ _remove_copilot_hooks() {
   echo "Removed Copilot CLI hooks: $copilot_hooks"
 }
 
+# Remove Grok Build hooks if ~/.grok/hooks/peon-ping.json exists
+_remove_grok_hooks() {
+  local grok_hooks="$HOME/.grok/hooks/peon-ping.json"
+  [ -f "$grok_hooks" ] || return 0
+  rm -f "$grok_hooks"
+  echo "Removed Grok Build hooks: $grok_hooks"
+}
+
 # Remove Codex hooks managed by peon-ping in ~/.codex/config.toml
 _remove_codex_hooks() {
   local codex_config="$HOME/.codex/config.toml"
@@ -218,6 +226,10 @@ _remove_cursor_hooks
 # Remove Copilot CLI hooks
 echo "Removing Copilot CLI hooks..."
 _remove_copilot_hooks
+
+# Remove Grok Build hooks
+echo "Removing Grok Build hooks..."
+_remove_grok_hooks
 
 # Remove OpenAI Codex hooks
 echo "Removing Codex hooks..."


### PR DESCRIPTION
## Summary

Grok Build ships Claude-style lifecycle hooks, but the stdin envelope is camelCase (`hookEventName`, `sessionId`, `notificationType`) with snake_case event values (`session_start`, `stop`, `notification`). Pointing those hooks at `peon.sh` stays silent.

This adds a native adapter and installer wiring, same shape as Codex / Copilot:

- `adapters/grok.sh` and `adapters/grok.ps1` translate the Grok envelope to CESP
- `install.sh` / `install.ps1` write `~/.grok/hooks/peon-ping.json` when `~/.grok` exists
- uninstall removes only that file
- session ids get a `grok-` prefix so `peon packs ide-bind grok …` works

## Event mapping

| Grok event | CESP |
|---|---|
| `SessionStart` | `session.start` |
| `Stop` (`reason: end_turn`, or omitted) | `task.complete` |
| `Stop` (`shutdown` / `channel_closed`) | `SessionEnd` (cleanup only) |
| `Notification` / `permission_prompt` | `input.required` |
| `Notification` / `idle_prompt` | `task.complete` |
| `PostToolUseFailure` (`run_terminal_command`) | `task.error` |
| `StopFailure` | `task.error` |
| `PreCompact` | `resource.limit` |
| `UserPromptSubmit` / `SubagentStart` | silent (same as other adapters) |
| `PreToolUse` / `PostToolUse` / `PostCompact` | not registered |

Grok's `Stop` / `SubagentStop` hooks are stop-gates. Adapter stdout is discarded so a chime cannot be parsed as a keep-working decision.

## Test plan

- [x] `bats tests/grok.bats` (17 tests)
- [x] `bats tests/install.bats --filter Grok` (register / `--local` skip / uninstall)
- [ ] Windows Pester job on CI (`tests/adapters-windows.Tests.ps1` Category A: Grok Adapter)

Manual: with `~/.grok` present, re-run the installer, reload hooks (`/hooks` then `r`), and confirm greeting + completion sounds.

If Grok was already running during install it will not pick up the new file until a reload or a new session.