### PR TITLE
fix: relay --status reports the daemon's actual bound port

### DIFF
--- a/relay.sh
+++ b/relay.sh
@@ -75,6 +75,7 @@ for arg in "$@"; do
 done
 
 PIDFILE="$PEON_DIR/.relay.pid"
+PORTFILE="$PEON_DIR/.relay.port"
 LOGFILE="$PEON_DIR/.relay.log"
 
 # --- Handle --stop ---
@@ -83,10 +84,10 @@ if [ "$DAEMON_ACTION" = "stop" ]; then
     pid=$(cat "$PIDFILE" 2>/dev/null)
     if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
       kill "$pid" 2>/dev/null
-      rm -f "$PIDFILE"
+      rm -f "$PIDFILE" "$PORTFILE"
       echo "peon-ping relay stopped (PID $pid)"
     else
-      rm -f "$PIDFILE"
+      rm -f "$PIDFILE" "$PORTFILE"
       echo "peon-ping relay was not running (stale PID file removed)"
     fi
   else
@@ -100,10 +101,18 @@ if [ "$DAEMON_ACTION" = "status" ]; then
   if [ -f "$PIDFILE" ]; then
     pid=$(cat "$PIDFILE" 2>/dev/null)
     if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
-      echo "peon-ping relay is running (PID $pid, port $RELAY_PORT)"
+      # Prefer the port the daemon actually bound (persisted at start time)
+      # over the env/flag-derived RELAY_PORT, which reflects only this
+      # invocation's environment and may not match how the daemon was started.
+      _status_port="$RELAY_PORT"
+      if [ -f "$PORTFILE" ]; then
+        _saved_port=$(cat "$PORTFILE" 2>/dev/null)
+        [ -n "$_saved_port" ] && _status_port="$_saved_port"
+      fi
+      echo "peon-ping relay is running (PID $pid, port $_status_port)"
       exit 0
     else
-      rm -f "$PIDFILE"
+      rm -f "$PIDFILE" "$PORTFILE"
       echo "peon-ping relay is not running (stale PID file removed)"
       exit 1
     fi
@@ -150,11 +159,14 @@ if [ "$DAEMON_MODE" = "true" ]; then
       echo "peon-ping relay already running (PID $old_pid)"
       exit 0
     fi
-    rm -f "$PIDFILE"
+    rm -f "$PIDFILE" "$PORTFILE"
   fi
 
   # Fork to background
   nohup bash "$0" --port="$RELAY_PORT" --bind="$BIND_ADDR" --peon-dir="$PEON_DIR" > "$LOGFILE" 2>&1 &
+  # Write PORTFILE before PIDFILE so a --status racing right after start
+  # never observes a PIDFILE without a matching PORTFILE.
+  echo "$RELAY_PORT" > "$PORTFILE"
   echo "$!" > "$PIDFILE"
   echo "peon-ping relay started in background (PID $!)"
   echo "  Listening: ${BIND_ADDR}:${RELAY_PORT}"

--- a/tests/relay.bats
+++ b/tests/relay.bats
@@ -238,6 +238,31 @@ start_relay() {
   RELAY_PID=""
 }
 
+@test "relay --status reports the port the daemon actually started on, not the caller's env/default" {
+  # Regression: --status previously echoed whatever RELAY_PORT resolved to
+  # in *its own* invocation (env var or hardcoded 19998 default) instead of
+  # the port the running daemon actually bound, so a status check made
+  # without the original PEON_RELAY_PORT/--port would report a stale port
+  # for a genuinely healthy daemon.
+  bash "$RELAY_SH" --daemon --port="$RELAY_PORT" --peon-dir="$TEST_DIR" > /dev/null 2>&1
+  RELAY_PID=$(cat "$TEST_DIR/.relay.pid" 2>/dev/null)
+
+  for i in $(seq 1 30); do
+    if "$REAL_CURL" -sf "http://127.0.0.1:$RELAY_PORT/health" > /dev/null 2>&1; then
+      break
+    fi
+    sleep 0.1
+  done
+
+  # Query status with no --port and no PEON_RELAY_PORT set, so RELAY_PORT
+  # inside this invocation falls back to the hardcoded 19998 default —
+  # different from the port the daemon was actually started on.
+  run env -u PEON_RELAY_PORT bash "$RELAY_SH" --status --peon-dir="$TEST_DIR"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"port $RELAY_PORT"* ]]
+  [[ "$output" != *"port 19998"* ]]
+}
+
 @test "relay --daemon prevents duplicate start" {
   # Start first instance
   bash "$RELAY_SH" --daemon --port="$RELAY_PORT" --peon-dir="$TEST_DIR" > /dev/null 2>&1

--- a/tests/relay.bats
+++ b/tests/relay.bats
@@ -259,8 +259,11 @@ start_relay() {
   # different from the port the daemon was actually started on.
   run env -u PEON_RELAY_PORT bash "$RELAY_SH" --status --peon-dir="$TEST_DIR"
   [ "$status" -eq 0 ]
-  [[ "$output" == *"port $RELAY_PORT"* ]]
-  [[ "$output" != *"port 19998"* ]]
+  # grep -q rather than a non-final bare [[ ]]: under macOS bash 3.2 a failing
+  # bare [[ ]] only gates the test when it is the body's last statement, so the
+  # positive assertion below would otherwise pass no matter what --status said.
+  printf '%s' "$output" | grep -q "port $RELAY_PORT"
+  ! printf '%s' "$output" | grep -q "port 19998"
 }
 
 @test "relay --daemon prevents duplicate start" {


### PR DESCRIPTION
## Summary

`relay --status` was reporting `RELAY_PORT` as resolved in its *own* invocation (env var or the hardcoded 19998 default) rather than the port the running daemon actually bound to, so a status check made without the original `PEON_RELAY_PORT`/`--port` reported a stale port for a genuinely healthy daemon.

This PR persists the daemon's port to a new `.relay.port` file at start time (written before `.relay.pid` to avoid a race), and has `--status` prefer it. Cleaned up alongside `.relay.pid` on `--stop` and stale-pid detection.

## Test plan
- [x] New regression test: `relay --status reports the port the daemon actually started on, not the caller's env/default`