### PR TITLE
fix(opencode): only set tab title when stdout is a TTY to avoid polluting piped output

### DIFF
--- a/adapters/opencode/peon-ping.ts
+++ b/adapters/opencode/peon-ping.ts
@@ -45,6 +45,7 @@ function findPeonSh(): string | null {
 }
 
 function setTabTitle(title: string): void {
+  if (!process.stdout.isTTY) return
   process.stdout.write(`\x1b]0;${title}\x07`)
 }
 


### PR DESCRIPTION
Closes #579

Prevents OSC title pollution when opencode runs with piped stdout
(e.g. T3 Code agent list via ChildProcessSpawner). The title bytes
ESC]0;... BEL polluted model_selection_json and caused
UnknownError at SessionPrompt.createUserMessage.

Only write when process.stdout.isTTY is true, preserving interactive
TUI tab titles while keeping piped output clean.

Verified: opencode agent list | cat -v now shows build (primary) not ^[]0;imbios: ready^Gbuild (primary)