### PR TITLE
ci: batch A integration check (#564, #566, #571, #580) plus vitest in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,27 @@ jobs:
       - name: Run tests
         run: bats tests/
 
+  test-opencode:
+    # The opencode adapter is TypeScript, so bats cannot reach it. Its vitest
+    # suite existed and passed but nothing ran it, which meant 58 tests gated
+    # nothing and three PRs could touch the adapter without CI noticing.
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: adapters/opencode
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        run: npm install --no-audit --no-fund
+
+      - name: Run vitest
+        run: npx vitest run
+
   test-windows:
     runs-on: windows-latest
     steps:

--- a/adapters/opencode/peon-ping.ts
+++ b/adapters/opencode/peon-ping.ts
@@ -45,6 +45,7 @@ function findPeonSh(): string | null {
 }
 
 function setTabTitle(title: string): void {
+  if (!process.stdout.isTTY) return
   process.stdout.write(`\x1b]0;${title}\x07`)
 }
 

--- a/adapters/opencode/peon-ping.ts
+++ b/adapters/opencode/peon-ping.ts
@@ -63,6 +63,7 @@ export const PeonPingPlugin: Plugin = async ({ directory }) => {
   const sessionId = `oc-${Date.now()}`
   const subagentSessionIds = new Set<string>()
   const busySessions = new Set<string>()
+  let lastSessionStart = 0
 
   function firePeon(event: string): void {
     const payload = JSON.stringify({
@@ -100,6 +101,7 @@ export const PeonPingPlugin: Plugin = async ({ directory }) => {
             break
           }
           setTabTitle(`${projectName}: ready`)
+          lastSessionStart = Date.now()
           firePeon("SessionStart")
           break
         }
@@ -148,8 +150,10 @@ export const PeonPingPlugin: Plugin = async ({ directory }) => {
           if (statusType === "busy" || statusType === "running") {
             if (sid && !busySessions.has(sid)) {
               busySessions.add(sid)
-              setTabTitle(`${projectName}: working`)
-              firePeon("UserPromptSubmit")
+              if (Date.now() - lastSessionStart > 3000) {
+                setTabTitle(`${projectName}: working`)
+                firePeon("UserPromptSubmit")
+              }
             }
           } else {
             if (sid) busySessions.delete(sid)

--- a/adapters/opencode/peon-ping.ts
+++ b/adapters/opencode/peon-ping.ts
@@ -19,6 +19,7 @@
  *   session.idle                 → Stop
  *   session.error                → PostToolUseFailure
  *   permission.asked             → PermissionRequest
+ *   question(.v2).asked          → Notification (elicitation_dialog)
  *
  * Requires peon-ping installed: brew install PeonPing/tap/peon-ping
  *   or: curl -fsSL peonping.com/install | bash
@@ -29,6 +30,8 @@ import * as path from "node:path"
 import * as os from "node:os"
 import { spawn } from "node:child_process"
 import type { Plugin } from "@opencode-ai/plugin"
+
+const MAX_PENDING_QUESTION_IDS = 100
 
 const PEON_SH_PATHS = [
   path.join(os.homedir(), ".claude", "hooks", "peon-ping", "peon.sh"),
@@ -62,11 +65,12 @@ export const PeonPingPlugin: Plugin = async ({ directory }) => {
   const cwd = directory || process.cwd()
   const sessionId = `oc-${Date.now()}`
   const subagentSessionIds = new Set<string>()
+  const pendingQuestionIds = new Set<string>()
 
-  function firePeon(event: string): void {
+  function firePeon(event: string, notificationType = ""): void {
     const payload = JSON.stringify({
       hook_event_name: event,
-      notification_type: "",
+      notification_type: notificationType,
       cwd,
       session_id: sessionId,
       permission_mode: "",
@@ -137,6 +141,31 @@ export const PeonPingPlugin: Plugin = async ({ directory }) => {
         case "permission.asked": {
           setTabTitle(`\u25cf ${projectName}: needs approval`)
           firePeon("PermissionRequest")
+          break
+        }
+
+        case "question.asked":
+        case "question.v2.asked": {
+          const properties = (event as any).properties
+          if (isSubagent(properties?.sessionID)) break
+          const requestId = properties?.id
+          if (typeof requestId !== "string" || pendingQuestionIds.has(requestId)) break
+          if (pendingQuestionIds.size >= MAX_PENDING_QUESTION_IDS) {
+            pendingQuestionIds.delete(pendingQuestionIds.values().next().value!)
+          }
+          pendingQuestionIds.add(requestId)
+          setTabTitle(`\u25cf ${projectName}: needs input`)
+          firePeon("Notification", "elicitation_dialog")
+          break
+        }
+
+        case "question.replied":
+        case "question.rejected":
+        case "question.v2.replied":
+        case "question.v2.rejected": {
+          const properties = (event as any).properties
+          const requestId = properties?.requestID ?? properties?.id
+          if (typeof requestId === "string") pendingQuestionIds.delete(requestId)
           break
         }
 

--- a/adapters/opencode/peon-ping.ts
+++ b/adapters/opencode/peon-ping.ts
@@ -88,10 +88,7 @@ export const PeonPingPlugin: Plugin = async ({ directory }) => {
     return !!sid && subagentSessionIds.has(sid)
   }
 
-  setTimeout(() => {
-    setTabTitle(`${projectName}: ready`)
-    firePeon("SessionStart")
-  }, 100)
+  setTabTitle(`${projectName}: ready`)
 
   return {
     event: async ({ event }) => {

--- a/adapters/opencode/peon-ping.ts
+++ b/adapters/opencode/peon-ping.ts
@@ -62,6 +62,7 @@ export const PeonPingPlugin: Plugin = async ({ directory }) => {
   const cwd = directory || process.cwd()
   const sessionId = `oc-${Date.now()}`
   const subagentSessionIds = new Set<string>()
+  let isBusy = false
 
   function firePeon(event: string): void {
     const payload = JSON.stringify({
@@ -121,6 +122,7 @@ export const PeonPingPlugin: Plugin = async ({ directory }) => {
         case "session.idle": {
           const sid = (event as any).properties?.sessionID
           if (isSubagent(sid)) break
+          isBusy = false
           setTabTitle(`\u25cf ${projectName}: done`)
           firePeon("Stop")
           break
@@ -129,6 +131,7 @@ export const PeonPingPlugin: Plugin = async ({ directory }) => {
         case "session.error": {
           const sid = (event as any).properties?.sessionID
           if (isSubagent(sid)) break
+          isBusy = false
           setTabTitle(`\u25cf ${projectName}: error`)
           firePeon("PostToolUseFailure")
           break
@@ -146,8 +149,13 @@ export const PeonPingPlugin: Plugin = async ({ directory }) => {
           const status = event.properties?.status
           const statusType = typeof status === "object" ? (status as any)?.type : status
           if (statusType === "busy" || statusType === "running") {
-            setTabTitle(`${projectName}: working`)
-            firePeon("UserPromptSubmit")
+            if (!isBusy) {
+              isBusy = true
+              setTabTitle(`${projectName}: working`)
+              firePeon("UserPromptSubmit")
+            }
+          } else {
+            isBusy = false
           }
           break
         }

--- a/adapters/opencode/peon-ping.ts
+++ b/adapters/opencode/peon-ping.ts
@@ -62,7 +62,7 @@ export const PeonPingPlugin: Plugin = async ({ directory }) => {
   const cwd = directory || process.cwd()
   const sessionId = `oc-${Date.now()}`
   const subagentSessionIds = new Set<string>()
-  let isBusy = false
+  const busySessions = new Set<string>()
 
   function firePeon(event: string): void {
     const payload = JSON.stringify({
@@ -122,7 +122,7 @@ export const PeonPingPlugin: Plugin = async ({ directory }) => {
         case "session.idle": {
           const sid = (event as any).properties?.sessionID
           if (isSubagent(sid)) break
-          isBusy = false
+          if (sid) busySessions.delete(sid)
           setTabTitle(`\u25cf ${projectName}: done`)
           firePeon("Stop")
           break
@@ -131,7 +131,7 @@ export const PeonPingPlugin: Plugin = async ({ directory }) => {
         case "session.error": {
           const sid = (event as any).properties?.sessionID
           if (isSubagent(sid)) break
-          isBusy = false
+          if (sid) busySessions.delete(sid)
           setTabTitle(`\u25cf ${projectName}: error`)
           firePeon("PostToolUseFailure")
           break
@@ -149,13 +149,13 @@ export const PeonPingPlugin: Plugin = async ({ directory }) => {
           const status = event.properties?.status
           const statusType = typeof status === "object" ? (status as any)?.type : status
           if (statusType === "busy" || statusType === "running") {
-            if (!isBusy) {
-              isBusy = true
+            if (sid && !busySessions.has(sid)) {
+              busySessions.add(sid)
               setTabTitle(`${projectName}: working`)
               firePeon("UserPromptSubmit")
             }
           } else {
-            isBusy = false
+            if (sid) busySessions.delete(sid)
           }
           break
         }

--- a/skills/peon-ping-config/SKILL.md
+++ b/skills/peon-ping-config/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: peon-ping-config
 description: Update peon-ping configuration — volume, pack rotation, categories, active pack, and other settings. Use when user wants to change peon-ping settings like volume, enable round-robin, add packs to rotation, toggle sound categories, or adjust any config.
-user_invocable: false
+user-invocable: false
 ---
 
 # peon-ping-config

--- a/skills/peon-ping-log/SKILL.md
+++ b/skills/peon-ping-log/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: peon-ping-log
 description: Log exercise reps for the Peon Trainer. Use when user says they did pushups, squats, or wants to log reps. Examples - "/peon-ping-log 25 pushups", "/peon-ping-log 30 squats", "log 50 pushups".
-user_invocable: true
+user-invocable: true
 ---
 
 # peon-ping-log

--- a/skills/peon-ping-rename/SKILL.md
+++ b/skills/peon-ping-rename/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: peon-ping-rename
 description: Rename the current Claude session for peon-ping notifications and terminal tab title. Use when user wants to give this session a custom name like "/peon-ping-rename Auth Refactor". Call with no argument to reset to auto-detect.
-user_invocable: true
+user-invocable: true
 license: MIT
 metadata:
   author: PeonPing

--- a/skills/peon-ping-toggle/SKILL.md
+++ b/skills/peon-ping-toggle/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: peon-ping-toggle
 description: Toggle peon-ping sound notifications on/off. Use when user wants to mute, unmute, pause, or resume peon sounds during a Claude Code session. Also handles config changes like volume, pack rotation, categories — any peon-ping setting.
-user_invocable: true
+user-invocable: true
 ---
 
 # peon-ping-toggle

--- a/skills/peon-ping-use/SKILL.md
+++ b/skills/peon-ping-use/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: peon-ping-use
 description: Set which voice pack (character voice) plays for the current chat session. Automatically enables session_override rotation mode if not already set. Use when user wants a specific character voice like GLaDOS, Peon, or Kerrigan for this conversation.
-user_invocable: true
+user-invocable: true
 license: MIT
 metadata:
   author: PeonPing

--- a/tests/opencode-peon-ping.test.ts
+++ b/tests/opencode-peon-ping.test.ts
@@ -1,0 +1,165 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+const stdin = {
+  write: vi.fn(),
+  end: vi.fn(),
+}
+const spawnedProcess = {
+  stdin,
+  unref: vi.fn(),
+}
+
+vi.mock("node:fs", () => ({
+  existsSync: vi.fn(() => true),
+}))
+
+vi.mock("node:child_process", () => ({
+  spawn: vi.fn(() => spawnedProcess),
+}))
+
+import { spawn } from "node:child_process"
+import { PeonPingPlugin } from "../adapters/opencode/peon-ping.js"
+
+async function createEventHandler() {
+  const plugin = await PeonPingPlugin({ directory: "/tmp/example-project" } as any)
+  return plugin.event!
+}
+
+function payloads(): Array<Record<string, unknown>> {
+  return stdin.write.mock.calls.map(([payload]) => JSON.parse(payload))
+}
+
+describe("PeonPingPlugin question events", () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.clearAllMocks()
+    vi.spyOn(process.stdout, "write").mockImplementation(() => true)
+  })
+
+  afterEach(() => {
+    vi.clearAllTimers()
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it("dispatches a private elicitation notification for question.asked", async () => {
+    const event = await createEventHandler()
+    const sensitiveText = "SENTINEL_SECRET_QUESTION_V1"
+
+    await event({
+      event: {
+        type: "question.asked",
+        properties: {
+          id: "question-request-v1",
+          sessionID: "primary-session",
+          questions: [{ question: sensitiveText, options: [{ label: "Secret option" }] }],
+        },
+      },
+    } as any)
+
+    expect(payloads()).toEqual([{
+      hook_event_name: "Notification",
+      notification_type: "elicitation_dialog",
+      cwd: "/tmp/example-project",
+      session_id: expect.stringMatching(/^oc-\d+$/),
+      permission_mode: "",
+      source: "opencode",
+    }])
+    expect(stdin.write.mock.calls[0][0]).not.toContain(sensitiveText)
+    expect(stdin.write.mock.calls[0][0]).not.toContain("question-request-v1")
+  })
+
+  it("dispatches a private elicitation notification for question.v2.asked", async () => {
+    const event = await createEventHandler()
+    const sensitiveText = "SENTINEL_SECRET_QUESTION_V2"
+
+    await event({
+      event: {
+        type: "question.v2.asked",
+        properties: {
+          id: "question-request-v2",
+          sessionID: "primary-session",
+          questions: [{ question: sensitiveText, options: ["Never serialize me"] }],
+        },
+      },
+    } as any)
+
+    expect(payloads()[0]).toMatchObject({
+      hook_event_name: "Notification",
+      notification_type: "elicitation_dialog",
+    })
+    expect(stdin.write.mock.calls[0][0]).not.toContain(sensitiveText)
+    expect(stdin.write.mock.calls[0][0]).not.toContain("question-request-v2")
+  })
+
+  it("suppresses duplicate v1 and v2 representations with the same id", async () => {
+    const event = await createEventHandler()
+    const properties = { id: "same-question", sessionID: "primary-session", questions: [] }
+
+    await event({ event: { type: "question.asked", properties } } as any)
+    await event({ event: { type: "question.v2.asked", properties } } as any)
+
+    expect(spawn).toHaveBeenCalledTimes(1)
+  })
+
+  it("bounds pending question ids and evicts the oldest request", async () => {
+    const event = await createEventHandler()
+
+    for (let id = 0; id <= 100; id += 1) {
+      await event({
+        event: {
+          type: "question.asked",
+          properties: { id: `question-${id}`, sessionID: "primary-session", questions: [] },
+        },
+      } as any)
+    }
+    await event({
+      event: {
+        type: "question.v2.asked",
+        properties: { id: "question-0", sessionID: "primary-session", questions: [] },
+      },
+    } as any)
+
+    expect(spawn).toHaveBeenCalledTimes(102)
+  })
+
+  it("suppresses question notifications from tracked subagent sessions", async () => {
+    const event = await createEventHandler()
+
+    await event({
+      event: {
+        type: "session.created",
+        properties: { info: { id: "subagent-session", parentID: "primary-session" } },
+      },
+    } as any)
+    await event({
+      event: {
+        type: "question.asked",
+        properties: { id: "subagent-question", sessionID: "subagent-session", questions: [] },
+      },
+    } as any)
+
+    expect(spawn).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    "question.replied",
+    "question.rejected",
+    "question.v2.replied",
+    "question.v2.rejected",
+  ])("cleans deduplication state on %s", async (settledType) => {
+    const event = await createEventHandler()
+    const properties = { id: "reusable-question", sessionID: "primary-session", questions: [] }
+
+    await event({ event: { type: "question.asked", properties } } as any)
+    await event({
+      event: {
+        type: settledType,
+        properties: { requestID: "reusable-question", sessionID: "primary-session" },
+      },
+    } as any)
+    await event({ event: { type: "question.v2.asked", properties } } as any)
+
+    expect(spawn).toHaveBeenCalledTimes(2)
+  })
+})


### PR DESCRIPTION
Not for merge. This is a single CI run that validates four opencode/skills PRs together before each is merged on its own, so the batch costs one 30-minute run instead of four.

Contains:

- **#564** `user_invocable` to `user-invocable` in all five bundled skills. Verified against Claude Code's actual schema: the loader reads `a["user-invocable"]`, and the underscore spelling in the binary is an unrelated internal error code (`cmd_not_user_invocable`). All five skills' declared visibility was being silently ignored.
- **#566** opencode: debounce `UserPromptSubmit`, drop the `SessionStart` double-fire.
- **#571** opencode: notify on `question(.v2).asked`, with dedup by request id.
- **#580** opencode: only write the tab-title escape when stdout is a TTY. Taken as the one real commit; the PR also carried a stray `chore: update` that duplicated a `local _trainer_focused=""` line in `peon.sh`, which is what made it conflict.

#566 and #571 both declare state right after `subagentSessionIds`, which is the only conflict. Resolved by keeping both.

Also adds a `test-opencode` job. The adapter is TypeScript so bats cannot reach it, and nothing ran its vitest suite: 58 tests that passed locally and gated nothing, while three of the four PRs above edit that exact file. All 58 pass on the merged result.