### PR TITLE
ci: batch B integration check (#578, #576, #570)

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -430,9 +430,12 @@ param(
     [Parameter(ValueFromRemainingArguments)]$ExtraArgs = @()
 )
 
-# 8-second self-timeout safety net — kills this process if anything blocks unexpectedly.
+# 8-second self-timeout safety net: kills this process if anything blocks unexpectedly.
 # Uses System.Timers.Timer (not Forms.Timer) so it works in headless PowerShell without a message pump.
-# Must fire before ANY I/O (config read, state read, stdin read).
+# Scope: Register-ObjectEvent runs its action on the pipeline thread the next time that
+# thread goes idle, so this covers work that is slow but still executing statements. It
+# cannot interrupt a thread parked inside one blocking call, which is why the stdin read
+# further down bounds itself instead of relying on this timer.
 if (-not $Command) {
     $safetyTimer = New-Object System.Timers.Timer
     $safetyTimer.Interval = 8000
@@ -2503,14 +2506,22 @@ if (-not $config.enabled) {
 $_activePack = Get-ActivePack $config
 & $peonLog 'config' @{ loaded = $ConfigPath; volume = [string]$config.volume; pack = $_activePack; enabled = 'True' }
 
-# Read hook input from stdin (StreamReader with UTF-8 auto-strips BOM on Windows)
+# Read hook input from stdin (StreamReader with UTF-8 auto-strips BOM on Windows).
+# Bounded at 2s, matching the `timeout 2 cat` guard peon.sh uses for the same reason:
+# a host can open the stdin pipe and never close the write end, and a synchronous
+# ReadToEnd() then parks this thread for the life of the process. The safety timer at
+# the top of this script cannot rescue that case, so on timeout leave $hookInput empty
+# and fall through to the no-input guard below, which exits 0.
 $hookInput = ""
 try {
     if (-not [Console]::IsInputRedirected) { exit 0 }
     $stream = [Console]::OpenStandardInput()
     $reader = New-Object System.IO.StreamReader($stream, [System.Text.Encoding]::UTF8)
-    $hookInput = $reader.ReadToEnd()
-    $reader.Close()
+    $readTask = $reader.ReadToEndAsync()
+    if ($readTask.Wait(2000)) {
+        $hookInput = $readTask.Result
+        $reader.Close()
+    }
 } catch {
     exit 0
 }

--- a/peon.sh
+++ b/peon.sh
@@ -3708,10 +3708,14 @@ if not mn or not mn.get('service') or not mn.get('enabled', True):
     sys.exit(1)
 print('service=' + mn.get('service', ''))
 " > /dev/null 2>&1 || { echo "peon-ping: mobile not configured" >&2; exit 1; }
-        send_mobile_notification "Test notification from peon-ping" "peon-ping" "blue"
-        wait
-        echo "peon-ping: test notification sent"
-        exit 0 ;;
+        PEON_TEST=1
+        if send_mobile_notification "Test notification from peon-ping" "peon-ping" "blue"; then
+          echo "peon-ping: test notification sent"
+          exit 0
+        else
+          echo "peon-ping: test notification failed" >&2
+          exit 1
+        fi ;;
       *)
         echo "Usage: peon mobile <ntfy|pushover|telegram|on|off|status|test>" >&2
         echo "" >&2

--- a/peon.sh
+++ b/peon.sh
@@ -1226,14 +1226,14 @@ print('MOBILE_PRIORITY=' + q(str(mn.get('priority', '') or '')))
     ntfy)
       [ -z "$MOBILE_TOPIC" ] && return 0
       local ntfy_url="${MOBILE_SERVER}/${MOBILE_TOPIC}"
-      local auth_header=""
-      [ -n "$MOBILE_TOKEN" ] && auth_header="-H \"Authorization: Bearer ${MOBILE_TOKEN}\""
+      local -a auth_args=()
+      [ -n "$MOBILE_TOKEN" ] && auth_args=(-H "Authorization: Bearer ${MOBILE_TOKEN}")
       if [ "$use_bg" = true ]; then
         nohup curl -sf \
           -H "Title: $title" \
           -H "Priority: $priority" \
           -H "Tags: video_game" \
-          $auth_header \
+          "${auth_args[@]+"${auth_args[@]}"}" \
           -d "$msg" \
           "$ntfy_url" >/dev/null 2>&1 &
       else
@@ -1241,7 +1241,7 @@ print('MOBILE_PRIORITY=' + q(str(mn.get('priority', '') or '')))
           -H "Title: $title" \
           -H "Priority: $priority" \
           -H "Tags: video_game" \
-          $auth_header \
+          "${auth_args[@]+"${auth_args[@]}"}" \
           -d "$msg" \
           "$ntfy_url" >/dev/null 2>&1
       fi

--- a/relay.sh
+++ b/relay.sh
@@ -75,6 +75,7 @@ for arg in "$@"; do
 done
 
 PIDFILE="$PEON_DIR/.relay.pid"
+PORTFILE="$PEON_DIR/.relay.port"
 LOGFILE="$PEON_DIR/.relay.log"
 
 # --- Handle --stop ---
@@ -83,10 +84,10 @@ if [ "$DAEMON_ACTION" = "stop" ]; then
     pid=$(cat "$PIDFILE" 2>/dev/null)
     if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
       kill "$pid" 2>/dev/null
-      rm -f "$PIDFILE"
+      rm -f "$PIDFILE" "$PORTFILE"
       echo "peon-ping relay stopped (PID $pid)"
     else
-      rm -f "$PIDFILE"
+      rm -f "$PIDFILE" "$PORTFILE"
       echo "peon-ping relay was not running (stale PID file removed)"
     fi
   else
@@ -100,10 +101,18 @@ if [ "$DAEMON_ACTION" = "status" ]; then
   if [ -f "$PIDFILE" ]; then
     pid=$(cat "$PIDFILE" 2>/dev/null)
     if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
-      echo "peon-ping relay is running (PID $pid, port $RELAY_PORT)"
+      # Prefer the port the daemon actually bound (persisted at start time)
+      # over the env/flag-derived RELAY_PORT, which reflects only this
+      # invocation's environment and may not match how the daemon was started.
+      _status_port="$RELAY_PORT"
+      if [ -f "$PORTFILE" ]; then
+        _saved_port=$(cat "$PORTFILE" 2>/dev/null)
+        [ -n "$_saved_port" ] && _status_port="$_saved_port"
+      fi
+      echo "peon-ping relay is running (PID $pid, port $_status_port)"
       exit 0
     else
-      rm -f "$PIDFILE"
+      rm -f "$PIDFILE" "$PORTFILE"
       echo "peon-ping relay is not running (stale PID file removed)"
       exit 1
     fi
@@ -150,11 +159,14 @@ if [ "$DAEMON_MODE" = "true" ]; then
       echo "peon-ping relay already running (PID $old_pid)"
       exit 0
     fi
-    rm -f "$PIDFILE"
+    rm -f "$PIDFILE" "$PORTFILE"
   fi
 
   # Fork to background
   nohup bash "$0" --port="$RELAY_PORT" --bind="$BIND_ADDR" --peon-dir="$PEON_DIR" > "$LOGFILE" 2>&1 &
+  # Write PORTFILE before PIDFILE so a --status racing right after start
+  # never observes a PIDFILE without a matching PORTFILE.
+  echo "$RELAY_PORT" > "$PORTFILE"
   echo "$!" > "$PIDFILE"
   echo "peon-ping relay started in background (PID $!)"
   echo "  Listening: ${BIND_ADDR}:${RELAY_PORT}"

--- a/tests/install-ps1-hook-rewrite.Tests.ps1
+++ b/tests/install-ps1-hook-rewrite.Tests.ps1
@@ -123,3 +123,87 @@ Describe "install.ps1 Copilot CLI camelCase fallback" {
         $content | Should -Match 'elseif \(\$event\.sessionId\) \{ \$event\.sessionId \}'
     }
 }
+
+Describe "install.ps1 hook stdin read is bounded" {
+    # A host can hand the hook a stdin pipe and never close the write end. A plain
+    # ReadToEnd() then parks the pipeline thread for the life of the process, and the
+    # 8-second safety timer cannot help: Register-ObjectEvent runs its action on that
+    # same blocked thread. peon.sh has guarded this since #445 with `timeout 2 cat`;
+    # these tests hold the PowerShell path to the same bound.
+
+    BeforeAll {
+        # Lift the hook body out of the here-string that install.ps1 writes to peon.ps1.
+        $lines = Get-Content $script:InstallPs1
+        $startLine = ($lines | Select-String -Pattern '^\$hookScript = @' | Select-Object -First 1).LineNumber
+        $endLine = ($lines | Select-String -Pattern "^'@" | Where-Object { $_.LineNumber -gt $startLine } | Select-Object -First 1).LineNumber
+        $script:HookBody = $lines[$startLine..($endLine - 2)] -join "`n"
+    }
+
+    # Asserted as booleans rather than `$HookBody | Should -Match`, so a failure reports
+    # one line instead of dumping the whole 3000-line hook body into the CI log.
+    It "uses a timed async read rather than a blocking ReadToEnd" {
+        ($script:HookBody -match '\$readTask = \$reader\.ReadToEndAsync\(\)') |
+            Should -BeTrue -Because 'the stdin read must not block indefinitely'
+        ($script:HookBody -match '\$readTask\.Wait\(2000\)') |
+            Should -BeTrue -Because 'the read is bounded at 2s, matching peon.sh'
+    }
+
+    It "no longer calls ReadToEnd() unbounded in the hook body" {
+        ($script:HookBody -match '\$reader\.ReadToEnd\(\)') |
+            Should -BeFalse -Because 'the unbounded read is what wedged the process'
+    }
+
+    It "exits instead of hanging when stdin never closes" {
+        # The bug is an indefinite hang, so the ceiling only has to separate "bounded"
+        # from "forever". Bound is 2s plus interpreter startup.
+        $sandbox = Join-Path ([System.IO.Path]::GetTempPath()) "peon-stdin-$([guid]::NewGuid().ToString('N'))"
+        New-Item -ItemType Directory -Path $sandbox -Force | Out-Null
+        $peon = Join-Path $sandbox 'peon.ps1'
+        $proc = $null
+        try {
+            Set-Content -Path $peon -Value $script:HookBody -Encoding UTF8
+            Copy-Item (Join-Path $script:RepoRoot 'config.json') (Join-Path $sandbox 'config.json') -Force
+
+            $psi = [System.Diagnostics.ProcessStartInfo]::new('powershell.exe',
+                "-NoProfile -NonInteractive -File `"$peon`"")
+            $psi.RedirectStandardInput = $true
+            $psi.UseShellExecute = $false
+            $proc = [System.Diagnostics.Process]::Start($psi)
+
+            # Write the payload a host sends, then hold the write end open.
+            $proc.StandardInput.Write('{"hook_event_name":"SessionStart","session_id":"pester-stdin"}')
+            $proc.StandardInput.Flush()
+
+            $proc.WaitForExit(20000) | Should -BeTrue -Because 'the hook must not block forever on a stdin pipe that never closes'
+        } finally {
+            if ($proc -and -not $proc.HasExited) { $proc.Kill(); $proc.WaitForExit(5000) | Out-Null }
+            Remove-Item $sandbox -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    It "still reads the payload when stdin closes normally" {
+        $sandbox = Join-Path ([System.IO.Path]::GetTempPath()) "peon-stdin-$([guid]::NewGuid().ToString('N'))"
+        New-Item -ItemType Directory -Path $sandbox -Force | Out-Null
+        $peon = Join-Path $sandbox 'peon.ps1'
+        $proc = $null
+        try {
+            Set-Content -Path $peon -Value $script:HookBody -Encoding UTF8
+            Copy-Item (Join-Path $script:RepoRoot 'config.json') (Join-Path $sandbox 'config.json') -Force
+
+            $psi = [System.Diagnostics.ProcessStartInfo]::new('powershell.exe',
+                "-NoProfile -NonInteractive -File `"$peon`"")
+            $psi.RedirectStandardInput = $true
+            $psi.UseShellExecute = $false
+            $proc = [System.Diagnostics.Process]::Start($psi)
+
+            $proc.StandardInput.Write('{"hook_event_name":"SessionStart","session_id":"pester-stdin"}')
+            $proc.StandardInput.Close()
+
+            $proc.WaitForExit(20000) | Should -BeTrue
+            $proc.ExitCode | Should -Be 0
+        } finally {
+            if ($proc -and -not $proc.HasExited) { $proc.Kill(); $proc.WaitForExit(5000) | Out-Null }
+            Remove-Item $sandbox -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+}

--- a/tests/peon.bats
+++ b/tests/peon.bats
@@ -2992,6 +2992,19 @@ JSON
   [[ "$cmdline" == *"ntfy.sh/test-topic"* ]]
 }
 
+@test "mobile ntfy sends Authorization header as a single argument" {
+  cat > "$TEST_DIR/config.json" <<'JSON'
+{
+  "default_pack": "peon", "volume": 0.5, "enabled": true, "categories": {},
+  "mobile_notify": { "enabled": true, "service": "ntfy", "topic": "test-topic", "server": "https://ntfy.sh", "token": "tok_with_space inside" }
+}
+JSON
+  run_peon '{"hook_event_name":"Stop","cwd":"/tmp/myproject","session_id":"s1","permission_mode":"default"}'
+  [ "$PEON_EXIT" -eq 0 ]
+  mobile_was_called
+  grep -Fx 'Authorization: Bearer tok_with_space inside' "$TEST_DIR/mobile_curl_argv.log"
+}
+
 @test "mobile ntfy sends push on PermissionRequest" {
   cat > "$TEST_DIR/config.json" <<'JSON'
 {

--- a/tests/peon.bats
+++ b/tests/peon.bats
@@ -3005,6 +3005,33 @@ JSON
   grep -Fx 'Authorization: Bearer tok_with_space inside' "$TEST_DIR/mobile_curl_argv.log"
 }
 
+@test "mobile test reports success when notification is sent" {
+  cat > "$TEST_DIR/config.json" <<'JSON'
+{
+  "default_pack": "peon", "volume": 0.5, "enabled": true, "categories": {},
+  "mobile_notify": { "enabled": true, "service": "ntfy", "topic": "test-topic", "server": "https://ntfy.sh" }
+}
+JSON
+  # Unset PEON_TEST so the CLI itself must request synchronous delivery.
+  run env -u PEON_TEST bash "$PEON_SH" mobile test
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"test notification sent"* ]]
+  mobile_was_called
+}
+
+@test "mobile test fails when notification delivery fails" {
+  cat > "$TEST_DIR/config.json" <<'JSON'
+{
+  "default_pack": "peon", "volume": 0.5, "enabled": true, "categories": {},
+  "mobile_notify": { "enabled": true, "service": "ntfy", "topic": "test-topic", "server": "https://ntfy.sh" }
+}
+JSON
+  touch "$TEST_DIR/.mock_mobile_fail"
+  run env -u PEON_TEST bash "$PEON_SH" mobile test
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"test notification failed"* ]]
+}
+
 @test "mobile ntfy sends push on PermissionRequest" {
   cat > "$TEST_DIR/config.json" <<'JSON'
 {

--- a/tests/relay.bats
+++ b/tests/relay.bats
@@ -238,6 +238,31 @@ start_relay() {
   RELAY_PID=""
 }
 
+@test "relay --status reports the port the daemon actually started on, not the caller's env/default" {
+  # Regression: --status previously echoed whatever RELAY_PORT resolved to
+  # in *its own* invocation (env var or hardcoded 19998 default) instead of
+  # the port the running daemon actually bound, so a status check made
+  # without the original PEON_RELAY_PORT/--port would report a stale port
+  # for a genuinely healthy daemon.
+  bash "$RELAY_SH" --daemon --port="$RELAY_PORT" --peon-dir="$TEST_DIR" > /dev/null 2>&1
+  RELAY_PID=$(cat "$TEST_DIR/.relay.pid" 2>/dev/null)
+
+  for i in $(seq 1 30); do
+    if "$REAL_CURL" -sf "http://127.0.0.1:$RELAY_PORT/health" > /dev/null 2>&1; then
+      break
+    fi
+    sleep 0.1
+  done
+
+  # Query status with no --port and no PEON_RELAY_PORT set, so RELAY_PORT
+  # inside this invocation falls back to the hardcoded 19998 default —
+  # different from the port the daemon was actually started on.
+  run env -u PEON_RELAY_PORT bash "$RELAY_SH" --status --peon-dir="$TEST_DIR"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"port $RELAY_PORT"* ]]
+  [[ "$output" != *"port 19998"* ]]
+}
+
 @test "relay --daemon prevents duplicate start" {
   # Start first instance
   bash "$RELAY_SH" --daemon --port="$RELAY_PORT" --peon-dir="$TEST_DIR" > /dev/null 2>&1

--- a/tests/relay.bats
+++ b/tests/relay.bats
@@ -259,8 +259,11 @@ start_relay() {
   # different from the port the daemon was actually started on.
   run env -u PEON_RELAY_PORT bash "$RELAY_SH" --status --peon-dir="$TEST_DIR"
   [ "$status" -eq 0 ]
-  [[ "$output" == *"port $RELAY_PORT"* ]]
-  [[ "$output" != *"port 19998"* ]]
+  # grep -q rather than a non-final bare [[ ]]: under macOS bash 3.2 a failing
+  # bare [[ ]] only gates the test when it is the body's last statement, so the
+  # positive assertion below would otherwise pass no matter what --status said.
+  printf '%s' "$output" | grep -q "port $RELAY_PORT"
+  ! printf '%s' "$output" | grep -q "port 19998"
 }
 
 @test "relay --daemon prevents duplicate start" {

--- a/tests/setup.bash
+++ b/tests/setup.bash
@@ -415,6 +415,9 @@ for arg in "$@"; do
   fi
   # Mobile push notification services
   if [[ "$arg" == *"ntfy.sh"* ]] || [[ "$arg" == *"ntfy/"* ]]; then
+    # Record exact argv boundaries; the "$*" line below loses argument grouping,
+    # which matters when headers contain spaces (e.g. Authorization).
+    printf '%s\n' "$@" >> "${CLAUDE_PEON_DIR}/mobile_curl_argv.log"
     echo "MOBILE_NTFY: $*" >> "${CLAUDE_PEON_DIR}/mobile_curl.log"
     exit 0
   fi

--- a/tests/setup.bash
+++ b/tests/setup.bash
@@ -414,6 +414,11 @@ for arg in "$@"; do
     exit 0
   fi
   # Mobile push notification services
+  if [[ "$arg" == *"ntfy.sh"* || "$arg" == *"ntfy/"* || "$arg" == *"api.pushover.net"* || "$arg" == *"api.telegram.org"* ]]; then
+    if [ -f "${CLAUDE_PEON_DIR}/.mock_mobile_fail" ]; then
+      exit 22
+    fi
+  fi
   if [[ "$arg" == *"ntfy.sh"* ]] || [[ "$arg" == *"ntfy/"* ]]; then
     # Record exact argv boundaries; the "$*" line below loses argument grouping,
     # which matters when headers contain spaces (e.g. Authorization).


### PR DESCRIPTION
Not for merge. One CI run validating three shell/PowerShell PRs together before each is merged on its own.

- **#578** `relay --status` reports the port the daemon actually bound, persisted in a `.relay.port` file, rather than whatever `RELAY_PORT` resolves to in the status invocation's own environment. Comes with a regression test. I pushed one commit to that branch: the test's positive assertion was a non-final bare `[[ ]]`, which under macOS bash 3.2 reports ok no matter what `--status` printed, so only the negative check was gating. Now `grep -q`, per the convention documented at the top of `tests/eval-server.bats`.
- **#576** ntfy auth header built as an array instead of a string. The old `auth_header="-H \"Authorization: Bearer $TOKEN\""` expanded unquoted, so the header word-split on any space in the token and the quotes arrived literal. Also makes `peon mobile test` report real success or failure instead of always exiting 0. Tests included.
- **#570** bounds the `peon.ps1` stdin read at 2s, matching the `timeout 2 cat` guard `peon.sh` has had since #445. A host can open the stdin pipe and never close the write end, and `ReadToEnd()` then parks the pipeline thread for the life of the process; the 8s safety timer cannot help because `Register-ObjectEvent` runs its action on that same blocked thread. Closes #568. Pester tests included, and they assert against a spawned process rather than by grepping the source.