### PR TITLE
ci: batch C integration check (#565, #562)

### DIFF
--- a/peon.sh
+++ b/peon.sh
@@ -751,11 +751,44 @@ play_sound() {
   esac
 }
 
+# --- Live tmux client context (click-to-focus) ---
+# Echoes "<bundle_id>|<client_tty>|<terminal_pid>" describing the client attached
+# to this pane's session at this instant — empty fields when nothing is attached,
+# and an empty bundle id off macOS. Memoized because both consumers below want a
+# slice of it and the lookup forks ps/lsappinfo a few times.
+_peon_tmux_client_context() {
+  if [ -n "${_PEON_TMUX_CTX_RESOLVED:-}" ]; then
+    printf '%s\n' "${_PEON_TMUX_CTX:-}"
+    return 0
+  fi
+  _PEON_TMUX_CTX_RESOLVED=1
+  _PEON_TMUX_CTX=""
+  { [ -n "${TMUX:-}" ] && [ -n "${TMUX_PANE:-}" ]; } || return 0
+  local _helper
+  _helper="$(find_bundled_script "local-focus.sh")" 2>/dev/null || return 0
+  [ -x "$_helper" ] || return 0
+  _PEON_TMUX_CTX="$("$_helper" --print-context "${TMUX%%,*}" "$TMUX_PANE" "" "$(command -v tmux 2>/dev/null)" 2>/dev/null)"
+  printf '%s\n' "$_PEON_TMUX_CTX"
+}
+
 # --- Terminal bundle ID detection (macOS click-to-focus) ---
 # Returns the macOS bundle identifier for the current terminal emulator,
 # or empty string if unknown. Used with terminal-notifier -activate and
 # mac-overlay.js click handler to focus the right terminal on notification click.
 _mac_terminal_bundle_id() {
+  # Inside tmux, ask tmux — not this process's environment. The env below names
+  # the emulator the session was FIRST attached from and never updates, so it
+  # goes stale the moment the terminal is restarted or the session is re-attached
+  # from another one, and it is empty for emulators that export no identity at
+  # all (kitty, alacritty). scripts/local-focus.sh derives the app from the
+  # client attached right now; see its header for the full rationale.
+  if [ -n "${TMUX:-}" ] && ! _is_cmux_session; then
+    local _live_bundle
+    _live_bundle="$(_peon_tmux_client_context)"
+    _live_bundle="${_live_bundle%%|*}"
+    [ -n "$_live_bundle" ] && { echo "$_live_bundle"; return; }
+  fi
+
   case "${TERM_PROGRAM:-}" in
     ghostty)
       if _is_cmux_session; then
@@ -787,6 +820,11 @@ _mac_terminal_bundle_id() {
         echo "com.googlecode.iterm2"
       elif [ -n "${WARP_IS_LOCAL_SHELL_SESSION:-}" ]; then
         echo "dev.warp.Warp-Stable"
+      elif [ -n "${KITTY_WINDOW_ID:-}" ] || [ -n "${KITTY_PID:-}" ]; then
+        # kitty and alacritty set no TERM_PROGRAM, so they only ever reach here.
+        echo "net.kovidgoyal.kitty"
+      elif [ -n "${ALACRITTY_WINDOW_ID:-}" ] || [ -n "${ALACRITTY_SOCKET:-}" ]; then
+        echo "org.alacritty"
       else
         echo ""
       fi ;;
@@ -920,7 +958,14 @@ _mac_bundle_id_from_pid() {
 _resolve_session_tty() {
   [ -n "${PEON_SESSION_TTY:-}" ] && return 0
   if [ -n "${TMUX:-}" ]; then
-    PEON_SESSION_TTY=$(tmux display-message -p '#{client_tty}' 2>/dev/null || true)
+    # Take the tty from the same deterministic client pick the click path uses:
+    # with several clients on one session, an untargeted `display-message`
+    # answers for whichever tmux considers current, which need not be ours.
+    PEON_SESSION_TTY="$(_peon_tmux_client_context)"
+    PEON_SESSION_TTY="${PEON_SESSION_TTY#*|}"
+    PEON_SESSION_TTY="${PEON_SESSION_TTY%%|*}"
+    [ -z "$PEON_SESSION_TTY" ] && \
+      PEON_SESSION_TTY=$(tmux display-message -p '#{client_tty}' 2>/dev/null || true)
   else
     # Walk the full process tree; keep the LAST (highest ancestor) tty found.
     # Claude Code spawns hooks from worker processes that may have their own
@@ -997,6 +1042,10 @@ send_notification() {
       export PEON_SYNC="0"
       [ "${PEON_TEST:-0}" = "1" ] && export PEON_SYNC="1"
       if [ "$PEON_PLATFORM" = "mac" ]; then
+        # Prime the live tmux client lookup here, in this shell: both consumers
+        # below run in command substitutions, where the memoization would die
+        # with the subshell and the lookup would run twice.
+        _peon_tmux_client_context >/dev/null
         export PEON_BUNDLE_ID="$(_mac_terminal_bundle_id)"
         export PEON_IDE_PID="$(_mac_ide_pid)"
         # Warp's per-session deep link; opening it on click focuses the exact tab.

--- a/peon.sh
+++ b/peon.sh
@@ -1037,15 +1037,76 @@ send_notification() {
       local json_title json_msg
       json_title=$(python3 -c "import json,sys; print(json.dumps(sys.argv[1]))" "$title" 2>/dev/null || echo "\"$title\"")
       json_msg=$(python3 -c "import json,sys; print(json.dumps(sys.argv[1]))" "$msg" 2>/dev/null || echo "\"$msg\"")
+
+      # Build the request body, embedding click-to-focus context in a `focus`
+      # object so the Mac can, on click, raise the terminal tab hosting this ssh
+      # session and switch the *remote* tmux to this agent's pane. Everything is
+      # assembled by python3 (fed via env, never shell-interpolated) so untrusted
+      # strings can't break out of the JSON. `focus` is only emitted for real SSH
+      # sessions inside tmux — a devcontainer's tmux socket lives in the container
+      # and is unreachable from the Mac, so it stays out.
+      # Resolve the tmux binary that runs THIS session's server. The host must
+      # use the same binary when it reaches back in over ssh — a stock
+      # non-interactive ssh often lands on a different/older tmux (e.g. system
+      # 2.8 vs the server's 3.7b), and a version-mismatched client just prints
+      # "lost server" and the pane never switches. $TMUX is
+      # "<socket>,<server_pid>,<session>", so /proc/<server_pid>/exe is the
+      # exact server binary; fall back to whatever tmux is on PATH.
+      local _pp_tmux_bin=""
+      if [ -n "${TMUX:-}" ]; then
+        local _pp_spid
+        _pp_spid="$(printf '%s' "$TMUX" | cut -d, -f2)"
+        [ -n "$_pp_spid" ] && _pp_tmux_bin="$(readlink -f "/proc/$_pp_spid/exe" 2>/dev/null)"
+        [ -z "$_pp_tmux_bin" ] && _pp_tmux_bin="$(command -v tmux 2>/dev/null)"
+      fi
+
+      local relay_body=""
+      relay_body=$(
+        PP_TITLE="$title" PP_MSG="$msg" PP_COLOR="$color" \
+        PP_PLATFORM="$PEON_PLATFORM" \
+        PP_HOST="$(hostname -f 2>/dev/null || hostname 2>/dev/null || echo '')" \
+        PP_SSH_CONN="${SSH_CONNECTION:-}" \
+        PP_TMUX="${TMUX:-}" PP_TMUX_PANE="${TMUX_PANE:-}" \
+        PP_TMUX_BIN="$_pp_tmux_bin" \
+        PP_SESSION_ID="${SESSION_ID:-}" PP_RELAY_PORT="$relay_port" \
+        python3 - <<'PYBODY' 2>/dev/null
+import json, os
+body = {
+    "title": os.environ.get("PP_TITLE", ""),
+    "message": os.environ.get("PP_MSG", ""),
+    "color": os.environ.get("PP_COLOR", "red") or "red",
+}
+platform = os.environ.get("PP_PLATFORM", "")
+tmux = os.environ.get("PP_TMUX", "")
+if platform == "ssh" and tmux:
+    ssh_conn = os.environ.get("PP_SSH_CONN", "")
+    parts = ssh_conn.split()
+    server_ip = parts[2] if len(parts) >= 3 else ""
+    body["focus"] = {
+        "host": os.environ.get("PP_HOST", ""),
+        "server_ip": server_ip,
+        "tmux_socket": tmux.split(",", 1)[0],
+        "tmux_pane": os.environ.get("PP_TMUX_PANE", ""),
+        "tmux_bin": os.environ.get("PP_TMUX_BIN", ""),
+        "session_id": os.environ.get("PP_SESSION_ID", ""),
+        "ssh_conn": ssh_conn,
+        "relay_port": os.environ.get("PP_RELAY_PORT", ""),
+    }
+print(json.dumps(body))
+PYBODY
+      )
+      # Fallback when python3 is unavailable: minimal body, no focus context.
+      [ -z "$relay_body" ] && relay_body="{\"title\":${json_title},\"message\":${json_msg},\"color\":\"$color\"}"
+
       if [ "$use_bg" = true ]; then
         nohup curl -sf -X POST \
           -H "Content-Type: application/json" \
-          -d "{\"title\":${json_title},\"message\":${json_msg},\"color\":\"$color\"}" \
+          -d "$relay_body" \
           "http://${relay_host}:${relay_port}/notify" >/dev/null 2>&1 &
       else
         curl -sf -X POST \
           -H "Content-Type: application/json" \
-          -d "{\"title\":${json_title},\"message\":${json_msg},\"color\":\"$color\"}" \
+          -d "$relay_body" \
           "http://${relay_host}:${relay_port}/notify" >/dev/null 2>&1
       fi
       ;;

--- a/relay.sh
+++ b/relay.sh
@@ -177,6 +177,7 @@ import json
 import os
 import posixpath
 import random
+import re
 import shutil
 import subprocess
 import sys
@@ -399,24 +400,128 @@ def play_sound_on_host(path, volume):
             )
 
 
-def send_notification_on_host(title, message, color="red"):
+# Whitelist patterns for the click-to-focus `focus` payload. These strings
+# arrive over HTTP from a remote (possibly untrusted) session and are handed to
+# a click-to-run helper on the host, so every field is format-checked here and
+# the whole `focus` object is dropped if any field fails. Crucially the values
+# never enter a shell string — they ride as PEON_FOCUS_* env vars (see
+# send_notification_on_host) into scripts/ssh-focus.sh, which is invoked by a
+# constant path with no arguments.
+_FOCUS_PATTERNS = {
+    "host":        re.compile(r"^[A-Za-z0-9.:_-]{1,255}$"),
+    "server_ip":   re.compile(r"^[A-Za-z0-9.:_-]{0,255}$"),
+    "tmux_socket": re.compile(r"^/[A-Za-z0-9._/-]{1,256}$"),
+    "tmux_pane":   re.compile(r"^%?[0-9]{1,12}$"),
+    "session_id":  re.compile(r"^[A-Za-z0-9._-]{1,128}$"),
+    "relay_port":  re.compile(r"^[0-9]{1,5}$"),
+}
+# Optional fields (validated if present, but absence is fine).
+_FOCUS_OPTIONAL = {
+    "tmux_bin":    re.compile(r"^/[A-Za-z0-9._/-]{1,256}$"),
+}
+
+
+def validate_focus(focus):
+    """Validate a `focus` dict from /notify. Returns a clean dict of str values,
+    or None if it is missing/malformed. Requires the fields needed to both find
+    the local ssh tab and switch the remote tmux pane."""
+    if not isinstance(focus, dict):
+        return None
+    out = {}
+    for key, pat in _FOCUS_PATTERNS.items():
+        val = focus.get(key, "")
+        if not isinstance(val, str):
+            return None
+        if not pat.match(val):
+            return None
+        out[key] = val
+    # Optional fields: keep only if present and well-formed, else empty.
+    for key, pat in _FOCUS_OPTIONAL.items():
+        val = focus.get(key, "")
+        out[key] = val if (isinstance(val, str) and pat.match(val)) else ""
+    # ssh_conn must be exactly four whitespace-separated ip/port tokens.
+    ssh_conn = focus.get("ssh_conn", "")
+    if not isinstance(ssh_conn, str):
+        return None
+    conn_parts = ssh_conn.split()
+    if len(conn_parts) == 4 and all(
+        re.match(r"^[A-Za-z0-9.:_-]{1,255}$", p) for p in conn_parts
+    ):
+        out["ssh_conn"] = ssh_conn
+    else:
+        out["ssh_conn"] = ""
+    # The remote tmux switch is the whole point; require pane + socket.
+    if not out["tmux_pane"] or not out["tmux_socket"]:
+        return None
+    return out
+
+
+def send_notification_on_host(title, message, color="red", focus=None):
     """Send a desktop notification using the host's native notification system.
 
     Delegates to scripts/notify.sh which handles overlay/standard styles, icons,
     click-to-focus, WSL toast/forms, and Linux notify-send.
     Falls back to inline osascript/notify-send if notify.sh is missing.
+
+    When `focus` (a validated dict) is present on macOS and enabled in config,
+    wires up a click handler that jumps to the ssh tab + remote tmux pane via
+    scripts/ssh-focus.sh. All focus data is passed as PEON_FOCUS_* env, never
+    interpolated into a shell command.
     """
     notify_script = os.path.join(PEON_DIR, "scripts", "notify.sh")
     if os.path.isfile(notify_script):
         config = load_config()
         icon_path = ""  # let notify.sh resolve pack icon via _resolve_pack_icon()
         env = os.environ.copy()
+        # The relay is a long-lived daemon; its own ambient TMUX/TERM context is
+        # never the remote session's. Scrub the vars notify.sh would otherwise use
+        # to fabricate a click target, so a relayed notification is clickable only
+        # via the focus context we set below (or not at all) — never via whatever
+        # shell happened to launch the daemon.
+        for _amb in ("TMUX", "TMUX_PANE", "PEON_SESSION_TTY", "PEON_CLICK_COMMAND"):
+            env.pop(_amb, None)
         env["PEON_PLATFORM"] = HOST_PLATFORM
         env["PEON_NOTIF_STYLE"] = config.get("notification_style", "overlay")
         env["PEON_NOTIF_POSITION"] = config.get("notification_position", "top-center")
         env["PEON_NOTIF_DISMISS"] = str(config.get("notification_dismiss_seconds", 4))
         env["PEON_DIR"] = PEON_DIR
         env["PEON_SYNC"] = os.environ.get("PEON_TEST", "0")
+
+        if (
+            focus
+            and HOST_PLATFORM == "mac"
+            and config.get("relay_click_focus", True)
+        ):
+            ssh_focus = os.path.join(PEON_DIR, "scripts", "ssh-focus.sh")
+            if os.path.isfile(ssh_focus):
+                # Constant path, no args — click handler runs `bash -lc <path>`.
+                env["PEON_CLICK_COMMAND"] = ssh_focus
+                env["PEON_FOCUS_HOST"] = focus.get("host", "")
+                env["PEON_FOCUS_SERVER_IP"] = focus.get("server_ip", "")
+                env["PEON_FOCUS_SSH_CONN"] = focus.get("ssh_conn", "")
+                env["PEON_FOCUS_TMUX_SOCKET"] = focus.get("tmux_socket", "")
+                env["PEON_FOCUS_TMUX_PANE"] = focus.get("tmux_pane", "")
+                env["PEON_FOCUS_TMUX_BIN"] = focus.get("tmux_bin", "")
+                env["PEON_FOCUS_SESSION_ID"] = focus.get("session_id", "")
+                env["PEON_FOCUS_RELAY_PORT"] = focus.get("relay_port", "")
+                # Optional override to force a terminal app; normally unset since
+                # ssh-focus.sh auto-discovers the terminal from the ssh process.
+                force_bundle = config.get("relay_terminal_bundle_id", "")
+                if force_bundle:
+                    env["PEON_BUNDLE_ID"] = force_bundle
+                # Pre-warm the ssh connection now, while the notification is on
+                # screen, so the click-time pane switch reuses a ready master
+                # instead of paying a ~3s cold (GSSAPI) connect. Fire-and-forget.
+                if config.get("relay_prewarm_ssh", True):
+                    try:
+                        subprocess.Popen(
+                            ["bash", ssh_focus, "--prewarm"],
+                            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+                            env=env,
+                        )
+                    except Exception:
+                        pass
+
         subprocess.Popen(
             ["bash", notify_script, message, title, color, icon_path],
             stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
@@ -616,8 +721,12 @@ class RelayHandler(http.server.BaseHTTPRequestHandler):
         title = str(body.get("title", "peon-ping"))[:256]
         message = str(body.get("message", ""))[:512]
         color = str(body.get("color", "red"))
+        # Optional click-to-focus context; validate_focus() returns None if it
+        # is absent or any field is malformed, in which case the notification
+        # still shows (just not clickable-to-focus).
+        focus = validate_focus(body.get("focus"))
 
-        send_notification_on_host(title, message, color)
+        send_notification_on_host(title, message, color, focus)
 
         self.send_response(200)
         self.send_header("Content-Type", "text/plain")

--- a/scripts/local-focus.sh
+++ b/scripts/local-focus.sh
@@ -1,0 +1,253 @@
+#!/bin/bash
+# peon-ping: click-time focus helper for LOCAL tmux sessions (macOS).
+#
+# Usage:
+#   local-focus.sh <tmux-socket> <tmux-pane> [fallback-bundle-id] [tmux-bin]
+#       Click handler: raise the terminal that is showing this tmux session right
+#       now, then switch that client to the agent's own window/pane.
+#   local-focus.sh --print-context <tmux-socket> <tmux-pane> "" [tmux-bin]
+#       Print "<bundle_id>|<client_tty>|<terminal_pid>" for the notifier to use at
+#       notify time (empty fields when nothing is attached). No side effects.
+#
+# WHY the terminal is resolved at click time and not from the environment
+#
+# A hook only sees the environment its own process inherited, and a pane's
+# environment is frozen when the pane is created. The identity vars peon reads
+# (ITERM_SESSION_ID, GHOSTTY_RESOURCES_DIR, WARP_IS_LOCAL_SHELL_SESSION) therefore
+# name the emulator the tmux session was FIRST attached from — forever:
+#   - quit/restart the terminal, or attach the session from a different one, and
+#     the stored identity points at an app that is not showing this session, so
+#     the click raises the wrong window (or relaunches a quit app);
+#   - kitty and alacritty export no such var at all, so the identity comes out
+#     empty and the click raises nothing — the notification looks dead.
+# tmux is never stale: it knows which client is attached at this instant. So ask
+# tmux, then walk that client's process ancestry until an ancestor has a bundle
+# id — that ancestor is the hosting terminal, whichever emulator it happens to
+# be. Same discovery ssh-focus.sh does for relayed remote sessions.
+#
+# Constraints (mirrors ssh-focus.sh):
+#   - The overlay's click handler blocks on this: return fast, never prompt.
+#   - Runs under stock macOS /bin/bash 3.2 (BSD regex: interval upper bounds
+#     above 255 are invalid and silently never match — use unbounded +).
+#   - Only ever drive a tmux client that was positively identified.
+#   - Always exits 0.
+set -u
+
+MODE="click"
+if [ "${1:-}" = "--print-context" ]; then
+  MODE="context"
+  shift
+fi
+
+SOCK="${1:-}"
+PANE="${2:-}"
+FALLBACK_BUNDLE="${3:-}"
+TMUX_BIN_ARG="${4:-}"
+
+PEON_DIR="${PEON_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+
+_DBG_ON=""
+_dbg() {
+  if [ -z "$_DBG_ON" ]; then
+    # PEON_DEBUG is not exported by the hook, so honour config.json's `debug`
+    # too — otherwise the click path is undebuggable in normal use.
+    if [ "${PEON_DEBUG:-0}" = "1" ] || grep -q '"debug"[[:space:]]*:[[:space:]]*true' "$PEON_DIR/config.json" 2>/dev/null; then
+      _DBG_ON=1
+    else
+      _DBG_ON=0
+    fi
+  fi
+  [ "$_DBG_ON" = "1" ] || return 0
+  local d="$PEON_DIR/logs"
+  mkdir -p "$d" 2>/dev/null || return 0
+  printf '%s [local-focus] %s\n' "$(date '+%Y-%m-%dT%H:%M:%S')" "$*" \
+    >> "$d/peon-ping-$(date +%Y-%m-%d).log" 2>/dev/null || true
+}
+
+_bail() {
+  # context mode must still print a (empty) record so callers can parse blindly
+  [ "$MODE" = "context" ] && printf '||\n'
+  exit 0
+}
+
+# --- Validate inputs (both modes) ---
+[[ "$PANE" =~ ^%?[0-9]+$ ]] || { _dbg "bad pane=$PANE"; _bail; }
+[[ "$SOCK" =~ ^/[A-Za-z0-9._/-]+$ ]] || { _dbg "bad socket=$SOCK"; _bail; }
+
+# Which tmux to drive. The click runs under `bash -lc` from the overlay, whose
+# login PATH is whatever ~/.bash_profile happens to set — not the hook's PATH. On
+# a Mac that regularly means finding /usr/bin/tmux (3.5a) instead of the Homebrew
+# build the server actually runs, and a version-mismatched client on a live socket
+# just prints "lost server" and switches nothing. So the notifier pins the binary
+# it resolved at notify time, and PATH lookup is only the fallback.
+TMUX_BIN=""
+if [[ "$TMUX_BIN_ARG" =~ ^/[A-Za-z0-9._/-]+$ ]] && [ -x "$TMUX_BIN_ARG" ]; then
+  TMUX_BIN="$TMUX_BIN_ARG"
+else
+  TMUX_BIN="$(command -v tmux 2>/dev/null || true)"
+  if [ -z "$TMUX_BIN" ]; then
+    for _c in /opt/homebrew/bin/tmux /usr/local/bin/tmux /usr/bin/tmux; do
+      [ -x "$_c" ] && { TMUX_BIN="$_c"; break; }
+    done
+  fi
+fi
+[ -n "$TMUX_BIN" ] || { _dbg "no tmux binary found (arg=$TMUX_BIN_ARG)"; _bail; }
+
+TM=("$TMUX_BIN" -S "$SOCK")
+
+# --- Pick the client to focus ---
+# Prefer a client attached to this pane's own session; among those the most
+# recently active one is what the user is looking at (a session can carry several
+# clients — a second window, a phone over ssh). A client on a *different* session
+# is only a last resort: switch-client can still pull our session into it, but it
+# means yanking that client away from what it was showing, so it must never beat
+# a client that already has our session.
+_pick_client() {
+  local sess
+  sess="$("${TM[@]}" display-message -p -t "$PANE" '#{session_name}' 2>/dev/null)" || sess=""
+  "${TM[@]}" list-clients -F '#{client_activity}|#{client_pid}|#{client_tty}|#{client_session}' 2>/dev/null \
+    | awk -F'|' -v s="$sess" '
+        $2 == "" || $3 == "" { next }
+        {
+          # session name is the last field and may itself contain "|"
+          ses = $4; for (i = 5; i <= NF; i++) ses = ses "|" $i
+          if (s != "" && ses == s) {
+            if ($1 + 0 > best) { best = $1 + 0; bpid = $2; btty = $3 }
+          } else if ($1 + 0 > any) { any = $1 + 0; apid = $2; atty = $3 }
+        }
+        END {
+          if (btty != "") print bpid "|" btty
+          else if (atty != "") print apid "|" atty
+        }'
+}
+
+CLIENT_PID=""
+CLIENT_TTY=""
+_pc="$(_pick_client)"
+if [ -n "$_pc" ]; then
+  CLIENT_PID="${_pc%%|*}"
+  CLIENT_TTY="${_pc#*|}"
+fi
+
+# --- Derive the bundle id of a running app by PID (macOS lsappinfo) ---
+_bundle_from_pid() {
+  local pid="$1"
+  { [ -z "$pid" ] || [ "$pid" = "0" ]; } && return
+  lsappinfo info -only bundleid -app pid:"$pid" 2>/dev/null \
+    | sed -n 's/.*="\([^"]*\)".*/\1/p'
+}
+
+# Climb from the tmux client until an ancestor has a bundle id — that ancestor is
+# the terminal app (the client, shells and helper servers have none).
+TERM_PID=""
+TERM_BUNDLE=""
+if [ -n "$CLIENT_PID" ] && [ "$(uname -s)" = "Darwin" ]; then
+  p="$CLIENT_PID"
+  for _i in 1 2 3 4 5 6 7 8 9 10 11 12; do
+    p="$(ps -o ppid= -p "$p" 2>/dev/null | tr -d ' ')"
+    { [ -z "$p" ] || [ "$p" = "0" ] || [ "$p" = "1" ]; } && break
+    b="$(_bundle_from_pid "$p")"
+    if [ -n "$b" ]; then TERM_PID="$p"; TERM_BUNDLE="$b"; break; fi
+  done
+fi
+
+# The ancestry can dead-end at launchd: iTerm2 keeps its ptys in a detachable
+# iTermServer, and after iTerm2 restarts and re-adopts it that server's parent is
+# pid 1, not the new app. The notify-time guess is right in exactly that case
+# (same app, restarted), so fall back to it rather than raising nothing.
+if [ -z "$TERM_BUNDLE" ] && [ -n "$FALLBACK_BUNDLE" ]; then
+  TERM_BUNDLE="$FALLBACK_BUNDLE"
+  _dbg "ancestry gave no bundle; using fallback=$TERM_BUNDLE"
+fi
+
+_dbg "$MODE pane=$PANE tmux=$TMUX_BIN client_pid=$CLIENT_PID client_tty=$CLIENT_TTY term_pid=$TERM_PID bundle=$TERM_BUNDLE"
+
+if [ "$MODE" = "context" ]; then
+  printf '%s|%s|%s\n' "$TERM_BUNDLE" "$CLIENT_TTY" "$TERM_PID"
+  exit 0
+fi
+
+# --- Step 1: raise the terminal app ---
+# By PID when we have it (unambiguous, and works for any emulator); otherwise by
+# bundle id, matching a RUNNING app only — never `open -b`, which would launch a
+# terminal the user has quit and pop an empty window.
+if [ -n "$TERM_PID" ] || [ -n "$TERM_BUNDLE" ]; then
+  /usr/bin/osascript -l JavaScript -e '
+    function run(argv) {
+      ObjC.import("Cocoa");
+      var pid = parseInt(argv[0], 10);
+      if (pid > 0) {
+        var app = $.NSRunningApplication.runningApplicationWithProcessIdentifier(pid);
+        if (app && !app.isNil()) {
+          app.activateWithOptions($.NSApplicationActivateIgnoringOtherApps);
+          return;
+        }
+      }
+      var bid = argv[1];
+      if (!bid) return;
+      var apps = $.NSWorkspace.sharedWorkspace.runningApplications;
+      for (var i = 0; i < apps.count; i++) {
+        var a = apps.objectAtIndex(i);
+        var b = a.bundleIdentifier;
+        if (!b.isNil() && b.js === bid) {
+          a.activateWithOptions($.NSApplicationActivateIgnoringOtherApps);
+          return;
+        }
+      }
+    }' "${TERM_PID:-0}" "$TERM_BUNDLE" >/dev/null 2>&1 || true
+fi
+
+# --- Step 2: iTerm2 only — raise the exact window/tab hosting this client ---
+# Activating the app lands on its frontmost window, which may be a different tab.
+if [ "$TERM_BUNDLE" = "com.googlecode.iterm2" ] && [ -n "$CLIENT_TTY" ]; then
+  /usr/bin/osascript -l JavaScript -e '
+    function run(argv) {
+      var tty = argv[0];
+      var iTerm = Application("iTerm2");
+      var ws = iTerm.windows();
+      for (var w = 0; w < ws.length; w++) {
+        var ts = ws[w].tabs();
+        for (var t = 0; t < ts.length; t++) {
+          var ss = ts[t].sessions();
+          for (var s = 0; s < ss.length; s++) {
+            try {
+              if (ss[s].tty() !== tty) continue;
+              ts[t].select();
+              ss[s].select();
+              ws[w].index = 1;
+              iTerm.activate();
+              // AXRaise last, in its own guard: it needs Accessibility rights
+              // this process may not have, and a throw here must not cost us the
+              // activate above (which is what actually fronts the tab).
+              try {
+                var wn = ws[w].name();
+                var sw = Application("System Events").processes["iTerm2"].windows();
+                for (var i = 0; i < sw.length; i++) {
+                  if (sw[i].name() === wn) { sw[i].actions["AXRaise"].perform(); break; }
+                }
+              } catch (e2) {}
+              return;
+            } catch (e) {}
+          }
+        }
+      }
+    }' "$CLIENT_TTY" >/dev/null 2>&1 || true
+fi
+
+# --- Step 3: switch tmux to the agent's own window/pane ---
+# Target the client we identified (-c) instead of letting tmux guess: with more
+# than one client attached, an untargeted switch-client can move the wrong one.
+# One chained invocation so the three commands cannot interleave with a resize.
+if [ -n "$CLIENT_TTY" ]; then
+  "${TM[@]}" switch-client -c "$CLIENT_TTY" -t "$PANE" \; \
+             select-window -t "$PANE" \; \
+             select-pane -t "$PANE" >/dev/null 2>&1 \
+    || "${TM[@]}" select-window -t "$PANE" \; select-pane -t "$PANE" >/dev/null 2>&1 \
+    || _dbg "tmux switch failed pane=$PANE client=$CLIENT_TTY"
+else
+  # Nothing attached — there is no screen to switch. Selecting the window anyway
+  # would silently rearrange a detached session behind the user's back.
+  _dbg "no attached client; skipped tmux switch"
+fi
+
+exit 0

--- a/scripts/mac-overlay.js
+++ b/scripts/mac-overlay.js
@@ -61,9 +61,13 @@ function run(argv) {
   // All overlays with the same slot will coordinate dismissal
   var dismissNotificationName = 'com.peonping.dismiss.' + slot;
 
-  // Register a click handler if we have a target bundle ID, IDE PID, or persistent mode
+  // Register a click handler if we have a target bundle ID, IDE PID, persistent
+  // mode, or a custom click command. The last case covers relay notifications
+  // for remote ssh sessions: the hosting terminal isn't known at notify time
+  // (it's discovered on click by ssh-focus.sh), so there's no bundle id to key
+  // on — the click command alone must make the overlay clickable.
   var clickHandler = null;
-  if (bundleId || idePid > 0 || persistent) {
+  if (bundleId || idePid > 0 || persistent || clickCommand) {
     function activateBundle(targetBundleId) {
       if (!targetBundleId) return false;
       var ws = $.NSWorkspace.sharedWorkspace;

--- a/scripts/notify.sh
+++ b/scripts/notify.sh
@@ -119,6 +119,14 @@ _find_cmux_focus_helper() {
   return 1
 }
 
+_find_local_focus_helper() {
+  local p="$PEON_DIR/scripts/local-focus.sh"
+  [ -x "$p" ] && { echo "$p"; return 0; }
+  p="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/local-focus.sh"
+  [ -x "$p" ] && { echo "$p"; return 0; }
+  return 1
+}
+
 _find_cmux_workspace_field_helper() {
   local p="$PEON_DIR/scripts/cmux-workspace-field.sh"
   [ -f "$p" ] && { echo "$p"; return 0; }
@@ -317,7 +325,24 @@ case "$PEON_PLATFORM" in
     if [ -z "$click_command" ] && [ -n "${TMUX:-}" ] && [ -n "${TMUX_PANE:-}" ] && command -v tmux >/dev/null 2>&1; then
       _pp_tsock=$(printf '%q' "${TMUX%%,*}")
       _pp_tpane=$(printf '%q' "$TMUX_PANE")
-      click_command="tmux -S $_pp_tsock switch-client -t $_pp_tpane 2>/dev/null; tmux -S $_pp_tsock select-window -t $_pp_tpane 2>/dev/null; tmux -S $_pp_tsock select-pane -t $_pp_tpane 2>/dev/null"
+      _pp_local_focus=""
+      if [ "$PEON_PLATFORM" = "mac" ]; then
+        _pp_local_focus="$(_find_local_focus_helper)" 2>/dev/null || _pp_local_focus=""
+      fi
+      if [ -n "$_pp_local_focus" ]; then
+        # macOS: hand the whole click to local-focus.sh, which re-derives the
+        # hosting terminal from the tmux client attached at CLICK time (the user
+        # may have restarted or swapped terminals since this notification was
+        # posted), raises it, then switches that client to our pane. bundle_id
+        # rides along as the fallback for the one case tmux can't answer — see
+        # scripts/local-focus.sh.
+        # Pin the tmux binary resolved here: the click runs under `bash -lc`,
+        # where PATH may resolve a different (version-mismatched) tmux.
+        _pp_tmuxbin="$(command -v tmux 2>/dev/null || true)"
+        click_command="$(printf '%q %s %s %q %q' "$_pp_local_focus" "$_pp_tsock" "$_pp_tpane" "$bundle_id" "$_pp_tmuxbin")"
+      else
+        click_command="tmux -S $_pp_tsock switch-client -t $_pp_tpane 2>/dev/null; tmux -S $_pp_tsock select-window -t $_pp_tpane 2>/dev/null; tmux -S $_pp_tsock select-pane -t $_pp_tpane 2>/dev/null"
+      fi
     fi
     if [ -z "$click_command" ]; then
       click_command="$(_terminal_focus_click_command "$bundle_id" "${PEON_SESSION_TTY:-}")" || true

--- a/scripts/ssh-focus.sh
+++ b/scripts/ssh-focus.sh
@@ -1,0 +1,263 @@
+#!/bin/bash
+# peon-ping: click-time focus helper for relayed (remote SSH) notifications.
+#
+# Invoked by the notification overlay / terminal-notifier as `bash -lc <this>`
+# with NO arguments. Every input arrives via PEON_FOCUS_* environment variables
+# set by relay.sh — never on the command line — so untrusted remote strings can
+# never break out into a shell command here.
+#
+# What it does, on click:
+#   A. Find the local ssh client process hosting the remote agent's session.
+#   B. Raise the terminal app (and, where scriptable, the exact tab) that ssh
+#      runs in — whatever terminal emulator it is (discovered, not hardcoded).
+#   C. Best-effort switch the *remote* tmux to the agent's own window/pane over
+#      that same ssh, reusing a ControlMaster if one exists.
+#
+# Constraints (why the code looks the way it does):
+#   - Must return fast (<1s): the overlay's click handler blocks on it.
+#   - Must never prompt or hang → ssh uses BatchMode + ConnectTimeout, backgrounded.
+#   - Must never switch a tmux it hasn't POSITIVELY matched to this agent.
+#   - Must run under macOS's stock /bin/bash 3.2 (no assoc arrays, no ${x,,}).
+#   - Always exits 0.
+set -u
+
+# Two modes:
+#   (default) click: focus the tab + switch the remote tmux pane.
+#   --prewarm       : just open/reuse the ssh master to the box, then exit. The
+#                     relay fires this the moment the notification appears, so by
+#                     the time the user clicks, the (slow, GSSAPI/Kerberos) ssh
+#                     connection is already established and the pane switch is
+#                     instant instead of paying a ~3s cold connect on click.
+MODE="click"
+[ "${1:-}" = "--prewarm" ] && MODE="prewarm"
+
+PEON_DIR="${PEON_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+
+# Shared ssh options: a per-connection master (ControlMaster) kept alive for
+# 10 min so repeated clicks — and the click after a prewarm — reuse one
+# connection. ClearAllForwardings drops the config's RemoteForward (the relay
+# tunnel) which would otherwise fail noisily on these extra connections.
+_CM_DIR="$HOME/.ssh/peon-cm"
+mkdir -p "$_CM_DIR" 2>/dev/null && chmod 700 "$_CM_DIR" 2>/dev/null
+SSH_CM=(-o BatchMode=yes -o ClearAllForwardings=yes \
+        -o ControlMaster=auto -o "ControlPath=$_CM_DIR/%C" -o ControlPersist=600)
+
+_dbg() {
+  [ "${PEON_DEBUG:-0}" = "1" ] || return 0
+  local d="$PEON_DIR/logs"
+  mkdir -p "$d" 2>/dev/null || return 0
+  printf '%s [ssh-focus] %s\n' "$(date '+%Y-%m-%dT%H:%M:%S')" "$*" \
+    >> "$d/peon-ping-$(date +%Y-%m-%d).log" 2>/dev/null || true
+}
+
+# --- Focus context (defensively re-validated even though relay.sh validated) ---
+F_TMUX_SOCKET="${PEON_FOCUS_TMUX_SOCKET:-}"
+F_TMUX_PANE="${PEON_FOCUS_TMUX_PANE:-}"
+F_TMUX_BIN="${PEON_FOCUS_TMUX_BIN:-}"
+F_SERVER_IP="${PEON_FOCUS_SERVER_IP:-}"
+F_HOST="${PEON_FOCUS_HOST:-}"
+F_RELAY_PORT="${PEON_FOCUS_RELAY_PORT:-}"
+
+TMUX_OK=1
+[[ "$F_TMUX_PANE" =~ ^%?[0-9]{1,12}$ ]] || TMUX_OK=0
+[[ "$F_TMUX_SOCKET" =~ ^/[A-Za-z0-9._/-]+$ ]] || TMUX_OK=0
+[[ "$F_RELAY_PORT" =~ ^[0-9]{1,5}$ ]] || F_RELAY_PORT=""
+[[ "$F_SERVER_IP" =~ ^[A-Za-z0-9.:_-]+$ ]] || F_SERVER_IP=""
+# Remote tmux binary must be the server's own (a version-mismatched client just
+# says "lost server"). Use the transmitted absolute path; fall back to `tmux`.
+[[ "$F_TMUX_BIN" =~ ^/[A-Za-z0-9._/-]+$ ]] || F_TMUX_BIN=""
+RTMUX="${F_TMUX_BIN:-tmux}"
+
+_dbg "start pane=$F_TMUX_PANE socket=$F_TMUX_SOCKET tmux_bin=$RTMUX server_ip=$F_SERVER_IP relay_port=$F_RELAY_PORT tmux_ok=$TMUX_OK"
+
+# --- Derive the bundle id of a running app by PID (macOS lsappinfo) ---
+_bundle_from_pid() {
+  local pid="$1"
+  { [ -z "$pid" ] || [ "$pid" = "0" ]; } && return
+  lsappinfo info -only bundleid -app pid:"$pid" 2>/dev/null \
+    | sed -n 's/.*="\([^"]*\)".*/\1/p'
+}
+
+# --- Extract the [user@]host destination from an ssh command line (best-effort) ---
+# Walks argv, skipping options and their arguments, and returns the first bare
+# operand. Handles both "-p 22" and glued "-p22"/"-oFoo=bar" forms.
+_ssh_dest() {
+  local -a toks
+  toks=($1)
+  local n="${#toks[@]}" i=1 tok c
+  local with_arg="bcDEeFIiJLlmOopQRSWw"
+  while [ "$i" -lt "$n" ]; do
+    tok="${toks[$i]}"
+    case "$tok" in
+      --)
+        i=$((i + 1)); [ "$i" -lt "$n" ] && printf '%s' "${toks[$i]}"; return ;;
+      -*)
+        c="${tok:1:1}"
+        if [ "${#tok}" -gt 2 ] && [ -n "$c" ] && [ "${with_arg#*"$c"}" != "$with_arg" ]; then
+          : # option with glued argument — consume just this token
+        elif [ "${#tok}" -eq 2 ] && [ "${with_arg#*"$c"}" != "$with_arg" ]; then
+          i=$((i + 1)) # option takes the next token as its argument
+        fi ;;
+      *)
+        printf '%s' "$tok"; return ;;
+    esac
+    i=$((i + 1))
+  done
+}
+
+# --- Step A: collect local ssh candidates attached to a real terminal (ttys*) ---
+CAND_PID=()
+CAND_CMD=()
+while IFS=$'\t' read -r cpid ccmd; do
+  [ -n "$cpid" ] || continue
+  CAND_PID+=("$cpid")
+  CAND_CMD+=("$ccmd")
+done < <(ps -Ao pid=,tty=,command= 2>/dev/null \
+  | awk '$2 != "??" && $3 ~ /(^|\/)ssh$/ { pid=$1; $1=""; $2=""; sub(/^ +/, ""); print pid "\t" $0 }')
+
+NCAND="${#CAND_PID[@]}"
+_dbg "ssh candidates=$NCAND"
+
+SSHPID=""
+# Cascade — first match wins; every match here is a POSITIVE identification, so
+# it is safe to also switch the remote tmux. If none match we focus nothing and
+# never touch tmux (better than jumping to the wrong box).
+if [ "$NCAND" -eq 1 ]; then
+  SSHPID="${CAND_PID[0]}"
+  _dbg "A1 single-candidate pid=$SSHPID"
+fi
+
+# A2: reverse-forward owner — the ssh that tunnels the relay port back to the
+# Mac IS this tab, regardless of any bastion in between. The forward may be a
+# CLI `-R <port>` OR a `RemoteForward` in ssh_config (invisible in argv), so
+# check both: the command line, then the effective config via `ssh -G`.
+if [ -z "$SSHPID" ] && [ -n "$F_RELAY_PORT" ]; then
+  for idx in "${!CAND_PID[@]}"; do
+    cmd="${CAND_CMD[$idx]}"
+    case "$cmd" in
+      *-R*"$F_RELAY_PORT"*) SSHPID="${CAND_PID[$idx]}"; _dbg "A2 reverse-forward(cli) pid=$SSHPID"; break ;;
+    esac
+    d="$(_ssh_dest "$cmd")"
+    if [ -n "$d" ] && ssh -G "$d" 2>/dev/null \
+        | awk 'tolower($1)=="remoteforward"{print $2}' \
+        | grep -Eq "(^|:)${F_RELAY_PORT}\$"; then
+      SSHPID="${CAND_PID[$idx]}"; _dbg "A2 reverse-forward(config) pid=$SSHPID"; break
+    fi
+  done
+fi
+
+# A3: remote endpoint IP equals the box's server_ip (direct connections only;
+# breaks behind a bastion, hence last).
+if [ -z "$SSHPID" ] && [ -n "$F_SERVER_IP" ] && command -v lsof >/dev/null 2>&1; then
+  for idx in "${!CAND_PID[@]}"; do
+    if lsof -nP -p "${CAND_PID[$idx]}" -iTCP -sTCP:ESTABLISHED 2>/dev/null \
+        | grep -q -- "->$F_SERVER_IP:"; then
+      SSHPID="${CAND_PID[$idx]}"; _dbg "A3 endpoint pid=$SSHPID"; break
+    fi
+  done
+fi
+
+if [ -z "$SSHPID" ]; then
+  _dbg "no positive ssh match; giving up"
+  exit 0
+fi
+
+# Resolve the ssh destination once (used by prewarm and the pane switch).
+sshcmd="$(ps -ww -o command= -p "$SSHPID" 2>/dev/null)"
+dest="$(_ssh_dest "$sshcmd")"
+
+# --- Prewarm mode: just open/join the ssh master, then exit fast. ---
+if [ "$MODE" = "prewarm" ]; then
+  if [ -n "$dest" ]; then
+    _dbg "prewarm dest=$dest"
+    nohup ssh "${SSH_CM[@]}" -o ConnectTimeout=8 "$dest" true >/dev/null 2>&1 &
+  fi
+  exit 0
+fi
+
+# --- Step B: focus the hosting terminal (terminal-agnostic) ---
+sshtty="$(ps -o tty= -p "$SSHPID" 2>/dev/null | tr -d ' ')"
+case "$sshtty" in
+  tty*) ttydev="/dev/$sshtty" ;;
+  ""|'?'*) ttydev="" ;;
+  *) ttydev="/dev/$sshtty" ;;
+esac
+
+# Climb the process tree until an ancestor has a bundle id — that ancestor is
+# the terminal app (shells and ssh have none).
+term_pid=""
+term_bundle=""
+p="$SSHPID"
+for _i in 1 2 3 4 5 6 7 8 9 10 11 12; do
+  p="$(ps -o ppid= -p "$p" 2>/dev/null | tr -d ' ')"
+  { [ -z "$p" ] || [ "$p" = "0" ] || [ "$p" = "1" ]; } && break
+  b="$(_bundle_from_pid "$p")"
+  if [ -n "$b" ]; then term_pid="$p"; term_bundle="$b"; break; fi
+done
+_dbg "sshpid=$SSHPID tty=$ttydev term_pid=$term_pid term_bundle=$term_bundle"
+
+# Baseline: activate the terminal app by PID — works for any emulator.
+if [ -n "$term_pid" ]; then
+  /usr/bin/osascript -l JavaScript -e '
+    function run(argv){
+      ObjC.import("Cocoa");
+      var app=$.NSRunningApplication.runningApplicationWithProcessIdentifier(parseInt(argv[0],10));
+      if(app && !app.isNil()){ app.activateWithOptions($.NSApplicationActivateIgnoringOtherApps); }
+    }' "$term_pid" >/dev/null 2>&1 || true
+fi
+
+# Enhancement: iTerm2 can raise the exact tab whose tty matches the ssh session.
+if [ "$term_bundle" = "com.googlecode.iterm2" ] && [ -n "$ttydev" ]; then
+  /usr/bin/osascript -l JavaScript -e '
+    function run(argv){var tty=argv[0];var iTerm=Application("iTerm2");var ws=iTerm.windows();
+    for(var w=0;w<ws.length;w++){var ts=ws[w].tabs();
+    for(var t=0;t<ts.length;t++){var ss=ts[t].sessions();
+    for(var s=0;s<ss.length;s++){try{if(ss[s].tty()===tty){ts[t].select();ss[s].select();ws[w].index=1;iTerm.activate();return}}catch(e){}}}}}' \
+    "$ttydev" >/dev/null 2>&1 || true
+fi
+
+# --- Step C: switch the remote tmux to the agent's pane (best-effort) ---
+if [ "$TMUX_OK" = "1" ] && [ -n "$dest" ]; then
+  _dbg "remote-switch dest=$dest"
+  switched=0
+
+  # Fast path: the main ssh connection can forward the remote tmux control
+  # socket to a local one (LocalForward in ssh config). If it did, drive the
+  # remote tmux with the LOCAL client over that socket — a single round-trip,
+  # no new ssh connection and no remote shell spawn (big win on high-RTT /
+  # GSSAPI links). Discover the socket from `ssh -G` by matching the forward
+  # whose remote end is this session's tmux socket; require the local socket to
+  # exist (main connection up) and the local tmux to speak the server's
+  # protocol (else the command fails fast and we fall back below).
+  if command -v tmux >/dev/null 2>&1; then
+    localsock="$(ssh -G "$dest" 2>/dev/null \
+      | awk -v r="$F_TMUX_SOCKET" 'tolower($1)=="localforward" && $3==r {print $2; exit}')"
+    if [ -n "$localsock" ] && [ -S "$localsock" ]; then
+      # F_TMUX_PANE is regex-validated. One chained invocation = one round-trip.
+      if tmux -S "$localsock" switch-client -t "$F_TMUX_PANE" \; \
+              select-window -t "$F_TMUX_PANE" \; \
+              select-pane -t "$F_TMUX_PANE" >/dev/null 2>&1; then
+        switched=1
+        _dbg "switched via forwarded socket=$localsock"
+      else
+        _dbg "forwarded socket present but tmux failed (version mismatch?) socket=$localsock"
+      fi
+    fi
+  fi
+
+  # Fallback: run tmux ON the remote over ssh, reusing the (possibly prewarmed)
+  # ControlMaster. Used when there's no tunnel (main connection down / not
+  # configured) or the local/remote tmux versions differ.
+  if [ "$switched" = "0" ]; then
+    # F_TMUX_SOCKET / F_TMUX_PANE / RTMUX are regex-validated. Separate tmux
+    # invocations (not tmux's `;`) so each survives the remote shell.
+    remote_cmd="$RTMUX -S $F_TMUX_SOCKET switch-client -t $F_TMUX_PANE 2>/dev/null; $RTMUX -S $F_TMUX_SOCKET select-window -t $F_TMUX_PANE 2>/dev/null; $RTMUX -S $F_TMUX_SOCKET select-pane -t $F_TMUX_PANE 2>/dev/null"
+    TO=""
+    if command -v timeout >/dev/null 2>&1; then TO="timeout 8"
+    elif command -v gtimeout >/dev/null 2>&1; then TO="gtimeout 8"; fi
+    nohup $TO ssh "${SSH_CM[@]}" -o ConnectTimeout=8 "$dest" "$remote_cmd" \
+      >/dev/null 2>&1 &
+  fi
+fi
+
+exit 0


### PR DESCRIPTION
Not for merge. One CI run validating the two click-to-focus PRs together, since both touch `peon.sh` near `send_notification` and #562 also touches `relay.sh`.

- **#565** resolves the hosting terminal at click time by asking tmux which client is attached, instead of reading `ITERM_SESSION_ID` / `GHOSTTY_RESOURCES_DIR` / `WARP_IS_LOCAL_SHELL_SESSION` out of the hook's own environment. A pane's environment is frozen when the pane is created, so inside tmux that value names whichever emulator the session was *first* attached from, forever. It also fixes kitty and alacritty, which export none of those and were producing an empty bundle id, so `activateBundle()` no-opped and the notification looked dead.
- **#562** carries click-to-focus context through the relay for remote SSH sessions, which previously POSTed only `{title,message,color}` and dropped everything else, then raises the local terminal tab and switches the remote tmux to the agent's pane. `validate_focus()` whitelist-validates every field and drops the whole object on any mismatch, and it scrubs the daemon's ambient `TMUX` so it cannot fabricate a local target.

They merge without conflict despite adjacent `peon.sh` regions (~751-1046 and ~1037-1113). Both had green CI already, but against a pre-#581 base when main was red, so this is their first run against a green main.