### PR TITLE
ci: batch D integration check (#572, #563)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+### Added
+- **Grok Build adapter.** Grok's hook stdin is camelCase (`hookEventName`, `sessionId`) with snake_case event values (`session_start`, `stop`), so calling `peon.sh` directly stays silent. `adapters/grok.sh` and `adapters/grok.ps1` translate that envelope to CESP. When `~/.grok` exists, `install.sh` / `install.ps1` write `~/.grok/hooks/peon-ping.json` for `SessionStart`, `UserPromptSubmit`, `Stop`, `StopFailure`, `Notification`, subagent start/stop, `PostToolUseFailure`, and `PreCompact`. Noisy per-tool hooks stay unregistered. Session-end `Stop` fires (`reason: shutdown` / `channel_closed`) are treated as cleanup, not a completion chime. `run_terminal_command` failures map to Bash so `task.error` still plays. Stop-gate stdout is discarded so a chime cannot keep the agent working.
+
 ## v2.36.0 (2026-08-09)
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,7 @@ IDE triggers hook → `peon.sh` reads JSON stdin → single Python call maps eve
 - **`adapters/kiro.sh`** — Translates Kiro CLI (Amazon) events to CESP JSON
 - **`adapters/windsurf.sh`** — Translates Windsurf Cascade hook events to CESP JSON
 - **`adapters/antigravity.sh`** — Filesystem watcher for Google Antigravity agent events
+- **`adapters/grok.sh`** — Translates Grok Build camelCase hook events to CESP JSON
 
 All adapters have native Windows PowerShell (`.ps1`) counterparts alongside the bash originals. Windows adapters pipe CESP JSON to `peon.ps1` instead of `peon.sh`. Filesystem watchers (amp, antigravity, kimi) use .NET `FileSystemWatcher` instead of fswatch/inotifywait.
 

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@
 ![macOS](https://img.shields.io/badge/macOS-blue) ![WSL2](https://img.shields.io/badge/WSL2-blue) ![Linux](https://img.shields.io/badge/Linux-blue) ![Windows](https://img.shields.io/badge/Windows-blue) ![MSYS2](https://img.shields.io/badge/MSYS2-blue) ![SSH](https://img.shields.io/badge/SSH-blue)
 ![License](https://img.shields.io/badge/license-MIT-green)
 
-![Claude Code](https://img.shields.io/badge/Claude_Code-hook-ffab01) ![Amp](https://img.shields.io/badge/Amp-adapter-ffab01) ![Gemini CLI](https://img.shields.io/badge/Gemini_CLI-adapter-ffab01) ![GitHub Copilot](https://img.shields.io/badge/GitHub_Copilot-adapter-ffab01) ![Codex](https://img.shields.io/badge/Codex-adapter-ffab01) ![Cursor](https://img.shields.io/badge/Cursor-adapter-ffab01) ![OpenCode](https://img.shields.io/badge/OpenCode-adapter-ffab01) ![Kilo CLI](https://img.shields.io/badge/Kilo_CLI-adapter-ffab01) ![Kiro](https://img.shields.io/badge/Kiro-adapter-ffab01) ![Kimi Code](https://img.shields.io/badge/Kimi_Code-adapter-ffab01) ![Windsurf](https://img.shields.io/badge/Windsurf-adapter-ffab01) ![Antigravity](https://img.shields.io/badge/Antigravity-adapter-ffab01) ![OpenClaw](https://img.shields.io/badge/OpenClaw-adapter-ffab01) ![Rovo Dev CLI](https://img.shields.io/badge/Rovo_Dev_CLI-adapter-ffab01) ![DeepAgents](https://img.shields.io/badge/DeepAgents-adapter-ffab01) ![oh-my-pi](https://img.shields.io/badge/oh--my--pi-adapter-ffab01) ![Qwen Code](https://img.shields.io/badge/Qwen_Code-adapter-ffab01) ![iFlow CLI](https://img.shields.io/badge/iFlow_CLI-adapter-ffab01) ![Trae](https://img.shields.io/badge/Trae-adapter-ffab01) ![Kiro IDE](https://img.shields.io/badge/Kiro_IDE-adapter-ffab01) ![ECA](https://img.shields.io/badge/ECA-adapter-ffab01)
+![Claude Code](https://img.shields.io/badge/Claude_Code-hook-ffab01) ![Amp](https://img.shields.io/badge/Amp-adapter-ffab01) ![Gemini CLI](https://img.shields.io/badge/Gemini_CLI-adapter-ffab01) ![GitHub Copilot](https://img.shields.io/badge/GitHub_Copilot-adapter-ffab01) ![Codex](https://img.shields.io/badge/Codex-adapter-ffab01) ![Grok Build](https://img.shields.io/badge/Grok_Build-adapter-ffab01) ![Cursor](https://img.shields.io/badge/Cursor-adapter-ffab01) ![OpenCode](https://img.shields.io/badge/OpenCode-adapter-ffab01) ![Kilo CLI](https://img.shields.io/badge/Kilo_CLI-adapter-ffab01) ![Kiro](https://img.shields.io/badge/Kiro-adapter-ffab01) ![Kimi Code](https://img.shields.io/badge/Kimi_Code-adapter-ffab01) ![Windsurf](https://img.shields.io/badge/Windsurf-adapter-ffab01) ![Antigravity](https://img.shields.io/badge/Antigravity-adapter-ffab01) ![OpenClaw](https://img.shields.io/badge/OpenClaw-adapter-ffab01) ![Rovo Dev CLI](https://img.shields.io/badge/Rovo_Dev_CLI-adapter-ffab01) ![DeepAgents](https://img.shields.io/badge/DeepAgents-adapter-ffab01) ![oh-my-pi](https://img.shields.io/badge/oh--my--pi-adapter-ffab01) ![Qwen Code](https://img.shields.io/badge/Qwen_Code-adapter-ffab01) ![iFlow CLI](https://img.shields.io/badge/iFlow_CLI-adapter-ffab01) ![Trae](https://img.shields.io/badge/Trae-adapter-ffab01) ![Kiro IDE](https://img.shields.io/badge/Kiro_IDE-adapter-ffab01) ![ECA](https://img.shields.io/badge/ECA-adapter-ffab01)
 
 **Game character voice lines + visual overlay notifications when your AI coding agent needs attention — or let the agent pick its own sound via MCP.**
 
-AI coding agents don't notify you when they finish or need permission. You tab away, lose focus, and waste 15 minutes getting back into flow. peon-ping fixes this with voice lines and bold on-screen banners from Warcraft, StarCraft, Portal, Zelda, and more — works with **Claude Code**, **Amp**, **GitHub Copilot**, **Codex**, **Cursor**, **OpenCode**, **Kilo CLI**, **Kiro**, **Kimi Code**, **Windsurf**, **Google Antigravity**, **Rovo Dev CLI**, **DeepAgents**, **Qwen Code**, **iFlow CLI**, **Trae**, **Kiro IDE**, **ECA**, and any MCP client.
+AI coding agents don't notify you when they finish or need permission. You tab away, lose focus, and waste 15 minutes getting back into flow. peon-ping fixes this with voice lines and bold on-screen banners from Warcraft, StarCraft, Portal, Zelda, and more — works with **Claude Code**, **Amp**, **GitHub Copilot**, **Codex**, **Grok Build**, **Cursor**, **OpenCode**, **Kilo CLI**, **Kiro**, **Kimi Code**, **Windsurf**, **Google Antigravity**, **Rovo Dev CLI**, **DeepAgents**, **Qwen Code**, **iFlow CLI**, **Trae**, **Kiro IDE**, **ECA**, and any MCP client.
 
 **See it in action** &rarr; [peonping.com](https://peonping.com/)
 
@@ -726,6 +726,7 @@ peon-ping works with any agentic IDE that supports hooks. Adapters translate IDE
 | **Gemini CLI** | Adapter | Add hooks pointing to `adapters/gemini.sh` (or `.ps1` on Windows) ([setup](#gemini-cli-setup)) |
 | **GitHub Copilot CLI** | Built-in (auto-detect) | `install.sh` / `install.ps1` auto-registers hooks at `~/.copilot/hooks/peon-ping.json` if `~/.copilot` exists. Per-repo manual wiring also available via `adapters/copilot.sh` / `.ps1` ([setup](#github-copilot-cli-setup)) |
 | **OpenAI Codex** | Built-in (auto-detect) | `install.sh` / `install.ps1` auto-registers stable hooks in `~/.codex/config.toml` if `~/.codex` exists. The adapter is also available for manual wiring ([setup](#openai-codex-setup)) |
+| **Grok Build** | Built-in (auto-detect) | `install.sh` / `install.ps1` auto-register hooks at `~/.grok/hooks/peon-ping.json` if `~/.grok` exists. The adapter is also available for manual wiring ([setup](#grok-build-setup)) |
 | **Cursor** | Built-in | `curl \| bash`, `peon-ping-setup`, or Windows `install.ps1` auto-detect and register hooks. On Windows, enable **Settings → Features → Third-party skills** so Cursor loads `~/.claude/settings.json` for SessionStart/Stop sounds. |
 | **OpenCode** | Adapter | `bash adapters/opencode.sh` / `powershell adapters/opencode.ps1` ([setup](#opencode-setup)) |
 | **Kilo CLI** | Adapter | `bash adapters/kilo.sh` / `powershell adapters/kilo.ps1` ([setup](#kilo-cli-setup)) |
@@ -770,6 +771,22 @@ The registered Codex events are `SessionStart`, `UserPromptSubmit`, `PermissionR
 3. Restart Codex if it was already running during installation.
 
 peon-ping writes inline hooks to `~/.codex/config.toml` instead of creating `hooks.json`, matching the [Codex hooks documentation](https://developers.openai.com/codex/hooks) guidance to avoid mixing both hook representations in the same config layer. Legacy `notify` wiring still works as a fallback, but new installs should use the stable hooks path.
+
+### Grok Build setup
+
+Grok Build sends camelCase hook payloads (`hookEventName`, `sessionId`, `notificationType`) with snake_case event values (`session_start`, `stop`). That is not what `peon.sh` reads natively, so peon-ping ships `adapters/grok.sh` (and `grok.ps1` on Windows) instead of pointing Grok at `peon.sh` directly.
+
+If `~/.grok` already exists, the Unix and Windows installers write `~/.grok/hooks/peon-ping.json` automatically. If you install Grok Build later, re-run the peon-ping installer.
+
+Registered events: `SessionStart`, `SessionEnd`, `UserPromptSubmit`, `Stop`, `StopFailure`, `Notification`, `SubagentStart`, `SubagentStop`, `PostToolUseFailure`, and `PreCompact`. `PreToolUse`, `PostToolUse`, `PostCompact`, and `PermissionDenied` are left unregistered — per-tool hooks are too noisy. Session-end `Stop` fires (`reason: shutdown` or `channel_closed`) are treated as cleanup, not a completion chime. Shell failures arrive as `toolName: run_terminal_command` and are rewritten to Bash so `task.error` still plays.
+
+**Setup:**
+
+1. Install the peon-ping runtime (`curl | bash`, Homebrew + `peon-ping-setup`, or `install.ps1`).
+
+2. If Grok was already running, reload hooks with `/hooks` then `r`, or start a new session. Project hooks need `/hooks-trust` once; `~/.grok/hooks/` is always trusted.
+
+Grok can also scan `~/.claude/settings.json`. Those Claude hooks still call `peon.sh` with Grok's camelCase envelope, so they stay silent. The native `~/.grok/hooks/peon-ping.json` file is the one that actually plays sounds. To hide the unused Claude entries from Grok's `/hooks` list, set `[compat.claude] hooks = false` in `~/.grok/config.toml`.
 
 ### Amp setup
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -6,7 +6,7 @@
 ![macOS](https://img.shields.io/badge/macOS-blue) ![WSL2](https://img.shields.io/badge/WSL2-blue) ![Linux](https://img.shields.io/badge/Linux-blue) ![Windows](https://img.shields.io/badge/Windows-blue) ![MSYS2](https://img.shields.io/badge/MSYS2-blue) ![SSH](https://img.shields.io/badge/SSH-blue)
 ![License](https://img.shields.io/badge/license-MIT-green)
 
-![Claude Code](https://img.shields.io/badge/Claude_Code-hook-ffab01) ![Amp](https://img.shields.io/badge/Amp-adapter-ffab01) ![Gemini CLI](https://img.shields.io/badge/Gemini_CLI-adapter-ffab01) ![GitHub Copilot](https://img.shields.io/badge/GitHub_Copilot-adapter-ffab01) ![Codex](https://img.shields.io/badge/Codex-adapter-ffab01) ![Cursor](https://img.shields.io/badge/Cursor-adapter-ffab01) ![OpenCode](https://img.shields.io/badge/OpenCode-adapter-ffab01) ![Kilo CLI](https://img.shields.io/badge/Kilo_CLI-adapter-ffab01) ![Kiro](https://img.shields.io/badge/Kiro-adapter-ffab01) ![Kimi Code](https://img.shields.io/badge/Kimi_Code-adapter-ffab01) ![Windsurf](https://img.shields.io/badge/Windsurf-adapter-ffab01) ![Antigravity](https://img.shields.io/badge/Antigravity-adapter-ffab01) ![OpenClaw](https://img.shields.io/badge/OpenClaw-adapter-ffab01) ![Rovo Dev CLI](https://img.shields.io/badge/Rovo_Dev_CLI-adapter-ffab01) ![DeepAgents](https://img.shields.io/badge/DeepAgents-adapter-ffab01) ![oh-my-pi](https://img.shields.io/badge/oh--my--pi-adapter-ffab01)
+![Claude Code](https://img.shields.io/badge/Claude_Code-hook-ffab01) ![Amp](https://img.shields.io/badge/Amp-adapter-ffab01) ![Gemini CLI](https://img.shields.io/badge/Gemini_CLI-adapter-ffab01) ![GitHub Copilot](https://img.shields.io/badge/GitHub_Copilot-adapter-ffab01) ![Codex](https://img.shields.io/badge/Codex-adapter-ffab01) ![Grok Build](https://img.shields.io/badge/Grok_Build-adapter-ffab01) ![Cursor](https://img.shields.io/badge/Cursor-adapter-ffab01) ![OpenCode](https://img.shields.io/badge/OpenCode-adapter-ffab01) ![Kilo CLI](https://img.shields.io/badge/Kilo_CLI-adapter-ffab01) ![Kiro](https://img.shields.io/badge/Kiro-adapter-ffab01) ![Kimi Code](https://img.shields.io/badge/Kimi_Code-adapter-ffab01) ![Windsurf](https://img.shields.io/badge/Windsurf-adapter-ffab01) ![Antigravity](https://img.shields.io/badge/Antigravity-adapter-ffab01) ![OpenClaw](https://img.shields.io/badge/OpenClaw-adapter-ffab01) ![Rovo Dev CLI](https://img.shields.io/badge/Rovo_Dev_CLI-adapter-ffab01) ![DeepAgents](https://img.shields.io/badge/DeepAgents-adapter-ffab01) ![oh-my-pi](https://img.shields.io/badge/oh--my--pi-adapter-ffab01)
 
 **AIコーディングエージェントが注意を必要とする時に、ゲームキャラクターのボイスライン＋ビジュアルオーバーレイ通知を再生 — またはMCPでエージェント自身にサウンドを選ばせることも可能。**
 
@@ -616,6 +616,7 @@ peon-ping はフックをサポートする任意のエージェント型 IDE �
 | **Gemini CLI** | アダプター | `adapters/gemini.sh`（Windows では `.ps1`）を指すフックを追加（[セットアップ](#gemini-cli-セットアップ)） |
 | **GitHub Copilot** | アダプター | `.github/hooks/hooks.json` に `adapters/copilot.sh`（または `.ps1`）を指すフックを追加（[セットアップ](#github-copilot-セットアップ)） |
 | **OpenAI Codex** | 組み込み（自動検出） | `~/.codex` が存在する場合、`install.sh` / `install.ps1` が `~/.codex/config.toml` に stable hooks を自動登録。アダプターの手動接続も可能（[セットアップ](#openai-codex-セットアップ)） |
+| **Grok Build** | 組み込み（自動検出） | `~/.grok` が存在する場合、`install.sh` / `install.ps1` が `~/.grok/hooks/peon-ping.json` にフックを自動登録。アダプターの手動接続も可能（[セットアップ](#grok-build-セットアップ)） |
 | **Cursor** | 組み込み | `curl \| bash`、`peon-ping-setup`、または Windows `install.ps1` が自動検出して登録。Windows では **設定 → 機能 → サードパーティスキル** を有効にして、Cursor が `~/.claude/settings.json` を読み込み SessionStart/Stop サウンドを再生するようにしてください。 |
 | **OpenCode** | アダプター | `bash adapters/opencode.sh` / `powershell adapters/opencode.ps1`（[セットアップ](#opencode-セットアップ)） |
 | **Kilo CLI** | アダプター | `bash adapters/kilo.sh` / `powershell adapters/kilo.ps1`（[セットアップ](#kilo-cli-セットアップ)） |
@@ -635,6 +636,14 @@ peon-ping はフックをサポートする任意のエージェント型 IDE �
 Codex サポートは stable Codex hooks API と peon-ping アダプターを使用します。`~/.codex` がすでに存在する場合、Unix / Windows インストーラーは `~/.codex/config.toml` に peon 管理の設定ブロックを自動で追加します。Codex を後からインストールした場合は、peon-ping インストーラーを再実行してください。
 
 登録される Codex イベントは `SessionStart`、`UserPromptSubmit`、`PermissionRequest`、`PreCompact`、`SubagentStart`、`SubagentStop`、`Stop` です。`SessionStart` は `startup`、`resume`、`clear` にだけマッチします。Codex のコンテキスト圧縮は `PreCompact` で扱うため、compact 起点の `SessionStart` はスキップします。`PreToolUse`、`PostToolUse`、`PostCompact` は意図的に登録しません。Codex には失敗専用の別 hook がなく、成功したツール hook は peon-ping には多すぎるため、Codex アダプターは `PostToolUse` を無視します。
+
+### Grok Build セットアップ
+
+Grok Build のフック入力は camelCase（`hookEventName`、`sessionId`）で、イベント値は snake_case（`session_start`、`stop`）です。`peon.sh` はその形式を直接読めないため、`adapters/grok.sh`（Windows では `grok.ps1`）を使います。
+
+`~/.grok` が既にあれば、インストーラーが `~/.grok/hooks/peon-ping.json` を自動で書き込みます。Grok Build を後から入れた場合は peon-ping インストーラーを再実行してください。
+
+登録イベント: `SessionStart`、`SessionEnd`、`UserPromptSubmit`、`Stop`、`StopFailure`、`Notification`、`SubagentStart`、`SubagentStop`、`PostToolUseFailure`、`PreCompact`。セッション終了時の `Stop`（`shutdown` / `channel_closed`）は完了音ではなくクリーンアップとして扱います。既に起動中の Grok では `/hooks` のあと `r` で再読み込みするか、新しいセッションを開いてください。
 
 **セットアップ：**
 

--- a/README_ko.md
+++ b/README_ko.md
@@ -6,7 +6,7 @@
 ![macOS](https://img.shields.io/badge/macOS-blue) ![WSL2](https://img.shields.io/badge/WSL2-blue) ![Linux](https://img.shields.io/badge/Linux-blue) ![Windows](https://img.shields.io/badge/Windows-blue) ![MSYS2](https://img.shields.io/badge/MSYS2-blue) ![SSH](https://img.shields.io/badge/SSH-blue)
 ![License](https://img.shields.io/badge/license-MIT-green)
 
-![Claude Code](https://img.shields.io/badge/Claude_Code-hook-ffab01) ![Amp](https://img.shields.io/badge/Amp-adapter-ffab01) ![Gemini CLI](https://img.shields.io/badge/Gemini_CLI-adapter-ffab01) ![GitHub Copilot](https://img.shields.io/badge/GitHub_Copilot-adapter-ffab01) ![Codex](https://img.shields.io/badge/Codex-adapter-ffab01) ![Cursor](https://img.shields.io/badge/Cursor-adapter-ffab01) ![OpenCode](https://img.shields.io/badge/OpenCode-adapter-ffab01) ![Kilo CLI](https://img.shields.io/badge/Kilo_CLI-adapter-ffab01) ![Kiro](https://img.shields.io/badge/Kiro-adapter-ffab01) ![Windsurf](https://img.shields.io/badge/Windsurf-adapter-ffab01) ![Antigravity](https://img.shields.io/badge/Antigravity-adapter-ffab01) ![OpenClaw](https://img.shields.io/badge/OpenClaw-adapter-ffab01) ![oh-my-pi](https://img.shields.io/badge/oh--my--pi-adapter-ffab01)
+![Claude Code](https://img.shields.io/badge/Claude_Code-hook-ffab01) ![Amp](https://img.shields.io/badge/Amp-adapter-ffab01) ![Gemini CLI](https://img.shields.io/badge/Gemini_CLI-adapter-ffab01) ![GitHub Copilot](https://img.shields.io/badge/GitHub_Copilot-adapter-ffab01) ![Codex](https://img.shields.io/badge/Codex-adapter-ffab01) ![Grok Build](https://img.shields.io/badge/Grok_Build-adapter-ffab01) ![Cursor](https://img.shields.io/badge/Cursor-adapter-ffab01) ![OpenCode](https://img.shields.io/badge/OpenCode-adapter-ffab01) ![Kilo CLI](https://img.shields.io/badge/Kilo_CLI-adapter-ffab01) ![Kiro](https://img.shields.io/badge/Kiro-adapter-ffab01) ![Windsurf](https://img.shields.io/badge/Windsurf-adapter-ffab01) ![Antigravity](https://img.shields.io/badge/Antigravity-adapter-ffab01) ![OpenClaw](https://img.shields.io/badge/OpenClaw-adapter-ffab01) ![oh-my-pi](https://img.shields.io/badge/oh--my--pi-adapter-ffab01)
 
 **AI 코딩 에이전트가 관심을 요청할 때 게임 캐릭터 음성 + 시각 오버레이 알림을 재생하거나, MCP를 통해 에이전트가 직접 효과음을 선택할 수 있습니다.**
 
@@ -322,6 +322,7 @@ peon-ping은 훅을 지원하는 모든 에이전트 기반 IDE에서 동작합�
 | **Gemini CLI** | 어댑터 | `~/.gemini/settings.json`에 `adapters/gemini.sh` 훅 추가 ([설정](#gemini-cli-설정)) |
 | **GitHub Copilot** | 어댑터 | `.github/hooks/hooks.json`에 `adapters/copilot.sh` 훅 추가 ([설정](#github-copilot-설정)) |
 | **OpenAI Codex** | 내장(자동 감지) | `~/.codex`가 있으면 `install.sh` / `install.ps1`이 `~/.codex/config.toml`에 stable hooks를 자동 등록. 수동 어댑터 연결도 가능 ([설정](#openai-codex-설정)) |
+| **Grok Build** | 내장(자동 감지) | `~/.grok`가 있으면 `install.sh` / `install.ps1`이 `~/.grok/hooks/peon-ping.json`에 훅을 자동 등록. 수동 어댑터 연결도 가능 ([설정](#grok-build-설정)) |
 | **Cursor** | 내장 | `curl \| bash` 또는 `peon-ping-setup`이 자동 감지 후 Cursor 훅 등록 |
 | **OpenCode** | 어댑터 | `curl -fsSL https://raw.githubusercontent.com/PeonPing/peon-ping/main/adapters/opencode.sh \| bash` ([설정](#opencode-설정)) |
 | **Kilo CLI** | 어댑터 | `curl -fsSL https://raw.githubusercontent.com/PeonPing/peon-ping/main/adapters/kilo.sh \| bash` ([설정](#kilo-cli-설정)) |
@@ -336,6 +337,14 @@ peon-ping은 훅을 지원하는 모든 에이전트 기반 IDE에서 동작합�
 `~/.codex`가 이미 있으면 Unix/Windows 설치 관리자가 `~/.codex/config.toml`에 peon-ping 관리 stable hooks 블록을 자동으로 추가합니다. Codex를 나중에 설치했다면 peon-ping 설치 관리자를 다시 실행하세요.
 
 등록되는 이벤트는 `SessionStart`, `UserPromptSubmit`, `PermissionRequest`, `PreCompact`, `SubagentStart`, `SubagentStop`, `Stop`입니다. `SessionStart`는 `startup`, `resume`, `clear`에만 매칭되며, 압축 흐름은 `PreCompact`가 처리합니다. `PreToolUse`, `PostToolUse`, `PostCompact`는 등록하지 않으며, Codex 어댑터는 `PostToolUse`를 무시합니다. Codex가 요청하면 `/hooks`에서 peon-ping 명령을 검토하고 신뢰 처리하세요.
+
+### Grok Build 설정
+
+Grok Build 훅 입력은 camelCase(`hookEventName`, `sessionId`)이고 이벤트 값은 snake_case(`session_start`, `stop`)입니다. `peon.sh`는 이 형식을 바로 읽지 못하므로 `adapters/grok.sh`(Windows는 `grok.ps1`)를 사용합니다.
+
+`~/.grok`가 이미 있으면 설치 관리자가 `~/.grok/hooks/peon-ping.json`을 자동으로 씁니다. Grok Build를 나중에 설치했다면 peon-ping 설치 관리자를 다시 실행하세요.
+
+등록 이벤트: `SessionStart`, `SessionEnd`, `UserPromptSubmit`, `Stop`, `StopFailure`, `Notification`, `SubagentStart`, `SubagentStop`, `PostToolUseFailure`, `PreCompact`. 세션 종료 `Stop`(`shutdown` / `channel_closed`)은 완료음이 아니라 정리로 처리합니다. 이미 실행 중인 Grok에서는 `/hooks` 후 `r`로 다시 읽거나 새 세션을 여세요.
 
 **설정 방법:**
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -6,11 +6,11 @@
 ![macOS](https://img.shields.io/badge/macOS-blue) ![WSL2](https://img.shields.io/badge/WSL2-blue) ![Linux](https://img.shields.io/badge/Linux-blue) ![Windows](https://img.shields.io/badge/Windows-blue) ![MSYS2](https://img.shields.io/badge/MSYS2-blue) ![SSH](https://img.shields.io/badge/SSH-blue)
 ![License](https://img.shields.io/badge/license-MIT-green)
 
-![Claude Code](https://img.shields.io/badge/Claude_Code-hook-ffab01) ![Amp](https://img.shields.io/badge/Amp-adapter-ffab01) ![Gemini CLI](https://img.shields.io/badge/Gemini_CLI-adapter-ffab01) ![GitHub Copilot](https://img.shields.io/badge/GitHub_Copilot-adapter-ffab01) ![Codex](https://img.shields.io/badge/Codex-adapter-ffab01) ![Cursor](https://img.shields.io/badge/Cursor-adapter-ffab01) ![OpenCode](https://img.shields.io/badge/OpenCode-adapter-ffab01) ![Kilo CLI](https://img.shields.io/badge/Kilo_CLI-adapter-ffab01) ![Kiro](https://img.shields.io/badge/Kiro-adapter-ffab01) ![Kimi Code](https://img.shields.io/badge/Kimi_Code-adapter-ffab01) ![Windsurf](https://img.shields.io/badge/Windsurf-adapter-ffab01) ![Antigravity](https://img.shields.io/badge/Antigravity-adapter-ffab01) ![OpenClaw](https://img.shields.io/badge/OpenClaw-adapter-ffab01) ![Rovo Dev CLI](https://img.shields.io/badge/Rovo_Dev_CLI-adapter-ffab01) ![DeepAgents](https://img.shields.io/badge/DeepAgents-adapter-ffab01) ![oh-my-pi](https://img.shields.io/badge/oh--my--pi-adapter-ffab01) ![Qwen Code](https://img.shields.io/badge/Qwen_Code-adapter-ffab01) ![iFlow CLI](https://img.shields.io/badge/iFlow_CLI-adapter-ffab01) ![Trae](https://img.shields.io/badge/Trae-adapter-ffab01) ![Kiro IDE](https://img.shields.io/badge/Kiro_IDE-adapter-ffab01) ![ECA](https://img.shields.io/badge/ECA-adapter-ffab01)
+![Claude Code](https://img.shields.io/badge/Claude_Code-hook-ffab01) ![Amp](https://img.shields.io/badge/Amp-adapter-ffab01) ![Gemini CLI](https://img.shields.io/badge/Gemini_CLI-adapter-ffab01) ![GitHub Copilot](https://img.shields.io/badge/GitHub_Copilot-adapter-ffab01) ![Codex](https://img.shields.io/badge/Codex-adapter-ffab01) ![Grok Build](https://img.shields.io/badge/Grok_Build-adapter-ffab01) ![Cursor](https://img.shields.io/badge/Cursor-adapter-ffab01) ![OpenCode](https://img.shields.io/badge/OpenCode-adapter-ffab01) ![Kilo CLI](https://img.shields.io/badge/Kilo_CLI-adapter-ffab01) ![Kiro](https://img.shields.io/badge/Kiro-adapter-ffab01) ![Kimi Code](https://img.shields.io/badge/Kimi_Code-adapter-ffab01) ![Windsurf](https://img.shields.io/badge/Windsurf-adapter-ffab01) ![Antigravity](https://img.shields.io/badge/Antigravity-adapter-ffab01) ![OpenClaw](https://img.shields.io/badge/OpenClaw-adapter-ffab01) ![Rovo Dev CLI](https://img.shields.io/badge/Rovo_Dev_CLI-adapter-ffab01) ![DeepAgents](https://img.shields.io/badge/DeepAgents-adapter-ffab01) ![oh-my-pi](https://img.shields.io/badge/oh--my--pi-adapter-ffab01) ![Qwen Code](https://img.shields.io/badge/Qwen_Code-adapter-ffab01) ![iFlow CLI](https://img.shields.io/badge/iFlow_CLI-adapter-ffab01) ![Trae](https://img.shields.io/badge/Trae-adapter-ffab01) ![Kiro IDE](https://img.shields.io/badge/Kiro_IDE-adapter-ffab01) ![ECA](https://img.shields.io/badge/ECA-adapter-ffab01)
 
 **当你的 AI 编程助手需要关注时，播放游戏角色语音 + 显示视觉覆盖通知 — 或通过 MCP 让 AI 自行选择音效。**
 
-AI 编程助手完成任务或需要权限时不会通知你。你切换标签页、失去焦点，然后浪费 15 分钟重新进入状态。peon-ping 通过魔兽争霸、星际争霸、传送门、塞尔达等游戏的角色语音和醒目的屏幕横幅来解决这个问题 — 支持 **Claude Code**、**Amp**、**Gemini CLI**、**GitHub Copilot**、**Codex**、**Cursor**、**OpenCode**、**Kilo CLI**、**Kiro**、**Kimi Code**、**Windsurf**、**Google Antigravity**、**Rovo Dev CLI**、**DeepAgents**、**Qwen Code**、**iFlow CLI**、**Trae**、**Kiro IDE**、**ECA** 及任何 MCP 客户端.
+AI 编程助手完成任务或需要权限时不会通知你。你切换标签页、失去焦点，然后浪费 15 分钟重新进入状态。peon-ping 通过魔兽争霸、星际争霸、传送门、塞尔达等游戏的角色语音和醒目的屏幕横幅来解决这个问题 — 支持 **Claude Code**、**Amp**、**Gemini CLI**、**GitHub Copilot**、**Codex**、**Grok Build**、**Cursor**、**OpenCode**、**Kilo CLI**、**Kiro**、**Kimi Code**、**Windsurf**、**Google Antigravity**、**Rovo Dev CLI**、**DeepAgents**、**Qwen Code**、**iFlow CLI**、**Trae**、**Kiro IDE**、**ECA** 及任何 MCP 客户端.
 
 **查看演示** &rarr; [peonping.com](https://peonping.com/)
 
@@ -616,6 +616,7 @@ peon-ping 适用于任何支持钩子的代理式 IDE。适配器将 IDE 特定�
 | **Gemini CLI** | 适配器 | 添加指向 `adapters/gemini.sh`（Windows 用 `.ps1`）的钩子（[设置](#gemini-cli-设置)） |
 | **GitHub Copilot CLI** | 内置（自动检测） | 当 `~/.copilot` 存在时，`install.sh` / `install.ps1` 自动在 `~/.copilot/hooks/peon-ping.json` 注册钩子。也可通过 `adapters/copilot.sh` / `.ps1` 进行逐仓库手动配置（[设置](#github-copilot-cli-设置)） |
 | **OpenAI Codex** | 内置（自动检测） | 如果 `~/.codex` 存在，`install.sh` / `install.ps1` 会自动在 `~/.codex/config.toml` 注册 stable hooks。也可手动接入适配器（[设置](#openai-codex-设置)） |
+| **Grok Build** | 内置（自动检测） | 如果 `~/.grok` 存在，`install.sh` / `install.ps1` 会自动在 `~/.grok/hooks/peon-ping.json` 注册钩子。也可手动接入适配器（[设置](#grok-build-设置)） |
 | **Cursor** | 内置 | `curl \| bash`、`peon-ping-setup` 或 Windows `install.ps1` 自动检测并注册钩子。在 Windows 上，请在 **设置 → 功能 → 第三方技能** 中启用，以便 Cursor 加载 `~/.claude/settings.json` 以播放 SessionStart/Stop 音效。 |
 | **OpenCode** | 适配器 | `bash adapters/opencode.sh` / `powershell adapters/opencode.ps1`（[设置](#opencode-设置)） |
 | **Kilo CLI** | 适配器 | `bash adapters/kilo.sh` / `powershell adapters/kilo.ps1`（[设置](#kilo-cli-设置)） |
@@ -640,6 +641,16 @@ peon-ping 适用于任何支持钩子的代理式 IDE。适配器将 IDE 特定�
 Codex 支持使用 stable Codex hooks API 和 peon-ping 适配器。如果 `~/.codex` 已存在，Unix 和 Windows 安装器会自动向 `~/.codex/config.toml` 写入 peon 管理的配置块。如果你先安装了 peon-ping、之后才安装 Codex，请重新运行 peon-ping 安装器。
 
 默认注册的 Codex 事件包括 `SessionStart`、`UserPromptSubmit`、`PermissionRequest`、`PreCompact`、`SubagentStart`、`SubagentStop` 和 `Stop`。`SessionStart` 只匹配 `startup`、`resume` 和 `clear`；Codex 的上下文压缩由 `PreCompact` 处理，因此会跳过 compact 触发的 `SessionStart`。`PreToolUse`、`PostToolUse` 和 `PostCompact` 会刻意跳过；Codex 适配器会忽略 `PostToolUse`，因为 Codex 没有单独的失败专用 hook，而成功工具调用 hook 对 peon-ping 来说过于频繁。
+
+### Grok Build 设置
+
+Grok Build 的 hook 负载是 camelCase（`hookEventName`、`sessionId`、`notificationType`），事件值是 snake_case（`session_start`、`stop`），`peon.sh` 无法直接识别。因此 peon-ping 提供 `adapters/grok.sh`（Windows 上为 `grok.ps1`）。
+
+如果 `~/.grok` 已存在，Unix 和 Windows 安装器会自动写入 `~/.grok/hooks/peon-ping.json`。如果你先装了 peon-ping、之后才装 Grok Build，请重新运行安装器。
+
+默认注册的事件：`SessionStart`、`SessionEnd`、`UserPromptSubmit`、`Stop`、`StopFailure`、`Notification`、`SubagentStart`、`SubagentStop`、`PostToolUseFailure`、`PreCompact`。`PreToolUse`、`PostToolUse`、`PostCompact` 和 `PermissionDenied` 不会注册。会话结束时的 `Stop`（`reason: shutdown` / `channel_closed`）只做清理，不会播放完成音。shell 失败的 `toolName` 是 `run_terminal_command`，适配器会改写成 Bash，这样 `task.error` 仍会响。
+
+若 Grok 会话已经在跑，用 `/hooks` 然后按 `r` 重载，或新开一个会话。Grok 也会扫描 `~/.claude/settings.json` 里的 hook，但那些调用带着 Grok 的 camelCase 负载，`peon.sh` 会静音；真正发声的是 `~/.grok/hooks/peon-ping.json`。若不想在 `/hooks` 里看到那批静音的 Claude 条目，可在 `~/.grok/config.toml` 里设置 `[compat.claude] hooks = false`。
 
 **设置步骤：**
 

--- a/adapters/grok.ps1
+++ b/adapters/grok.ps1
@@ -1,0 +1,145 @@
+# peon-ping adapter for Grok Build (Windows)
+# Translates Grok Build hook events into peon.ps1 stdin JSON.
+#
+# Grok sends camelCase stdin (hookEventName, sessionId, notificationType)
+# with snake_case event values (session_start, stop, notification).
+#
+# Setup: re-run install.ps1 after Grok Build creates ~/.grok, or point
+#   Grok's hooks at this script.
+
+$ErrorActionPreference = "SilentlyContinue"
+
+$PeonDir = if ($env:CLAUDE_PEON_DIR) { $env:CLAUDE_PEON_DIR }
+           else { Join-Path $env:USERPROFILE ".claude\hooks\peon-ping" }
+
+$PeonScript = Join-Path $PeonDir "peon.ps1"
+if (-not (Test-Path $PeonScript)) { exit 0 }
+
+$inputJson = $null
+try {
+    if ([Console]::IsInputRedirected) {
+        $stream = [Console]::OpenStandardInput()
+        $reader = New-Object System.IO.StreamReader($stream, [System.Text.Encoding]::UTF8)
+        $raw = $reader.ReadToEnd()
+        $reader.Close()
+        if ($raw) { $inputJson = $raw | ConvertFrom-Json }
+    }
+} catch { if ($env:PEON_DEBUG -eq "1") { Write-Warning "peon-ping: [grok] ConvertFrom-Json failed: $_" } }
+
+function Get-Field($obj, [string]$name) {
+    if ($null -eq $obj) { return $null }
+    return $obj.PSObject.Properties[$name].Value
+}
+
+function First-NonEmpty {
+    foreach ($value in $args) {
+        if ($null -eq $value) { continue }
+        $text = "$value".Trim()
+        if ($text) { return $text }
+    }
+    return ""
+}
+
+$rawEvent = First-NonEmpty $env:GROK_HOOK_EVENT (Get-Field $inputJson "hookEventName") (Get-Field $inputJson "hook_event_name") (Get-Field $inputJson "event")
+$eventKey = $rawEvent.ToString().Trim().ToLower().Replace("-", "_")
+$notifType = (First-NonEmpty (Get-Field $inputJson "notificationType") (Get-Field $inputJson "notification_type") (Get-Field $inputJson "type")).ToLower()
+$reason = (First-NonEmpty (Get-Field $inputJson "reason") (Get-Field $inputJson "stopReason") (Get-Field $inputJson "stop_reason")).ToLower()
+
+if ($eventKey -in @(
+    "pre_tool_use", "pretooluse",
+    "post_tool_use", "posttooluse",
+    "post_compact", "postcompact",
+    "permission_denied", "permissiondenied"
+)) {
+    exit 0
+}
+
+$mapped = $null
+$ntype = ""
+
+if ($eventKey -in @("session_start", "sessionstart")) {
+    $mapped = "SessionStart"
+} elseif ($eventKey -in @("session_end", "sessionend")) {
+    $mapped = "SessionEnd"
+} elseif ($eventKey -in @("user_prompt_submit", "userpromptsubmit")) {
+    $mapped = "UserPromptSubmit"
+} elseif ($eventKey -in @("subagent_start", "subagentstart")) {
+    $mapped = "SubagentStart"
+} elseif ($eventKey -in @("subagent_stop", "subagentstop", "subagent_end", "subagentend")) {
+    $mapped = "SubagentStop"
+} elseif ($eventKey -in @("pre_compact", "precompact")) {
+    $mapped = "PreCompact"
+} elseif ($eventKey -in @("post_tool_use_failure", "posttoolusefailure", "stop_failure", "stopfailure")) {
+    $mapped = "PostToolUseFailure"
+} elseif ($eventKey -eq "notification") {
+    if ($notifType -in @("permission_prompt", "permission", "approval_required")) {
+        $mapped = "PermissionRequest"
+        $ntype = "permission_prompt"
+    } elseif ($notifType -in @("idle_prompt", "idle")) {
+        $mapped = "Notification"
+        $ntype = "idle_prompt"
+    } elseif ($notifType -in @("elicitation_dialog", "elicitation", "question")) {
+        $mapped = "Notification"
+        $ntype = "elicitation_dialog"
+    } else {
+        exit 0
+    }
+} elseif ($eventKey -eq "stop") {
+    if ($reason -in @("channel_closed", "shutdown")) {
+        $mapped = "SessionEnd"
+    } elseif ($reason -and $reason -ne "end_turn") {
+        exit 0
+    } else {
+        $mapped = "Stop"
+    }
+} else {
+    exit 0
+}
+
+$rawSid = First-NonEmpty (Get-Field $inputJson "sessionId") (Get-Field $inputJson "session_id") $env:GROK_SESSION_ID "$PID"
+$safeSid = ($rawSid -replace '[^A-Za-z0-9._:-]', '-').Trim('-')
+if (-not $safeSid) { $safeSid = "$PID" }
+$sessionId = if ($safeSid.StartsWith("grok-")) { $safeSid } else { "grok-$safeSid" }
+
+$cwd = First-NonEmpty (Get-Field $inputJson "cwd") (Get-Field $inputJson "workspaceRoot") (Get-Field $inputJson "workspace_root") $env:GROK_WORKSPACE_ROOT $PWD.Path
+
+$payload = @{
+    hook_event_name   = $mapped
+    notification_type = $ntype
+    cwd               = $cwd
+    session_id        = $sessionId
+    permission_mode   = (First-NonEmpty (Get-Field $inputJson "permissionMode") (Get-Field $inputJson "permission_mode"))
+    source            = "grok"
+}
+
+$agentId = First-NonEmpty (Get-Field $inputJson "agentId") (Get-Field $inputJson "agent_id") (Get-Field $inputJson "subagentId") (Get-Field $inputJson "subagent_id")
+if ($agentId) { $payload["agent_id"] = $agentId }
+
+$agentType = First-NonEmpty (Get-Field $inputJson "agentType") (Get-Field $inputJson "agent_type") (Get-Field $inputJson "subagentType") (Get-Field $inputJson "subagent_type")
+if ($agentType) { $payload["agent_type"] = $agentType }
+
+$summary = First-NonEmpty (Get-Field $inputJson "lastAssistantMessage") (Get-Field $inputJson "last_assistant_message") (Get-Field $inputJson "transcript_summary") (Get-Field $inputJson "summary")
+if ($summary) {
+    $payload["last_assistant_message"] = $summary
+    $payload["transcript_summary"] = $summary
+}
+
+if ($mapped -eq "PostToolUseFailure") {
+    $tn = First-NonEmpty (Get-Field $inputJson "toolName") (Get-Field $inputJson "tool_name") (Get-Field $inputJson "tool")
+    $shellTools = @("bash", "run_terminal_command", "shell")
+    if ((-not $tn) -or ($tn.ToLower() -in $shellTools) -or ($eventKey -in @("stop_failure", "stopfailure"))) {
+        $payload["tool_name"] = "Bash"
+    } else {
+        $payload["tool_name"] = $tn
+    }
+    $err = First-NonEmpty (Get-Field $inputJson "errorDetails") (Get-Field $inputJson "error_details") (Get-Field $inputJson "error") (Get-Field $inputJson "message") $summary
+    if (-not $err) { $err = "Grok event: $rawEvent" }
+    $payload["error"] = $err
+}
+
+$payloadJson = $payload | ConvertTo-Json -Compress
+
+# Discard peon.ps1 stdout so a Stop gate can never parse a chime as a decision.
+$payloadJson | powershell -NoProfile -NonInteractive -File $PeonScript >$null 2>$null
+
+exit 0

--- a/adapters/grok.sh
+++ b/adapters/grok.sh
@@ -1,0 +1,262 @@
+#!/bin/bash
+# peon-ping adapter for Grok Build
+# Translates Grok Build hook events into peon.sh stdin JSON.
+#
+# Grok sends camelCase stdin (hookEventName, sessionId, notificationType)
+# with snake_case event values (session_start, stop, notification). peon.sh
+# expects Claude-style PascalCase hook_event_name. This adapter translates
+# and then calls peon.sh.
+#
+# Setup: if ~/.grok already exists, install.sh / install.ps1 write
+#   ~/.grok/hooks/peon-ping.json automatically. Re-run the installer after
+#   installing Grok Build, or point Grok's hooks at this script by hand.
+#
+# Grok's Stop / SubagentStop hooks are stop-gates: anything that looks like
+# decision JSON on stdout can keep the agent working. peon.sh output is
+# discarded so a chime can never be parsed as a gate decision.
+
+set -euo pipefail
+
+PEON_DIR="${CLAUDE_PEON_DIR:-${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/peon-ping}"
+PEON_SH="$PEON_DIR/peon.sh"
+[ -f "$PEON_SH" ] || exit 0
+
+if [ -t 0 ]; then
+  GROK_STDIN=""
+else
+  GROK_STDIN="$(cat)"
+fi
+
+MAPPED_JSON="$(
+  _GROK_STDIN="$GROK_STDIN" python3 - <<'PY'
+import json
+import os
+import re
+import sys
+
+
+def first_non_empty(*values):
+    for value in values:
+        if value is None:
+            continue
+        if isinstance(value, str):
+            if value.strip():
+                return value.strip()
+        else:
+            return value
+    return ""
+
+
+raw_stdin = os.environ.get("_GROK_STDIN", "").strip()
+event_data = {}
+if raw_stdin:
+    try:
+        parsed = json.loads(raw_stdin)
+        if isinstance(parsed, dict):
+            event_data = parsed
+    except Exception:
+        event_data = {}
+
+raw_event = first_non_empty(
+    os.environ.get("GROK_HOOK_EVENT", ""),
+    event_data.get("hookEventName", ""),
+    event_data.get("hook_event_name", ""),
+    event_data.get("event", ""),
+)
+event_key = str(raw_event).strip().lower().replace("-", "_")
+
+notif_type = str(
+    first_non_empty(
+        event_data.get("notificationType", ""),
+        event_data.get("notification_type", ""),
+        event_data.get("type", ""),
+    )
+).strip().lower()
+
+reason = str(
+    first_non_empty(
+        event_data.get("reason", ""),
+        event_data.get("stopReason", ""),
+        event_data.get("stop_reason", ""),
+    )
+).strip().lower()
+
+# Per-tool hooks are too noisy. Completion / error / attention events
+# are the ones peon-ping has sounds for.
+if event_key in (
+    "pre_tool_use",
+    "pretooluse",
+    "post_tool_use",
+    "posttooluse",
+    "post_compact",
+    "postcompact",
+    "permission_denied",
+    "permissiondenied",
+):
+    sys.exit(0)
+
+if event_key in ("session_start", "sessionstart"):
+    mapped_event = "SessionStart"
+    mapped_ntype = ""
+elif event_key in ("session_end", "sessionend"):
+    mapped_event = "SessionEnd"
+    mapped_ntype = ""
+elif event_key in ("user_prompt_submit", "userpromptsubmit"):
+    mapped_event = "UserPromptSubmit"
+    mapped_ntype = ""
+elif event_key in ("subagent_start", "subagentstart"):
+    mapped_event = "SubagentStart"
+    mapped_ntype = ""
+elif event_key in ("subagent_stop", "subagentstop", "subagent_end", "subagentend"):
+    mapped_event = "SubagentStop"
+    mapped_ntype = ""
+elif event_key in ("pre_compact", "precompact"):
+    mapped_event = "PreCompact"
+    mapped_ntype = ""
+elif event_key in ("post_tool_use_failure", "posttoolusefailure"):
+    mapped_event = "PostToolUseFailure"
+    mapped_ntype = ""
+elif event_key in ("stop_failure", "stopfailure"):
+    mapped_event = "PostToolUseFailure"
+    mapped_ntype = ""
+elif event_key in ("notification",):
+    if notif_type in ("permission_prompt", "permission", "approval_required"):
+        mapped_event = "PermissionRequest"
+        mapped_ntype = "permission_prompt"
+    elif notif_type in ("idle_prompt", "idle"):
+        mapped_event = "Notification"
+        mapped_ntype = "idle_prompt"
+    elif notif_type in ("elicitation_dialog", "elicitation", "question"):
+        mapped_event = "Notification"
+        mapped_ntype = "elicitation_dialog"
+    elif notif_type in ("task_complete", "turn_complete"):
+        # Stop already covers genuine turn completion.
+        sys.exit(0)
+    else:
+        sys.exit(0)
+elif event_key in ("stop",):
+    # Grok also fires observe-only Stop at session end. Only chime on a
+    # real turn completion; treat session teardown as SessionEnd.
+    if reason in ("channel_closed", "shutdown"):
+        mapped_event = "SessionEnd"
+        mapped_ntype = ""
+    elif reason and reason != "end_turn":
+        sys.exit(0)
+    else:
+        mapped_event = "Stop"
+        mapped_ntype = ""
+else:
+    sys.exit(0)
+
+cwd = str(
+    first_non_empty(
+        event_data.get("cwd", ""),
+        event_data.get("workspaceRoot", ""),
+        event_data.get("workspace_root", ""),
+        os.environ.get("GROK_WORKSPACE_ROOT", ""),
+        os.environ.get("CLAUDE_PROJECT_DIR", ""),
+        os.environ.get("PWD", ""),
+        "/",
+    )
+)
+
+raw_session_id = str(
+    first_non_empty(
+        event_data.get("sessionId", ""),
+        event_data.get("session_id", ""),
+        os.environ.get("GROK_SESSION_ID", ""),
+        os.getpid(),
+    )
+)
+safe_session_id = re.sub(r"[^A-Za-z0-9._:-]", "-", raw_session_id).strip("-")
+if not safe_session_id:
+    safe_session_id = str(os.getpid())
+if safe_session_id.startswith("grok-"):
+    session_id = safe_session_id
+else:
+    session_id = f"grok-{safe_session_id}"
+
+payload = {
+    "hook_event_name": mapped_event,
+    "notification_type": mapped_ntype,
+    "cwd": cwd,
+    "session_id": session_id,
+    "permission_mode": str(
+        first_non_empty(
+            event_data.get("permissionMode", ""),
+            event_data.get("permission_mode", ""),
+            "",
+        )
+    ),
+    "source": "grok",
+}
+
+agent_id = first_non_empty(
+    event_data.get("agentId", ""),
+    event_data.get("agent_id", ""),
+    event_data.get("subagentId", ""),
+    event_data.get("subagent_id", ""),
+)
+if isinstance(agent_id, str) and agent_id:
+    payload["agent_id"] = agent_id[:80]
+
+agent_type = first_non_empty(
+    event_data.get("agentType", ""),
+    event_data.get("agent_type", ""),
+    event_data.get("subagentType", ""),
+    event_data.get("subagent_type", ""),
+)
+if isinstance(agent_type, str) and agent_type:
+    payload["agent_type"] = agent_type[:80]
+
+summary = first_non_empty(
+    event_data.get("lastAssistantMessage", ""),
+    event_data.get("last_assistant_message", ""),
+    event_data.get("transcript_summary", ""),
+    event_data.get("summary", ""),
+)
+if isinstance(summary, str) and summary:
+    payload["last_assistant_message"] = summary[:120]
+    payload["transcript_summary"] = summary[:120]
+
+tool_name = first_non_empty(
+    event_data.get("toolName", ""),
+    event_data.get("tool_name", ""),
+    event_data.get("tool", ""),
+)
+shell_tools = {"bash", "run_terminal_command", "shell"}
+if mapped_event == "PostToolUseFailure":
+    if str(tool_name).strip().lower() in shell_tools or event_key in ("stop_failure", "stopfailure"):
+        payload["tool_name"] = "Bash"
+    elif isinstance(tool_name, str) and tool_name:
+        payload["tool_name"] = tool_name[:64]
+    else:
+        payload["tool_name"] = "Bash"
+elif isinstance(tool_name, str) and tool_name:
+    payload["tool_name"] = tool_name[:64]
+
+error = first_non_empty(
+    event_data.get("errorDetails", ""),
+    event_data.get("error_details", ""),
+    event_data.get("error", ""),
+    event_data.get("message", ""),
+    summary,
+)
+if mapped_event == "PostToolUseFailure":
+    if not error:
+        error = f"Grok event: {raw_event or event_key}"
+    payload["error"] = str(error)[:180]
+
+print(json.dumps(payload))
+PY
+)" || MAPPED_JSON=""
+
+if [ -n "${MAPPED_JSON:-}" ]; then
+  # Discard peon.sh stdout so Stop/SubagentStop can never be parsed as a
+  # gate decision. SessionStart keeps stderr so update notices still surface.
+  if printf '%s' "$MAPPED_JSON" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("hook_event_name",""))' 2>/dev/null | grep -qx 'SessionStart'; then
+    printf '%s' "$MAPPED_JSON" | bash "$PEON_SH" >/dev/null || true
+  else
+    printf '%s' "$MAPPED_JSON" | bash "$PEON_SH" >/dev/null 2>&1 || true
+  fi
+fi

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -2,7 +2,7 @@
 
 > Game character voice lines + visual overlay notifications when your AI coding agent needs attention.
 
-peon-ping plays voice lines and shows bold on-screen overlay banners from Warcraft, StarCraft, Portal, Zelda, and 90+ other games when your AI coding agent finishes a task, needs permission, or hits an error. Works with Claude Code, Amp, GitHub Copilot, Cursor, OpenCode, Codex, Kiro, Kimi Code, Windsurf, DeepAgents, Qwen Code, iFlow CLI, Trae, Kiro IDE, ECA, and any MCP-compatible AI agent.
+peon-ping plays voice lines and shows bold on-screen overlay banners from Warcraft, StarCraft, Portal, Zelda, and 90+ other games when your AI coding agent finishes a task, needs permission, or hits an error. Works with Claude Code, Amp, GitHub Copilot, Cursor, OpenCode, Codex, Grok Build, Kiro, Kimi Code, Windsurf, DeepAgents, Qwen Code, iFlow CLI, Trae, Kiro IDE, ECA, and any MCP-compatible AI agent.
 
 ## Links
 
@@ -68,6 +68,7 @@ MCP resources: `peon-ping://catalog`, `peon-ping://pack/{name}`
 - Gemini CLI (adapter)
 - GitHub Copilot CLI (built-in: install.sh and install.ps1 auto-register PascalCase hooks at ~/.copilot/hooks/peon-ping.json when ~/.copilot exists, no per-repo setup needed; PascalCase event names trigger the VS Code-compatible payload format that peon.sh/peon.ps1 reads natively. Per-repo wiring also available via adapters/copilot.sh / .ps1 with .github/hooks/hooks.json. Skips postToolUse to avoid debounce flooding; correctly maps agentStop -> Stop. Requires PowerShell 7+ on Windows.)
 - OpenAI Codex (built-in auto-detect: install.sh and install.ps1 register stable hooks in ~/.codex/config.toml when ~/.codex exists; registered events are SessionStart, UserPromptSubmit, PermissionRequest, PreCompact, SubagentStart, SubagentStop, and Stop. SessionStart matches startup/resume/clear only; compaction is handled by PreCompact. PreToolUse, PostToolUse, and PostCompact are intentionally not registered; PostToolUse is ignored because Codex has no separate failure-only hook.)
+- Grok Build (built-in auto-detect: install.sh and install.ps1 write ~/.grok/hooks/peon-ping.json when ~/.grok exists, pointing at adapters/grok.sh or grok.ps1. Grok stdin is camelCase with snake_case event values, so peon.sh cannot be invoked directly. Registered events: SessionStart, SessionEnd, UserPromptSubmit, Stop, StopFailure, Notification, SubagentStart, SubagentStop, PostToolUseFailure, PreCompact. Session-end Stop (reason shutdown/channel_closed) is treated as SessionEnd. run_terminal_command failures map to Bash for task.error. Stop-gate stdout is discarded.)
 - Cursor
 - OpenCode
 - Kilo CLI

--- a/install.ps1
+++ b/install.ps1
@@ -905,10 +905,11 @@ function Resolve-TtsBackend {
     switch ($Backend) {
         "native"     { return "tts-native.ps1" }
         "elevenlabs" { return "tts-elevenlabs.ps1" }
+        "minimax"    { return "tts-minimax.ps1" }
         "piper"      { return "tts-piper.ps1" }
         "auto" {
             # Probe in priority order: prefer premium when installed.
-            foreach ($b in @("elevenlabs", "piper", "native")) {
+            foreach ($b in @("elevenlabs", "minimax", "piper", "native")) {
                 $scriptName = Resolve-TtsBackend -Backend $b
                 $full = Join-Path $InstallDir "scripts\$scriptName"
                 if (Test-Path $full) { return $scriptName }

--- a/install.ps1
+++ b/install.ps1
@@ -511,12 +511,14 @@ function Normalize-IdeId {
         "trae" { return "trae" }
         "kiro-ide" { return "kiro-ide" }
         "eca" { return "eca" }
+        "grok" { return "grok" }
+        "grok-build" { return "grok" }
         default { return $key }
     }
 }
 
 function Get-KnownIdeIds {
-    return @("claude", "codex", "cursor", "opencode", "kilo", "kiro", "gemini", "copilot", "windsurf", "kimi", "antigravity", "amp", "deepagents", "openclaw", "rovodev")
+    return @("claude", "codex", "cursor", "opencode", "kilo", "kiro", "gemini", "copilot", "windsurf", "kimi", "antigravity", "amp", "deepagents", "openclaw", "rovodev", "grok")
 }
 
 function Expand-UserPath {
@@ -577,6 +579,7 @@ function Detect-SessionIde {
         "iflow-" = "iflow"
         "trae-" = "trae"
         "eca-" = "eca"
+        "grok-" = "grok"
     }
     foreach ($prefix in $prefixes.Keys) {
         if ($sid.StartsWith($prefix)) { return $prefixes[$prefix] }
@@ -2589,6 +2592,7 @@ $ideDisplayNames = @{
     'trae' = 'Trae'
     'kiro-ide' = 'Kiro IDE'
     'eca' = 'ECA'
+    'grok' = 'Grok Build'
 }
 $ideLabel = ''
 if ($sessionIde) {
@@ -3409,7 +3413,8 @@ $adapterFiles = @(
     "codex.ps1", "gemini.ps1", "copilot.ps1", "windsurf.ps1",
     "kiro.ps1", "openclaw.ps1", "amp.ps1", "antigravity.ps1",
     "kimi.ps1", "opencode.ps1", "kilo.ps1", "deepagents.ps1",
-    "qwen.ps1", "iflow.ps1", "trae.ps1", "kiro-ide.ps1", "eca.ps1"
+    "qwen.ps1", "iflow.ps1", "trae.ps1", "kiro-ide.ps1", "eca.ps1",
+    "grok.ps1"
 )
 
 $sourceAdaptersDir = Join-Path $ScriptDir "adapters"
@@ -3760,6 +3765,56 @@ if ((-not $Local) -and (Test-Path $CopilotDir)) {
     New-Item -ItemType Directory -Path $CopilotHooksDir -Force | Out-Null
     $copilotData | ConvertTo-Json -Depth 10 | Set-Content $CopilotHooksFile -Encoding UTF8
     Write-Host "  Copilot CLI hooks registered for: $($copilotEvents -join ', ')" -ForegroundColor Green
+}
+
+# --- Register Grok Build hooks if ~/.grok exists ---
+# Wires user-level hooks at %USERPROFILE%\.grok\hooks\peon-ping.json
+# pointing at adapters/grok.ps1. Grok's stdin is camelCase with snake_case
+# event values, so peon.ps1 cannot be invoked directly.
+$GrokDir = Join-Path $env:USERPROFILE ".grok"
+$GrokHooksDir = Join-Path $GrokDir "hooks"
+$GrokHooksFile = Join-Path $GrokHooksDir "peon-ping.json"
+$GrokAdapter = Join-Path $adaptersDir "grok.ps1"
+
+if ((-not $Local) -and (Test-Path $GrokDir)) {
+    Write-Host ""
+    Write-Host "Detected Grok Build installation, registering hooks..."
+
+    if (Test-Path $GrokAdapter) {
+        $grokHookCmd = "powershell -NoProfile -NonInteractive -File `"$GrokAdapter`""
+        $grokEvents = @(
+            "SessionStart", "SessionEnd", "UserPromptSubmit", "Stop", "StopFailure",
+            "Notification", "SubagentStart", "SubagentStop", "PostToolUseFailure",
+            "PreCompact"
+        )
+        $grokHooks = [ordered]@{}
+        foreach ($evt in $grokEvents) {
+            $grokHooks[$evt] = @(
+                [PSCustomObject]@{
+                    hooks = @(
+                        [PSCustomObject]@{
+                            type    = "command"
+                            command = $grokHookCmd
+                            timeout = 10
+                        }
+                    )
+                }
+            )
+        }
+        $grokData = [PSCustomObject]@{
+            hooks = [PSCustomObject]$grokHooks
+        }
+
+        New-Item -ItemType Directory -Path $GrokHooksDir -Force | Out-Null
+        $grokData | ConvertTo-Json -Depth 10 | Set-Content $GrokHooksFile -Encoding UTF8
+        Write-Host "  Grok Build hooks registered for: $($grokEvents -join ', ')" -ForegroundColor Green
+        Write-Host "  Reload hooks in a running Grok session (/hooks then r) or start a new one." -ForegroundColor Yellow
+    } else {
+        if (Test-Path $GrokHooksFile) {
+            Remove-Item -Path $GrokHooksFile -Force -ErrorAction SilentlyContinue
+        }
+        Write-Host "  Warning: Grok adapter is missing; stale peon-ping hooks were removed instead of registered." -ForegroundColor Yellow
+    }
 }
 
 # --- Register OpenAI Codex hooks if ~/.codex exists ---

--- a/install.sh
+++ b/install.sh
@@ -669,6 +669,7 @@ else
   curl -fsSL "$REPO_BASE/adapters/trae.sh" -o "$INSTALL_DIR/adapters/trae.sh" 2>/dev/null || true
   curl -fsSL "$REPO_BASE/adapters/kiro-ide.sh" -o "$INSTALL_DIR/adapters/kiro-ide.sh" 2>/dev/null || true
   curl -fsSL "$REPO_BASE/adapters/eca.sh" -o "$INSTALL_DIR/adapters/eca.sh" 2>/dev/null || true
+  curl -fsSL "$REPO_BASE/adapters/grok.sh" -o "$INSTALL_DIR/adapters/grok.sh" 2>/dev/null || true
   mkdir -p "$INSTALL_DIR/scripts"
   curl -fsSL "$REPO_BASE/scripts/hook-handle-use.sh" -o "$INSTALL_DIR/scripts/hook-handle-use.sh" 2>/dev/null || true
   curl -fsSL "$REPO_BASE/scripts/codex-config.py" -o "$INSTALL_DIR/scripts/codex-config.py"
@@ -1460,6 +1461,57 @@ with open(hooks_file, 'w') as f:
 
 print('Copilot CLI hooks registered for: ' + ', '.join(events))
 "
+fi
+
+# --- Register Grok Build hooks if ~/.grok exists ---
+# Wires user-level hooks at ~/.grok/hooks/peon-ping.json pointing at
+# adapters/grok.sh. Grok's stdin is camelCase with snake_case event
+# values, so peon.sh cannot be invoked directly.
+GROK_DIR="$HOME/.grok"
+GROK_HOOKS_DIR="$GROK_DIR/hooks"
+GROK_HOOKS_FILE="$GROK_HOOKS_DIR/peon-ping.json"
+GROK_ADAPTER="$INSTALL_DIR/adapters/grok.sh"
+
+if [ "$LOCAL_MODE" != true ] && [ -d "$GROK_DIR" ]; then
+  echo ""
+  echo "Detected Grok Build installation, registering hooks..."
+
+  if [ -f "$GROK_ADAPTER" ]; then
+    mkdir -p "$GROK_HOOKS_DIR"
+    python3 -c "
+import json, os
+
+hooks_file = '$(py_path "$GROK_HOOKS_FILE")'
+adapter = '$(py_path "$GROK_ADAPTER")'
+
+events = [
+    'SessionStart', 'SessionEnd', 'UserPromptSubmit', 'Stop', 'StopFailure',
+    'Notification', 'SubagentStart', 'SubagentStop', 'PostToolUseFailure',
+    'PreCompact',
+]
+
+hooks = {}
+for evt in events:
+    hooks[evt] = [{
+        'hooks': [{
+            'type': 'command',
+            'command': adapter,
+            'timeout': 10,
+        }]
+    }]
+
+os.makedirs(os.path.dirname(hooks_file), exist_ok=True)
+with open(hooks_file, 'w') as f:
+    json.dump({'hooks': hooks}, f, indent=2)
+    f.write('\n')
+
+print('Grok Build hooks registered for: ' + ', '.join(events))
+print('Reload hooks in a running Grok session (/hooks then r) or start a new one.')
+"
+  else
+    rm -f "$GROK_HOOKS_FILE"
+    echo "Warning: Grok adapter is missing; stale peon-ping hooks were removed instead of registered."
+  fi
 fi
 
 # --- Register OpenAI Codex hooks if ~/.codex exists ---

--- a/peon.sh
+++ b/peon.sh
@@ -465,12 +465,13 @@ _resolve_tts_backend() {
   case "$backend" in
     native)     echo "tts-native.sh" ;;
     elevenlabs) echo "tts-elevenlabs.sh" ;;
+    minimax)    echo "tts-minimax.sh" ;;
     piper)      echo "tts-piper.sh" ;;
     auto)
       # Probe in priority order: prefer premium when installed.
       # Each candidate is resolved inline (no recursive self-call).
       local candidate
-      for candidate in tts-elevenlabs.sh tts-piper.sh tts-native.sh; do  # keep in sync with named cases above
+      for candidate in tts-elevenlabs.sh tts-minimax.sh tts-piper.sh tts-native.sh; do  # keep in sync with named cases above
         find_bundled_script "$candidate" >/dev/null 2>&1 || continue
         echo "$candidate" && return 0
       done

--- a/peon.sh
+++ b/peon.sh
@@ -1565,6 +1565,8 @@ IDE_ALIASES = {
     'open_claw': 'openclaw',
     'rovodev': 'rovodev',
     'rovo': 'rovodev',
+    'grok': 'grok',
+    'grok-build': 'grok',
 }
 
 def normalize_ide_id(value):
@@ -1880,6 +1882,21 @@ if os.path.isdir(codex_dir):
         ides.append(('OpenAI Codex', codex_dir, 'installed'))
     else:
         ides.append(('OpenAI Codex', codex_dir, 'detected (not set up)'))
+
+grok_dir = os.path.join(home, '.grok')
+grok_hooks = os.path.join(grok_dir, 'hooks', 'peon-ping.json')
+if os.path.isdir(grok_dir):
+    grok_installed = False
+    if os.path.isfile(grok_hooks):
+        try:
+            grok_text = open(grok_hooks).read()
+            grok_installed = 'grok.sh' in grok_text or 'grok.ps1' in grok_text
+        except Exception:
+            grok_installed = False
+    if grok_installed:
+        ides.append(('Grok Build', grok_dir, 'installed'))
+    else:
+        ides.append(('Grok Build', grok_dir, 'detected (not set up)'))
 
 if ides:
     for name, path, st in ides:
@@ -2696,9 +2713,10 @@ IDE_ALIASES = {
     'kimi': 'kimi', 'antigravity': 'antigravity', 'amp': 'amp', 'deepagents': 'deepagents',
     'deep-agents': 'deepagents', 'deep_agents': 'deepagents', 'openclaw': 'openclaw',
     'open-claw': 'openclaw', 'open_claw': 'openclaw', 'rovodev': 'rovodev', 'rovo': 'rovodev',
+    'grok': 'grok', 'grok-build': 'grok',
 }
 KNOWN_IDES = ['claude', 'codex', 'cursor', 'opencode', 'kilo', 'kiro', 'gemini', 'copilot', 'windsurf',
-              'kimi', 'antigravity', 'amp', 'deepagents', 'openclaw', 'rovodev']
+              'kimi', 'antigravity', 'amp', 'deepagents', 'openclaw', 'rovodev', 'grok']
 
 def normalize_ide_id(value):
     raw = str(value or '').strip().lower()
@@ -2766,6 +2784,7 @@ IDE_ALIASES = {
     'kimi': 'kimi', 'antigravity': 'antigravity', 'amp': 'amp', 'deepagents': 'deepagents',
     'deep-agents': 'deepagents', 'deep_agents': 'deepagents', 'openclaw': 'openclaw',
     'open-claw': 'openclaw', 'open_claw': 'openclaw', 'rovodev': 'rovodev', 'rovo': 'rovodev',
+    'grok': 'grok', 'grok-build': 'grok',
 }
 
 def normalize_ide_id(value):
@@ -2807,9 +2826,10 @@ IDE_ALIASES = {
     'kimi': 'kimi', 'antigravity': 'antigravity', 'amp': 'amp', 'deepagents': 'deepagents',
     'deep-agents': 'deepagents', 'deep_agents': 'deepagents', 'openclaw': 'openclaw',
     'open-claw': 'openclaw', 'open_claw': 'openclaw', 'rovodev': 'rovodev', 'rovo': 'rovodev',
+    'grok': 'grok', 'grok-build': 'grok',
 }
 KNOWN_IDES = ['claude', 'codex', 'cursor', 'opencode', 'kilo', 'kiro', 'gemini', 'copilot', 'windsurf',
-              'kimi', 'antigravity', 'amp', 'deepagents', 'openclaw', 'rovodev']
+              'kimi', 'antigravity', 'amp', 'deepagents', 'openclaw', 'rovodev', 'grok']
 
 def normalize_ide_id(value):
     raw = str(value or '').strip().lower()
@@ -5338,6 +5358,8 @@ IDE_ALIASES = {
     'trae': 'trae',
     'kiro-ide': 'kiro-ide',
     'eca': 'eca',
+    'grok': 'grok',
+    'grok-build': 'grok',
 }
 
 def normalize_ide_id(value):
@@ -5375,6 +5397,7 @@ def detect_session_ide(source_value, event_payload, session_value):
         ('iflow-', 'iflow'),
         ('trae-', 'trae'),
         ('eca-', 'eca'),
+        ('grok-', 'grok'),
     )
     for prefix, ide in prefix_map:
         if sid.startswith(prefix):
@@ -5403,6 +5426,7 @@ IDE_DISPLAY_NAMES = {
     'trae': 'Trae',
     'kiro-ide': 'Kiro IDE',
     'eca': 'ECA',
+    'grok': 'Grok Build',
 }
 
 def display_ide_name(ide_id):

--- a/scripts/tts-minimax.ps1
+++ b/scripts/tts-minimax.ps1
@@ -1,0 +1,238 @@
+<#
+.SYNOPSIS
+    Windows MiniMax speech (T2A) TTS backend for peon-ping. Synthesizes stdin
+    text through the MiniMax text-to-audio (T2A v2) HTTP API, then plays the
+    returned audio via scripts/win-play.ps1. Fire-and-forget: the exit code is
+    always 0, every error is contained, and no output is produced during
+    normal hook invocations. Debug diagnostics go to stderr, gated on
+    PEON_DEBUG=1.
+
+.DESCRIPTION
+    Invoked from Invoke-TtsSpeak with decoded plain text piped on stdin and
+    voice/rate/volume passed as named parameters, matching the calling
+    convention in docs/adr/ADR-001-tts-backend-architecture.md. Unlike the
+    native SAPI5 backend, this backend produces an audio file over HTTP and
+    plays it locally.
+
+    The regional endpoint is selected from PEON_MINIMAX_REGION: "global_en"
+    (default) uses api.minimax.io, "cn_zh" uses api.minimaxi.com. The Bearer
+    credential comes from MINIMAX_API_KEY; an optional MINIMAX_GROUP_ID is
+    appended as a ?GroupId= query argument.
+
+    Under PEON_TTS_DRY_RUN=1 the script writes the resolved request (never the
+    credential itself) as JSON to PEON_TTS_TRACE_FILE and skips the network
+    call. This test hook lets Pester verify request construction without
+    reaching the API.
+
+.PARAMETER InputText
+    Pipeline input. Each object piped in becomes a line of the buffer;
+    trailing whitespace is trimmed before synthesis. Empty or whitespace-only
+    input exits 0 without any request.
+
+.PARAMETER Voice
+    MiniMax voice_id, or the sentinel string "default" to let the service pick
+    its default voice (voice_id is omitted from the request). Default:
+    "default".
+
+.PARAMETER Rate
+    Float, 1.0 = normal speed. Mapped to voice_setting.speed and clamped to the
+    MiniMax-supported 0.5-2.0 range. Default: 1.0.
+
+.PARAMETER Vol
+    Float, 0.0-1.0. Applied at the local player (win-play.ps1), not the API.
+    Default: 0.5.
+
+.PARAMETER ListVoices
+    If set, exits 0 without a request. MiniMax voices are documented voice_id
+    strings rather than a locally enumerable list.
+
+.EXAMPLE
+    "hello world" | .\tts-minimax.ps1 -Voice "some-voice-id" -Rate 1.0 -Vol 0.5
+#>
+param(
+    [Parameter(ValueFromPipeline = $true)]
+    [string]$InputText,
+    [string]$Voice = "default",
+    [double]$Rate = 1.0,
+    [double]$Vol = 0.5,
+    [switch]$ListVoices
+)
+
+begin {
+    $script:PeonDebug = ($env:PEON_DEBUG -eq "1")
+    $script:DryRun = ($env:PEON_TTS_DRY_RUN -eq "1")
+    $script:TracePath = $env:PEON_TTS_TRACE_FILE
+
+    function Write-DebugLine {
+        param([string]$Message)
+        if ($script:PeonDebug) {
+            [Console]::Error.WriteLine("[tts-minimax] $Message")
+        }
+    }
+
+    function Write-Trace {
+        param([hashtable]$Fields)
+        if (-not $script:DryRun) { return }
+        if (-not $script:TracePath) { return }
+        try {
+            $json = $Fields | ConvertTo-Json -Depth 6 -Compress
+            Set-Content -Path $script:TracePath -Value $json -Encoding UTF8
+        } catch {
+            Write-DebugLine "trace write failed: $_"
+        }
+    }
+
+    function Resolve-Endpoint {
+        param([string]$Region)
+        switch ($Region) {
+            "cn_zh"     { return "https://api.minimaxi.com/v1/t2a_v2" }
+            "global_en" { return "https://api.minimax.io/v1/t2a_v2" }
+            default     { return "https://api.minimax.io/v1/t2a_v2" }
+        }
+    }
+
+    # --- -ListVoices short-circuit: runs in begin, exits before process/end ---
+    if ($ListVoices) {
+        Write-DebugLine "voice enumeration not supported for the MiniMax backend"
+        exit 0
+    }
+
+    $script:Buffer = New-Object System.Text.StringBuilder
+}
+
+process {
+    if ($null -ne $InputText -and $InputText.Length -gt 0) {
+        [void]$script:Buffer.AppendLine($InputText)
+    }
+}
+
+end {
+    $text = $script:Buffer.ToString().TrimEnd()
+
+    # Fallback: when invoked via `powershell.exe -File tts-minimax.ps1` the
+    # pipeline does not bind piped stdin to $InputText -- read the redirected
+    # console stream directly so external callers behave like an in-process
+    # pipeline.
+    if (-not $text) {
+        try {
+            if ([Console]::IsInputRedirected) {
+                $stdin = [Console]::In.ReadToEnd()
+                if ($stdin) { $text = $stdin.TrimEnd() }
+            }
+        } catch {
+            Write-DebugLine "stdin read failed: $_"
+        }
+    }
+
+    if (-not $text) {
+        Write-Trace @{ Spoke = $false; Reason = "empty-input" }
+        exit 0
+    }
+
+    # Resolve request parameters from the environment.
+    $region = if ($env:PEON_MINIMAX_REGION) { $env:PEON_MINIMAX_REGION } else { "global_en" }
+    $model = if ($env:PEON_MINIMAX_MODEL) { $env:PEON_MINIMAX_MODEL } else { "speech-2.8-hd" }
+    $fmt = if ($env:PEON_MINIMAX_FORMAT) { $env:PEON_MINIMAX_FORMAT } else { "mp3" }
+    $apiKey = $env:MINIMAX_API_KEY
+    $groupId = $env:MINIMAX_GROUP_ID
+
+    $url = Resolve-Endpoint -Region $region
+    if ($groupId) {
+        $url = $url + "?GroupId=" + $groupId
+    }
+
+    # Clamp speed to the MiniMax-supported range.
+    $speed = [math]::Max(0.5, [math]::Min(2.0, $Rate))
+
+    $voiceSetting = @{ speed = $speed }
+    if ($Voice -and $Voice -ne "default") {
+        $voiceSetting["voice_id"] = $Voice
+    }
+
+    $body = [ordered]@{
+        model         = $model
+        text          = $text
+        stream        = $false
+        voice_setting = $voiceSetting
+        audio_setting = @{ format = $fmt }
+    }
+    $bodyJson = $body | ConvertTo-Json -Depth 6 -Compress
+
+    if ($script:DryRun) {
+        Write-Trace @{
+            url          = $url
+            region       = $region
+            model        = $model
+            format       = $fmt
+            voice        = $Voice
+            rate         = $Rate
+            has_api_key  = [bool]$apiKey
+            has_group_id = [bool]$groupId
+            request      = $body
+        }
+        exit 0
+    }
+
+    if (-not $apiKey) {
+        Write-DebugLine "MINIMAX_API_KEY not set -- skipping synthesis"
+        exit 0
+    }
+
+    # The Authorization header carries the Bearer credential; it is never
+    # written to stdout, stderr, or the trace file.
+    $headers = @{ Authorization = "Bearer $apiKey" }
+    try {
+        $resp = Invoke-RestMethod -Uri $url -Method Post -Headers $headers `
+            -ContentType "application/json" -Body $bodyJson -TimeoutSec 30
+    } catch {
+        Write-DebugLine "T2A request failed: $_"
+        exit 0
+    }
+
+    $statusCode = $null
+    if ($resp -and $resp.base_resp) { $statusCode = $resp.base_resp.status_code }
+    if ($statusCode -ne 0) {
+        Write-DebugLine "base_resp.status_code=$statusCode"
+        exit 0
+    }
+
+    $audioHex = $null
+    if ($resp -and $resp.data) { $audioHex = $resp.data.audio }
+    if (-not $audioHex) {
+        Write-DebugLine "response contained no audio"
+        exit 0
+    }
+
+    try {
+        $bytes = [byte[]]::new($audioHex.Length / 2)
+        for ($i = 0; $i -lt $audioHex.Length; $i += 2) {
+            $bytes[[int]($i / 2)] = [Convert]::ToByte($audioHex.Substring($i, 2), 16)
+        }
+    } catch {
+        Write-DebugLine "hex decode failed: $_"
+        exit 0
+    }
+
+    $tmp = Join-Path $env:TEMP ("peon-tts-minimax-" + [guid]::NewGuid().ToString('N').Substring(0, 8) + "." + $fmt)
+    try {
+        [System.IO.File]::WriteAllBytes($tmp, $bytes)
+    } catch {
+        Write-DebugLine "temp write failed: $_"
+        exit 0
+    }
+
+    try {
+        $winPlay = Join-Path $PSScriptRoot "win-play.ps1"
+        if (Test-Path $winPlay) {
+            & $winPlay -path $tmp -vol $Vol
+        } else {
+            Write-DebugLine "win-play.ps1 not found at $winPlay"
+        }
+    } catch {
+        Write-DebugLine "playback failed: $_"
+    } finally {
+        Remove-Item $tmp -Force -ErrorAction SilentlyContinue
+    }
+
+    exit 0
+}

--- a/scripts/tts-minimax.sh
+++ b/scripts/tts-minimax.sh
@@ -1,0 +1,289 @@
+#!/bin/bash
+# peon-ping: MiniMax speech (T2A) TTS backend
+#
+# A cloud HTTP backend that synthesizes speech through the MiniMax
+# text-to-audio (T2A v2) API, then plays the returned audio through the
+# platform's audio player. Unlike scripts/tts-native.sh (which speaks
+# directly to the OS engine), this backend produces an audio file over
+# HTTP and plays it locally.
+#
+# Usage:
+#   echo "text to speak" | tts-minimax.sh <voice> <rate> <volume>
+#   tts-minimax.sh --list-voices
+#
+# Positional args:
+#   voice   MiniMax voice_id (e.g. a configured voice) or "default" to let
+#           the service pick its default voice (voice_id is omitted).
+#   rate    float; 1.0 = normal speed. Mapped to voice_setting.speed and
+#           clamped to the MiniMax-supported 0.5-2.0 range.
+#   volume  float 0.0-1.0. Applied at the local player (not the API).
+#
+# Stdin:   one line of text to speak (read verbatim, no interpolation).
+# Stdout:  empty.
+# Stderr:  empty unless PEON_DEBUG=1, in which case diagnostics are
+#          prefixed with `[tts-minimax]`.
+# Exit:    always 0 — TTS failure must not fail the calling hook.
+#
+# Env vars:
+#   PEON_DEBUG           "1" enables stderr diagnostics
+#   PEON_DIR             peon-ping install dir (auto-resolved from $0)
+#   MINIMAX_API_KEY      Bearer credential (required; absent → silent exit 0)
+#   MINIMAX_GROUP_ID     optional; appended as ?GroupId=... when set
+#   PEON_MINIMAX_REGION  "global_en" (default) → api.minimax.io
+#                        "cn_zh"               → api.minimaxi.com
+#   PEON_MINIMAX_MODEL   T2A model id (default "speech-2.8-hd"; other options
+#                        include "speech-2.8-turbo")
+#   PEON_MINIMAX_FORMAT  audio format: mp3 (default), wav, flac, pcm
+#   PEON_TTS_DRY_RUN     "1" writes the resolved request to
+#                        PEON_TTS_TRACE_FILE and skips the network call
+#   PEON_TTS_TRACE_FILE  dry-run trace destination
+#
+# See docs/adr/ADR-001-tts-backend-architecture.md for the calling
+# convention this backend implements.
+
+set -uo pipefail
+
+PEON_DEBUG="${PEON_DEBUG:-0}"
+
+_debug() {
+  [ "$PEON_DEBUG" = "1" ] && printf '[tts-minimax] %s\n' "$*" >&2
+  return 0
+}
+
+# --- Resolve PEON_DIR ---
+if [ -z "${PEON_DIR:-}" ]; then
+  PEON_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+fi
+
+# --- Regional endpoint resolution ---
+# The T2A v2 endpoint differs by region: the global service lives on
+# api.minimax.io, the CN service on api.minimaxi.com. Any unrecognized
+# region falls back to the global endpoint.
+_endpoint_for_region() {
+  case "$1" in
+    cn_zh)     echo "https://api.minimaxi.com/v1/t2a_v2" ;;
+    global_en) echo "https://api.minimax.io/v1/t2a_v2" ;;
+    *)         echo "https://api.minimax.io/v1/t2a_v2" ;;
+  esac
+}
+
+# --- Request body construction ---
+# Built with python3 so arbitrary speech text (quotes, backslashes, newlines)
+# is JSON-escaped safely and rate is parsed as data, never interpolated into
+# a program string. Emits a single compact JSON object on stdout.
+_build_request_json() {
+  local text="$1" model="$2" voice="$3" rate="$4" fmt="$5"
+  MM_TEXT="$text" MM_MODEL="$model" MM_VOICE="$voice" MM_RATE="$rate" MM_FMT="$fmt" \
+    python3 - <<'PY'
+import json, os
+text = os.environ["MM_TEXT"]
+model = os.environ["MM_MODEL"]
+voice = os.environ["MM_VOICE"]
+fmt = os.environ["MM_FMT"]
+try:
+    speed = float(os.environ["MM_RATE"])
+except (ValueError, KeyError):
+    speed = 1.0
+# Clamp to the MiniMax-supported speed range.
+speed = max(0.5, min(2.0, speed))
+voice_setting = {"speed": speed}
+# "default" means "let the service choose" — omit voice_id entirely.
+if voice and voice != "default":
+    voice_setting["voice_id"] = voice
+body = {
+    "model": model,
+    "text": text,
+    "stream": False,
+    "voice_setting": voice_setting,
+    "audio_setting": {"format": fmt},
+}
+print(json.dumps(body))
+PY
+}
+
+# --- Response handling ---
+# Reads the T2A JSON response on stdin, verifies base_resp.status_code == 0,
+# then hex-decodes data.audio into the file named by $1. Exits non-zero on any
+# failure so the caller can skip playback.
+_decode_response_to_file() {
+  local outfile="$1"
+  # `python3 -c` (not `python3 - <<heredoc`) so the response JSON piped on
+  # stdin reaches the program instead of being shadowed by the here-doc.
+  MM_OUT="$outfile" python3 -c '
+import json, os, sys
+raw = sys.stdin.read()
+try:
+    payload = json.loads(raw)
+except Exception:
+    sys.exit(1)
+base = payload.get("base_resp") or {}
+if base.get("status_code", -1) != 0:
+    sys.stderr.write("base_resp.status_code=%s\n" % base.get("status_code"))
+    sys.exit(2)
+data = payload.get("data") or {}
+audio_hex = data.get("audio")
+if not audio_hex:
+    sys.exit(3)
+try:
+    audio_bytes = bytes.fromhex(audio_hex)
+except Exception:
+    sys.exit(4)
+with open(os.environ["MM_OUT"], "wb") as fh:
+    fh.write(audio_bytes)
+'
+}
+
+# --- Local playback (mirrors platform conventions in peon.sh play_sound) ---
+_play_linux() {
+  local file="$1" volume="$2" vint
+  if command -v pw-play >/dev/null 2>&1; then
+    pw-play --volume "$volume" "$file" 2>/dev/null || _debug "pw-play failed"
+  elif command -v ffplay >/dev/null 2>&1; then
+    vint=$(awk -v v="$volume" 'BEGIN { printf "%d", v * 100 }')
+    ffplay -nodisp -autoexit -volume "$vint" "$file" 2>/dev/null || _debug "ffplay failed"
+  elif command -v mpv >/dev/null 2>&1; then
+    vint=$(awk -v v="$volume" 'BEGIN { printf "%d", v * 100 }')
+    mpv --no-video --volume="$vint" "$file" 2>/dev/null || _debug "mpv failed"
+  elif command -v play >/dev/null 2>&1; then
+    play -v "$volume" "$file" 2>/dev/null || _debug "play failed"
+  elif command -v paplay >/dev/null 2>&1; then
+    paplay "$file" 2>/dev/null || _debug "paplay failed"
+  elif command -v aplay >/dev/null 2>&1; then
+    aplay -q "$file" 2>/dev/null || _debug "aplay failed"
+  else
+    _debug "no audio player found on Linux"
+  fi
+}
+
+_play_windows() {
+  local file="$1" volume="$2"
+  local ps_script="$PEON_DIR/scripts/win-play.ps1"
+  if [ ! -f "$ps_script" ]; then
+    _debug "win-play.ps1 not found at $ps_script"
+    return 0
+  fi
+  local winpath="$file"
+  command -v cygpath >/dev/null 2>&1 && winpath="$(cygpath -w "$file")"
+  powershell.exe -NoProfile -File "$ps_script" -path "$winpath" -vol "$volume" 2>/dev/null \
+    || _debug "win-play.ps1 failed"
+}
+
+_play_file() {
+  local file="$1" volume="$2"
+  case "$(uname -s)" in
+    Darwin)       afplay -v "$volume" "$file" 2>/dev/null || _debug "afplay failed" ;;
+    Linux)        _play_linux "$file" "$volume" ;;
+    MINGW*|MSYS*) _play_windows "$file" "$volume" ;;
+    *)            _debug "unsupported platform for playback: $(uname -s)" ;;
+  esac
+}
+
+# --- Entry point ---
+
+# MiniMax voices are documented voice_id strings rather than a locally
+# enumerable list, so --list-voices is a no-op that exits cleanly (keeps the
+# `peon tts voices` command working when this backend is active).
+if [ "${1:-}" = "--list-voices" ]; then
+  _debug "voice enumeration not supported for the MiniMax backend"
+  exit 0
+fi
+
+voice="${1:-default}"
+rate="${2:-1.0}"
+volume="${3:-0.5}"
+
+region="${PEON_MINIMAX_REGION:-global_en}"
+model="${PEON_MINIMAX_MODEL:-speech-2.8-hd}"
+fmt="${PEON_MINIMAX_FORMAT:-mp3}"
+url="$(_endpoint_for_region "$region")"
+if [ -n "${MINIMAX_GROUP_ID:-}" ]; then
+  url="${url}?GroupId=${MINIMAX_GROUP_ID}"
+fi
+
+# Read one line of text from stdin. Empty / whitespace-only input exits
+# silently — the hook pipeline sometimes invokes speak() with empty text.
+IFS= read -r text || text=""
+stripped="${text//[[:space:]]/}"
+if [ -z "$stripped" ]; then
+  _debug "empty input text"
+  exit 0
+fi
+
+# python3 is required for safe request/response handling.
+if ! command -v python3 >/dev/null 2>&1; then
+  _debug "python3 not found — cannot build request"
+  exit 0
+fi
+
+# Dry-run: record the resolved request (never the credential itself) and stop
+# before any network call. Powers the test harness.
+if [ "${PEON_TTS_DRY_RUN:-0}" = "1" ]; then
+  if [ -n "${PEON_TTS_TRACE_FILE:-}" ]; then
+    request_json="$(_build_request_json "$text" "$model" "$voice" "$rate" "$fmt")"
+    MM_TRACE="$PEON_TTS_TRACE_FILE" MM_URL="$url" MM_REGION="$region" \
+    MM_MODEL="$model" MM_FMT="$fmt" MM_VOICE="$voice" MM_RATE="$rate" \
+    MM_HAS_KEY="$([ -n "${MINIMAX_API_KEY:-}" ] && echo 1 || echo 0)" \
+    MM_HAS_GROUP="$([ -n "${MINIMAX_GROUP_ID:-}" ] && echo 1 || echo 0)" \
+    MM_REQ="$request_json" python3 - <<'PY'
+import json, os
+trace = {
+    "url": os.environ["MM_URL"],
+    "region": os.environ["MM_REGION"],
+    "model": os.environ["MM_MODEL"],
+    "format": os.environ["MM_FMT"],
+    "voice": os.environ["MM_VOICE"],
+    "rate": os.environ["MM_RATE"],
+    "has_api_key": os.environ["MM_HAS_KEY"] == "1",
+    "has_group_id": os.environ["MM_HAS_GROUP"] == "1",
+    "request": json.loads(os.environ["MM_REQ"]),
+}
+with open(os.environ["MM_TRACE"], "w") as fh:
+    json.dump(trace, fh)
+PY
+  fi
+  exit 0
+fi
+
+# Credential and curl are required for a live request.
+api_key="${MINIMAX_API_KEY:-}"
+if [ -z "$api_key" ]; then
+  _debug "MINIMAX_API_KEY not set — skipping synthesis"
+  exit 0
+fi
+if ! command -v curl >/dev/null 2>&1; then
+  _debug "curl not found — cannot reach the MiniMax API"
+  exit 0
+fi
+
+request_json="$(_build_request_json "$text" "$model" "$voice" "$rate" "$fmt")" || {
+  _debug "failed to build request body"
+  exit 0
+}
+
+# The Authorization header carries the Bearer credential; it is passed via an
+# argument to curl and never written to stdout, stderr, or the trace file.
+response="$(curl -sS --max-time 30 -X POST \
+  -H "Authorization: Bearer $api_key" \
+  -H "Content-Type: application/json" \
+  -d "$request_json" \
+  "$url" 2>/dev/null)" || {
+  _debug "curl request failed"
+  exit 0
+}
+
+tmpbase="$(mktemp "${TMPDIR:-/tmp}/peon-tts-minimax.XXXXXX")" || {
+  _debug "mktemp failed"
+  exit 0
+}
+tmpfile="${tmpbase}.${fmt}"
+mv "$tmpbase" "$tmpfile" 2>/dev/null || tmpfile="$tmpbase"
+
+if printf '%s' "$response" | _decode_response_to_file "$tmpfile"; then
+  _play_file "$tmpfile" "$volume"
+else
+  _debug "response decode failed — nothing to play"
+fi
+rm -f "$tmpfile" 2>/dev/null
+
+# Always exit 0 — TTS failure must never propagate to the caller.
+exit 0

--- a/tests/adapters-windows.Tests.ps1
+++ b/tests/adapters-windows.Tests.ps1
@@ -162,6 +162,49 @@ Describe "Category A: Codex Adapter" {
     }
 }
 
+Describe "Category A: Grok Adapter" {
+    BeforeAll {
+        $script:grokContent = Get-Content (Join-Path $script:AdaptersDir "grok.ps1") -Raw
+    }
+
+    It "maps session_start to SessionStart" {
+        $script:grokContent | Should -Match 'session_start'
+        $script:grokContent | Should -Match '\$mapped = "SessionStart"'
+    }
+
+    It "maps stop end_turn to Stop" {
+        $script:grokContent | Should -Match 'end_turn'
+        $script:grokContent | Should -Match '\$mapped = "Stop"'
+    }
+
+    It "maps permission_prompt to PermissionRequest" {
+        $script:grokContent | Should -Match 'permission_prompt'
+        $script:grokContent | Should -Match '\$mapped = "PermissionRequest"'
+    }
+
+    It "maps pre_compact to PreCompact" {
+        $script:grokContent | Should -Match 'pre_compact'
+        $script:grokContent | Should -Match '\$mapped = "PreCompact"'
+    }
+
+    It "keeps PreToolUse and PostToolUse silent" {
+        $script:grokContent | Should -Match 'pre_tool_use'
+        $script:grokContent | Should -Match 'post_tool_use'
+        $script:grokContent | Should -Match 'exit 0'
+    }
+
+    It "prefixes session ids with grok-" {
+        $script:grokContent | Should -Match 'grok-\$safeSid'
+        $script:grokContent | Should -Match 'source\s+= "grok"'
+    }
+
+    It "pipes JSON to peon.ps1 and discards stdout" {
+        $script:grokContent | Should -Match 'peon\.ps1'
+        $script:grokContent | Should -Match 'ConvertTo-Json'
+        $script:grokContent | Should -Match '>\s*\$null'
+    }
+}
+
 Describe "Category A: Gemini Adapter" {
     BeforeAll {
         $script:geminiContent = Get-Content (Join-Path $script:AdaptersDir "gemini.ps1") -Raw

--- a/tests/grok.bats
+++ b/tests/grok.bats
@@ -1,0 +1,157 @@
+#!/usr/bin/env bats
+
+load setup.bash
+
+setup() {
+  setup_test_env
+  unset GROK_HOOK_EVENT GROK_SESSION_ID GROK_WORKSPACE_ROOT
+
+  GROK_SH="${PEON_SH%/peon.sh}/adapters/grok.sh"
+
+  # Adapter resolves peon.sh via CLAUDE_PEON_DIR
+  ln -sf "$PEON_SH" "$TEST_DIR/peon.sh"
+}
+
+teardown() {
+  teardown_test_env
+}
+
+run_grok() {
+  local json="${1-}"
+  export PEON_TEST=1
+  if [ -n "$json" ]; then
+    echo "$json" | bash "$GROK_SH" 2>"$TEST_DIR/stderr.log"
+  else
+    bash "$GROK_SH" 2>"$TEST_DIR/stderr.log"
+  fi
+  GROK_EXIT=$?
+  GROK_STDERR=$(cat "$TEST_DIR/stderr.log" 2>/dev/null)
+  sleep 0.3
+}
+
+@test "adapter script has valid bash syntax" {
+  run bash -n "$GROK_SH"
+  [ "$status" -eq 0 ]
+}
+
+@test "session_start maps to session.start and plays greeting" {
+  run_grok '{"hookEventName":"session_start","sessionId":"s1"}'
+  [ "$GROK_EXIT" -eq 0 ]
+  afplay_was_called
+  sound=$(afplay_sound)
+  [[ "$sound" == *"/packs/peon/sounds/Hello"* ]]
+}
+
+@test "stop end_turn maps to task.complete and plays completion sound" {
+  run_grok '{"hookEventName":"stop","sessionId":"s1","reason":"end_turn"}'
+  [ "$GROK_EXIT" -eq 0 ]
+  afplay_was_called
+  sound=$(afplay_sound)
+  [[ "$sound" == *"/packs/peon/sounds/Done"* ]]
+}
+
+@test "stop without reason still plays completion sound" {
+  run_grok '{"hookEventName":"stop","sessionId":"s-plain"}'
+  [ "$GROK_EXIT" -eq 0 ]
+  afplay_was_called
+  sound=$(afplay_sound)
+  [[ "$sound" == *"/packs/peon/sounds/Done"* ]]
+}
+
+@test "session-end Stop is silent" {
+  run_grok '{"hookEventName":"stop","sessionId":"s1","reason":"shutdown"}'
+  [ "$GROK_EXIT" -eq 0 ]
+  ! afplay_was_called
+}
+
+@test "permission_prompt maps to input.required and plays permission sound" {
+  run_grok '{"hookEventName":"notification","sessionId":"s1","notificationType":"permission_prompt"}'
+  [ "$GROK_EXIT" -eq 0 ]
+  afplay_was_called
+  sound=$(afplay_sound)
+  [[ "$sound" == *"/packs/peon/sounds/Perm"* ]]
+}
+
+@test "idle_prompt maps to task.complete and plays completion sound" {
+  run_grok '{"hookEventName":"notification","sessionId":"s-idle","notificationType":"idle_prompt"}'
+  [ "$GROK_EXIT" -eq 0 ]
+  afplay_was_called
+  sound=$(afplay_sound)
+  [[ "$sound" == *"/packs/peon/sounds/Done"* ]]
+}
+
+@test "pre_compact maps to resource.limit and plays limit sound" {
+  run_grok '{"hookEventName":"pre_compact","sessionId":"s1"}'
+  [ "$GROK_EXIT" -eq 0 ]
+  afplay_was_called
+  sound=$(afplay_sound)
+  [[ "$sound" == *"/packs/peon/sounds/Limit"* ]]
+}
+
+@test "shell PostToolUseFailure plays error sound" {
+  run_grok '{"hookEventName":"post_tool_use_failure","sessionId":"s1","toolName":"run_terminal_command","errorDetails":"exit 1"}'
+  [ "$GROK_EXIT" -eq 0 ]
+  afplay_was_called
+  sound=$(afplay_sound)
+  [[ "$sound" == *"/packs/peon/sounds/Error"* ]]
+}
+
+@test "StopFailure plays error sound" {
+  run_grok '{"hookEventName":"stop_failure","sessionId":"s-fail","error":"rate_limit"}'
+  [ "$GROK_EXIT" -eq 0 ]
+  afplay_was_called
+  sound=$(afplay_sound)
+  [[ "$sound" == *"/packs/peon/sounds/Error"* ]]
+}
+
+@test "SubagentStart is silent" {
+  run_grok '{"hookEventName":"subagent_start","sessionId":"s1","agentId":"a1"}'
+  [ "$GROK_EXIT" -eq 0 ]
+  ! afplay_was_called
+}
+
+@test "PreToolUse is silent" {
+  run_grok '{"hookEventName":"pre_tool_use","sessionId":"s1","toolName":"read_file"}'
+  [ "$GROK_EXIT" -eq 0 ]
+  ! afplay_was_called
+}
+
+@test "PostToolUse is silent" {
+  run_grok '{"hookEventName":"post_tool_use","sessionId":"s1"}'
+  [ "$GROK_EXIT" -eq 0 ]
+  ! afplay_was_called
+}
+
+@test "PostCompact is silent" {
+  run_grok '{"hookEventName":"post_compact","sessionId":"s1"}'
+  [ "$GROK_EXIT" -eq 0 ]
+  ! afplay_was_called
+}
+
+@test "UserPromptSubmit plays no sound" {
+  run_grok '{"hookEventName":"user_prompt_submit","sessionId":"s1"}'
+  [ "$GROK_EXIT" -eq 0 ]
+  ! afplay_was_called
+}
+
+@test "stdin sessionId and cwd are forwarded with grok session prefix" {
+  run_grok '{"hookEventName":"stop","reason":"end_turn","cwd":"/tmp/grok-proj","sessionId":"sess-42"}'
+  [ "$GROK_EXIT" -eq 0 ]
+  /usr/bin/python3 -c "
+import json
+state = json.load(open('$TEST_DIR/.state.json'))
+last = state.get('last_active', {})
+assert last.get('session_id') == 'grok-sess-42', last
+assert last.get('cwd') == '/tmp/grok-proj', last
+"
+}
+
+@test "GROK_HOOK_EVENT env is used when stdin has no event name" {
+  export GROK_HOOK_EVENT=session_start
+  export GROK_SESSION_ID=env-sid
+  run_grok '{"cwd":"/tmp/from-env"}'
+  [ "$GROK_EXIT" -eq 0 ]
+  afplay_was_called
+  sound=$(afplay_sound)
+  [[ "$sound" == *"/packs/peon/sounds/Hello"* ]]
+}

--- a/tests/install.bats
+++ b/tests/install.bats
@@ -138,6 +138,39 @@ print('OK')
 "
 }
 
+@test "fresh install registers Grok Build hooks when ~/.grok exists" {
+  mkdir -p "$TEST_HOME/.grok"
+  bash "$CLONE_DIR/install.sh"
+  [ -f "$TEST_HOME/.grok/hooks/peon-ping.json" ]
+  /usr/bin/python3 -c "
+import json
+data = json.load(open('$TEST_HOME/.grok/hooks/peon-ping.json'))
+hooks = data.get('hooks', {})
+for event in ['SessionStart', 'UserPromptSubmit', 'Stop', 'Notification', 'PostToolUseFailure', 'PreCompact']:
+    assert event in hooks, f'{event} not in grok hooks'
+    cmds = [h.get('command','') for entry in hooks[event] for h in entry.get('hooks',[])]
+    assert any('adapters/grok.sh' in c for c in cmds), f'grok.sh not registered for {event}: {cmds}'
+assert 'PreToolUse' not in hooks
+assert 'PostToolUse' not in hooks
+print('OK')
+"
+}
+
+@test "--local install does not modify user Grok hooks" {
+  mkdir -p "$TEST_HOME/.grok"
+  cd "$PROJECT_DIR"
+  bash "$CLONE_DIR/install.sh" --local
+  [ ! -f "$TEST_HOME/.grok/hooks/peon-ping.json" ]
+}
+
+@test "uninstall removes Grok Build hooks" {
+  mkdir -p "$TEST_HOME/.grok"
+  bash "$CLONE_DIR/install.sh"
+  [ -f "$TEST_HOME/.grok/hooks/peon-ping.json" ]
+  bash "$INSTALL_DIR/uninstall.sh"
+  [ ! -f "$TEST_HOME/.grok/hooks/peon-ping.json" ]
+}
+
 @test "fresh install registers Codex stable hooks when ~/.codex exists" {
   mkdir -p "$TEST_HOME/.codex"
   cat > "$TEST_HOME/.codex/config.toml" <<TOML

--- a/tests/tts-minimax.Tests.ps1
+++ b/tests/tts-minimax.Tests.ps1
@@ -1,0 +1,221 @@
+# Pester 5 tests for scripts/tts-minimax.ps1 (Windows MiniMax T2A backend).
+# Run: Invoke-Pester -Path tests/tts-minimax.Tests.ps1
+#
+# Strategy mirrors tts-native.Tests.ps1: the impure half (the HTTP call) is
+# verified via a side-effect trace. Under PEON_TTS_DRY_RUN=1 the script writes
+# the resolved request (URL, region, model, format, voice, and JSON body) to
+# PEON_TTS_TRACE_FILE and exits 0 without reaching the API. The credential is
+# recorded only as a boolean, never as its value.
+
+BeforeAll {
+    $script:RepoRoot = Split-Path $PSScriptRoot -Parent
+    $script:TtsMinimaxPath = Join-Path (Join-Path $script:RepoRoot "scripts") "tts-minimax.ps1"
+
+    function Invoke-TtsMinimaxDryRun {
+        param(
+            [string]$InputText = "",
+            [string]$Voice = "default",
+            [double]$Rate = 1.0,
+            [double]$Vol = 0.5,
+            [string]$Region,
+            [string]$Model,
+            [string]$Format,
+            [string]$GroupId,
+            [string]$ApiKey
+        )
+
+        $tracePath = Join-Path $env:TEMP "peon-tts-minimax-trace-$([guid]::NewGuid().ToString('N').Substring(0,8)).json"
+
+        $argList = @("-NoProfile", "-NonInteractive", "-File", $script:TtsMinimaxPath,
+                     "-Voice", $Voice, "-Rate", $Rate, "-Vol", $Vol)
+
+        $psi = New-Object System.Diagnostics.ProcessStartInfo
+        $psi.FileName = "powershell.exe"
+        $psi.Arguments = ($argList | ForEach-Object {
+            if ($_ -match '\s') { "`"$_`"" } else { "$_" }
+        }) -join " "
+        $psi.UseShellExecute = $false
+        $psi.RedirectStandardInput = $true
+        $psi.RedirectStandardOutput = $true
+        $psi.RedirectStandardError = $true
+        $psi.CreateNoWindow = $true
+        $psi.Environment["PEON_TTS_DRY_RUN"] = "1"
+        $psi.Environment["PEON_TTS_TRACE_FILE"] = $tracePath
+        if ($Region) { $psi.Environment["PEON_MINIMAX_REGION"] = $Region }
+        if ($Model) { $psi.Environment["PEON_MINIMAX_MODEL"] = $Model }
+        if ($Format) { $psi.Environment["PEON_MINIMAX_FORMAT"] = $Format }
+        if ($GroupId) { $psi.Environment["MINIMAX_GROUP_ID"] = $GroupId }
+        if ($ApiKey) { $psi.Environment["MINIMAX_API_KEY"] = $ApiKey }
+
+        $proc = New-Object System.Diagnostics.Process
+        $proc.StartInfo = $psi
+        try {
+            $proc.Start() | Out-Null
+            if ($InputText) {
+                $proc.StandardInput.Write($InputText)
+            }
+            $proc.StandardInput.Close()
+
+            $stdoutTask = $proc.StandardOutput.ReadToEndAsync()
+            $stderrTask = $proc.StandardError.ReadToEndAsync()
+
+            if (-not $proc.WaitForExit(15000)) {
+                $proc.Kill()
+                throw "tts-minimax.ps1 timed out"
+            }
+
+            $stdout = $stdoutTask.Result
+            $stderr = $stderrTask.Result
+            $exitCode = $proc.ExitCode
+        } finally {
+            $proc.Dispose()
+        }
+
+        $trace = $null
+        $rawTrace = $null
+        if (Test-Path $tracePath) {
+            $rawTrace = Get-Content $tracePath -Raw -Encoding UTF8
+            $trace = $rawTrace | ConvertFrom-Json
+            Remove-Item $tracePath -Force -ErrorAction SilentlyContinue
+        }
+
+        return @{
+            ExitCode = $exitCode
+            Stdout   = $stdout
+            Stderr   = $stderr
+            Trace    = $trace
+            RawTrace = $rawTrace
+        }
+    }
+}
+
+# ============================================================
+# Structural / parse validation
+# ============================================================
+
+Describe "tts-minimax.ps1 structural validation" {
+    It "exists in scripts/" {
+        $script:TtsMinimaxPath | Should -Exist
+    }
+
+    It "has valid PowerShell syntax" {
+        $content = Get-Content $script:TtsMinimaxPath -Raw
+        $errors = $null
+        $null = [System.Management.Automation.PSParser]::Tokenize($content, [ref]$errors)
+        $errors.Count | Should -Be 0
+    }
+
+    It "contains a comment-based help header near the top" {
+        $content = Get-Content $script:TtsMinimaxPath -Raw
+        $content | Should -Match '(?s)^\s*<#.*\.SYNOPSIS.*\.PARAMETER.*\.EXAMPLE.*#>'
+    }
+
+    It "declares InputText with ValueFromPipeline" {
+        $content = Get-Content $script:TtsMinimaxPath -Raw
+        $content | Should -Match '(?s)\[Parameter\(\s*ValueFromPipeline\s*=\s*\$true\s*\)\][^}]*\[string\]\s*\$InputText'
+    }
+
+    It "declares Voice parameter with 'default' default" {
+        $content = Get-Content $script:TtsMinimaxPath -Raw
+        $content | Should -Match '\[string\]\s*\$Voice\s*=\s*"default"'
+    }
+
+    It "declares Rate parameter as double with 1.0 default" {
+        $content = Get-Content $script:TtsMinimaxPath -Raw
+        $content | Should -Match '\[double\]\s*\$Rate\s*=\s*1\.0'
+    }
+
+    It "declares Vol parameter as double with 0.5 default" {
+        $content = Get-Content $script:TtsMinimaxPath -Raw
+        $content | Should -Match '\[double\]\s*\$Vol\s*=\s*0\.5'
+    }
+
+    It "uses begin/process/end blocks for pipeline input" {
+        $content = Get-Content $script:TtsMinimaxPath -Raw
+        $content | Should -Match '(?ms)^\s*begin\s*\{'
+        $content | Should -Match '(?ms)^\s*process\s*\{'
+        $content | Should -Match '(?ms)^\s*end\s*\{'
+    }
+
+    It "does not contain ExecutionPolicy Bypass" {
+        $content = Get-Content $script:TtsMinimaxPath -Raw
+        $content | Should -Not -Match "ExecutionPolicy Bypass"
+    }
+}
+
+# ============================================================
+# Request construction (dry-run trace)
+# ============================================================
+
+Describe "tts-minimax.ps1 request construction" {
+    It "resolves the global endpoint by default" {
+        $r = Invoke-TtsMinimaxDryRun -InputText "hello"
+        $r.ExitCode | Should -Be 0
+        $r.Trace.url | Should -Be "https://api.minimax.io/v1/t2a_v2"
+        $r.Trace.region | Should -Be "global_en"
+    }
+
+    It "resolves the CN endpoint for region cn_zh" {
+        $r = Invoke-TtsMinimaxDryRun -InputText "hello" -Region "cn_zh"
+        $r.Trace.url | Should -Be "https://api.minimaxi.com/v1/t2a_v2"
+    }
+
+    It "falls back to the global endpoint for an unknown region" {
+        $r = Invoke-TtsMinimaxDryRun -InputText "hi" -Region "bogus"
+        $r.Trace.url | Should -Be "https://api.minimax.io/v1/t2a_v2"
+    }
+
+    It "appends MINIMAX_GROUP_ID as a query argument" {
+        $r = Invoke-TtsMinimaxDryRun -InputText "hi" -GroupId "grp42"
+        $r.Trace.url | Should -Be "https://api.minimax.io/v1/t2a_v2?GroupId=grp42"
+        $r.Trace.has_group_id | Should -BeTrue
+    }
+
+    It "defaults the model to speech-2.8-hd" {
+        $r = Invoke-TtsMinimaxDryRun -InputText "hi"
+        $r.Trace.model | Should -Be "speech-2.8-hd"
+        $r.Trace.request.model | Should -Be "speech-2.8-hd"
+    }
+
+    It "honors PEON_MINIMAX_MODEL (speech-2.8-turbo)" {
+        $r = Invoke-TtsMinimaxDryRun -InputText "hi" -Model "speech-2.8-turbo"
+        $r.Trace.request.model | Should -Be "speech-2.8-turbo"
+    }
+
+    It "carries the text and audio format in the request body" {
+        $r = Invoke-TtsMinimaxDryRun -InputText "read this" -Format "wav"
+        $r.Trace.request.text | Should -Be "read this"
+        $r.Trace.request.audio_setting.format | Should -Be "wav"
+    }
+
+    It "omits voice_id when the voice is default" {
+        $r = Invoke-TtsMinimaxDryRun -InputText "hi" -Voice "default"
+        $r.Trace.request.voice_setting.PSObject.Properties.Name | Should -Not -Contain "voice_id"
+    }
+
+    It "sets voice_id when an explicit voice is given" {
+        $r = Invoke-TtsMinimaxDryRun -InputText "hi" -Voice "some-voice-id"
+        $r.Trace.request.voice_setting.voice_id | Should -Be "some-voice-id"
+    }
+
+    It "clamps rate above 2.0 to 2.0" {
+        $r = Invoke-TtsMinimaxDryRun -InputText "hi" -Rate 3.0
+        $r.Trace.request.voice_setting.speed | Should -Be 2.0
+    }
+
+    It "clamps rate below 0.5 to 0.5" {
+        $r = Invoke-TtsMinimaxDryRun -InputText "hi" -Rate 0.1
+        $r.Trace.request.voice_setting.speed | Should -Be 0.5
+    }
+
+    It "records only a boolean for the credential, never its value" {
+        $r = Invoke-TtsMinimaxDryRun -InputText "hi" -ApiKey "super-secret-value"
+        $r.Trace.has_api_key | Should -BeTrue
+        $r.RawTrace | Should -Not -Match "super-secret-value"
+    }
+
+    It "exits 0 on empty input without writing a request body" {
+        $r = Invoke-TtsMinimaxDryRun -InputText ""
+        $r.ExitCode | Should -Be 0
+    }
+}

--- a/tests/tts-minimax.bats
+++ b/tests/tts-minimax.bats
@@ -1,0 +1,329 @@
+#!/usr/bin/env bats
+#
+# Unit tests for scripts/tts-minimax.sh (MiniMax T2A cloud TTS backend).
+#
+# The backend has two verifiable halves:
+#   1. Request construction — region → endpoint mapping, model/format/voice
+#      resolution, GroupId handling, JSON body. Verified through the dry-run
+#      trace (PEON_TTS_DRY_RUN=1 writes the resolved request to a trace file
+#      and skips the network call).
+#   2. Live request + response handling — verified against a PATH-mocked
+#      `curl` returning a canned T2A response and a PATH-mocked audio player,
+#      asserting the hex audio is decoded and handed to the player.
+#
+# The credential (MINIMAX_API_KEY) must never appear in the trace or on any
+# output stream — asserted explicitly below.
+
+TTS_SCRIPT="$(cd "$(dirname "${BATS_TEST_FILENAME}")/.." && pwd)/scripts/tts-minimax.sh"
+
+setup() {
+  TEST_DIR="$(mktemp -d)"
+  export TEST_DIR
+  MOCK_BIN="$TEST_DIR/mock_bin"
+  mkdir -p "$MOCK_BIN"
+  export PEON_DIR="$TEST_DIR"
+  unset PEON_DEBUG PEON_MINIMAX_REGION PEON_MINIMAX_MODEL PEON_MINIMAX_FORMAT
+  unset MINIMAX_API_KEY MINIMAX_GROUP_ID
+}
+
+teardown() {
+  rm -rf "$TEST_DIR"
+}
+
+# --- Helpers ---
+
+# Install a mock binary that logs args to <name>.log and stdin to <name>.stdin.
+mock_cmd() {
+  local name="$1" exit_code="${2:-0}"
+  local path="$MOCK_BIN/$name"
+  {
+    printf '%s\n' '#!/bin/bash'
+    printf 'echo "ARGS: $*" >> "%s/%s.log"\n' "$TEST_DIR" "$name"
+    printf 'if [ ! -t 0 ]; then cat >> "%s/%s.stdin"; fi\n' "$TEST_DIR" "$name"
+    printf 'exit %s\n' "$exit_code"
+  } > "$path"
+  chmod +x "$path"
+}
+
+mock_uname() {
+  local kernel="$1"
+  cat > "$MOCK_BIN/uname" <<SCRIPT
+#!/bin/bash
+printf '%s\n' '$kernel'
+SCRIPT
+  chmod +x "$MOCK_BIN/uname"
+}
+
+# Mock curl: log args, then emit a canned response body to stdout.
+mock_curl_response() {
+  local body="$1" exit_code="${2:-0}"
+  {
+    printf '%s\n' '#!/bin/bash'
+    printf 'echo "ARGS: $*" >> "%s/curl.log"\n' "$TEST_DIR"
+    printf 'printf %s %q\n' '%s' "$body"
+    printf 'exit %s\n' "$exit_code"
+  } > "$MOCK_BIN/curl"
+  chmod +x "$MOCK_BIN/curl"
+}
+
+with_mocks() { export PATH="$MOCK_BIN:$PATH"; }
+
+mock_args() { [ -f "$TEST_DIR/$1.log" ] && cat "$TEST_DIR/$1.log"; }
+mock_called() { [ -f "$TEST_DIR/$1.log" ]; }
+
+# Read a field out of the dry-run trace JSON.
+tj() {
+  python3 -c "import json;d=json.load(open('$1'));print($2)"
+}
+
+run_dry() {
+  # run_dry <text> <voice> <rate> <vol> ; writes trace to $TEST_DIR/trace.json
+  local text="$1" voice="${2:-default}" rate="${3:-1.0}" vol="${4:-0.5}"
+  printf '%s\n' "$text" | \
+    PEON_TTS_DRY_RUN=1 PEON_TTS_TRACE_FILE="$TEST_DIR/trace.json" \
+    bash "$TTS_SCRIPT" "$voice" "$rate" "$vol"
+}
+
+# ============================================================
+# Script existence + syntax
+# ============================================================
+
+@test "tts-minimax.sh: file exists and is executable" {
+  [ -f "$TTS_SCRIPT" ]
+  [ -x "$TTS_SCRIPT" ]
+}
+
+@test "tts-minimax.sh: passes bash -n syntax check" {
+  bash -n "$TTS_SCRIPT"
+}
+
+# ============================================================
+# Regional endpoint resolution (dry-run)
+# ============================================================
+
+@test "dry-run: default region resolves the global endpoint" {
+  run_dry "hello"
+  [ "$(tj "$TEST_DIR/trace.json" "d['url']")" = "https://api.minimax.io/v1/t2a_v2" ]
+  [ "$(tj "$TEST_DIR/trace.json" "d['region']")" = "global_en" ]
+}
+
+@test "dry-run: cn_zh region resolves the CN endpoint" {
+  printf '%s\n' "hello" | \
+    PEON_TTS_DRY_RUN=1 PEON_TTS_TRACE_FILE="$TEST_DIR/trace.json" \
+    PEON_MINIMAX_REGION=cn_zh bash "$TTS_SCRIPT" default 1.0 0.5
+  [ "$(tj "$TEST_DIR/trace.json" "d['url']")" = "https://api.minimaxi.com/v1/t2a_v2" ]
+}
+
+@test "dry-run: unknown region falls back to the global endpoint" {
+  printf '%s\n' "hi" | \
+    PEON_TTS_DRY_RUN=1 PEON_TTS_TRACE_FILE="$TEST_DIR/trace.json" \
+    PEON_MINIMAX_REGION=bogus bash "$TTS_SCRIPT" default 1.0 0.5
+  [ "$(tj "$TEST_DIR/trace.json" "d['url']")" = "https://api.minimax.io/v1/t2a_v2" ]
+}
+
+@test "dry-run: MINIMAX_GROUP_ID is appended as a query argument" {
+  printf '%s\n' "hi" | \
+    PEON_TTS_DRY_RUN=1 PEON_TTS_TRACE_FILE="$TEST_DIR/trace.json" \
+    MINIMAX_GROUP_ID=grp42 bash "$TTS_SCRIPT" default 1.0 0.5
+  [ "$(tj "$TEST_DIR/trace.json" "d['url']")" = "https://api.minimax.io/v1/t2a_v2?GroupId=grp42" ]
+  [ "$(tj "$TEST_DIR/trace.json" "d['has_group_id']")" = "True" ]
+}
+
+# ============================================================
+# Model + request body (dry-run)
+# ============================================================
+
+@test "dry-run: default model is speech-2.8-hd" {
+  run_dry "hi"
+  [ "$(tj "$TEST_DIR/trace.json" "d['model']")" = "speech-2.8-hd" ]
+  [ "$(tj "$TEST_DIR/trace.json" "d['request']['model']")" = "speech-2.8-hd" ]
+}
+
+@test "dry-run: PEON_MINIMAX_MODEL overrides the model (speech-2.8-turbo)" {
+  printf '%s\n' "hi" | \
+    PEON_TTS_DRY_RUN=1 PEON_TTS_TRACE_FILE="$TEST_DIR/trace.json" \
+    PEON_MINIMAX_MODEL=speech-2.8-turbo bash "$TTS_SCRIPT" default 1.0 0.5
+  [ "$(tj "$TEST_DIR/trace.json" "d['request']['model']")" = "speech-2.8-turbo" ]
+}
+
+@test "dry-run: request carries model, text, and voice_setting.speed" {
+  run_dry "read this aloud"
+  [ "$(tj "$TEST_DIR/trace.json" "d['request']['text']")" = "read this aloud" ]
+  [ "$(tj "$TEST_DIR/trace.json" "d['request']['voice_setting']['speed']")" = "1.0" ]
+  [ "$(tj "$TEST_DIR/trace.json" "d['request']['audio_setting']['format']")" = "mp3" ]
+}
+
+@test "dry-run: voice=default omits voice_id" {
+  run_dry "hi" default 1.0 0.5
+  [ "$(tj "$TEST_DIR/trace.json" "'voice_id' in d['request']['voice_setting']")" = "False" ]
+}
+
+@test "dry-run: explicit voice populates voice_setting.voice_id" {
+  run_dry "hi" some-voice-id 1.0 0.5
+  [ "$(tj "$TEST_DIR/trace.json" "d['request']['voice_setting']['voice_id']")" = "some-voice-id" ]
+}
+
+@test "dry-run: PEON_MINIMAX_FORMAT changes audio_setting.format" {
+  printf '%s\n' "hi" | \
+    PEON_TTS_DRY_RUN=1 PEON_TTS_TRACE_FILE="$TEST_DIR/trace.json" \
+    PEON_MINIMAX_FORMAT=wav bash "$TTS_SCRIPT" default 1.0 0.5
+  [ "$(tj "$TEST_DIR/trace.json" "d['request']['audio_setting']['format']")" = "wav" ]
+}
+
+# ============================================================
+# Rate clamping (dry-run)
+# ============================================================
+
+@test "dry-run: rate above 2.0 is clamped to 2.0" {
+  run_dry "hi" default 3.0 0.5
+  [ "$(tj "$TEST_DIR/trace.json" "d['request']['voice_setting']['speed']")" = "2.0" ]
+}
+
+@test "dry-run: rate below 0.5 is clamped to 0.5" {
+  run_dry "hi" default 0.1 0.5
+  [ "$(tj "$TEST_DIR/trace.json" "d['request']['voice_setting']['speed']")" = "0.5" ]
+}
+
+# ============================================================
+# Credential safety
+# ============================================================
+
+@test "dry-run: has_api_key reflects the environment" {
+  run_dry "hi"
+  [ "$(tj "$TEST_DIR/trace.json" "d['has_api_key']")" = "False" ]
+  printf '%s\n' "hi" | \
+    PEON_TTS_DRY_RUN=1 PEON_TTS_TRACE_FILE="$TEST_DIR/trace.json" \
+    MINIMAX_API_KEY=sekret bash "$TTS_SCRIPT" default 1.0 0.5
+  [ "$(tj "$TEST_DIR/trace.json" "d['has_api_key']")" = "True" ]
+}
+
+@test "dry-run: the API key value never appears in the trace" {
+  printf '%s\n' "hi" | \
+    PEON_TTS_DRY_RUN=1 PEON_TTS_TRACE_FILE="$TEST_DIR/trace.json" \
+    MINIMAX_API_KEY=super-secret-value bash "$TTS_SCRIPT" default 1.0 0.5
+  ! grep -q "super-secret-value" "$TEST_DIR/trace.json"
+}
+
+# ============================================================
+# Text safety — shell metacharacters
+# ============================================================
+
+@test "dry-run: metacharacters in text are JSON-escaped, not interpreted" {
+  run_dry 'Hello $USER `whoami` "quoted"'
+  [ "$(tj "$TEST_DIR/trace.json" "d['request']['text']")" = 'Hello $USER `whoami` "quoted"' ]
+}
+
+# ============================================================
+# Empty / whitespace input contract
+# ============================================================
+
+@test "empty stdin: exits 0 without writing a trace or calling curl" {
+  mock_curl_response '{}'
+  with_mocks
+  run bash -c ": | PEON_TTS_DRY_RUN=1 PEON_TTS_TRACE_FILE='$TEST_DIR/trace.json' bash '$TTS_SCRIPT' default 1.0 0.5"
+  [ "$status" -eq 0 ]
+  [ ! -f "$TEST_DIR/trace.json" ]
+  ! mock_called "curl"
+}
+
+@test "whitespace-only stdin: exits 0 without calling curl" {
+  mock_curl_response '{}'
+  with_mocks
+  run bash -c "printf '   \\n' | MINIMAX_API_KEY=k bash '$TTS_SCRIPT' default 1.0 0.5"
+  [ "$status" -eq 0 ]
+  ! mock_called "curl"
+}
+
+# ============================================================
+# --list-voices contract
+# ============================================================
+
+@test "--list-voices: exits 0 without a request" {
+  mock_curl_response '{}'
+  with_mocks
+  run bash "$TTS_SCRIPT" --list-voices
+  [ "$status" -eq 0 ]
+  ! mock_called "curl"
+}
+
+# ============================================================
+# Live path — request + response handling
+# ============================================================
+
+@test "live: no MINIMAX_API_KEY skips the request and exits 0" {
+  mock_curl_response '{"data":{"audio":"6162"},"base_resp":{"status_code":0}}'
+  with_mocks
+  run bash -c "echo hi | bash '$TTS_SCRIPT' default 1.0 0.5"
+  [ "$status" -eq 0 ]
+  ! mock_called "curl"
+}
+
+@test "live: curl is invoked with the endpoint URL and a Bearer header" {
+  mock_uname "Darwin"
+  mock_cmd "afplay"
+  mock_curl_response '{"data":{"audio":"6162","status":2},"base_resp":{"status_code":0}}'
+  with_mocks
+  echo "hi" | MINIMAX_API_KEY=k bash "$TTS_SCRIPT" default 1.0 0.5
+  mock_called "curl"
+  local args; args=$(mock_args "curl")
+  [[ "$args" == *"https://api.minimax.io/v1/t2a_v2"* ]]
+  [[ "$args" == *"Authorization: Bearer"* ]]
+}
+
+@test "live: successful response is hex-decoded and handed to the macOS player" {
+  mock_uname "Darwin"
+  # afplay mock records the byte content of the file it is asked to play.
+  cat > "$MOCK_BIN/afplay" <<SCRIPT
+#!/bin/bash
+echo "ARGS: \$*" >> "$TEST_DIR/afplay.log"
+for a in "\$@"; do f="\$a"; done
+[ -f "\$f" ] && od -An -tx1 "\$f" | tr -d ' \n' >> "$TEST_DIR/afplay.bytes"
+SCRIPT
+  chmod +x "$MOCK_BIN/afplay"
+  mock_curl_response '{"data":{"audio":"6162","status":2},"base_resp":{"status_code":0}}'
+  with_mocks
+  echo "hi" | MINIMAX_API_KEY=k bash "$TTS_SCRIPT" default 1.0 0.7
+  mock_called "afplay"
+  [[ "$(mock_args afplay)" == *"-v 0.7"* ]]
+  # 6162 hex == "ab"
+  [ "$(cat "$TEST_DIR/afplay.bytes")" = "6162" ]
+}
+
+@test "live: base_resp.status_code != 0 skips playback" {
+  mock_uname "Darwin"
+  mock_cmd "afplay"
+  mock_curl_response '{"base_resp":{"status_code":1001,"status_msg":"bad"}}'
+  with_mocks
+  run bash -c "echo hi | MINIMAX_API_KEY=k bash '$TTS_SCRIPT' default 1.0 0.5"
+  [ "$status" -eq 0 ]
+  ! mock_called "afplay"
+}
+
+@test "live: empty data.audio skips playback" {
+  mock_uname "Darwin"
+  mock_cmd "afplay"
+  mock_curl_response '{"data":{"audio":""},"base_resp":{"status_code":0}}'
+  with_mocks
+  run bash -c "echo hi | MINIMAX_API_KEY=k bash '$TTS_SCRIPT' default 1.0 0.5"
+  [ "$status" -eq 0 ]
+  ! mock_called "afplay"
+}
+
+@test "live: curl failure does not fail the script (exit 0)" {
+  mock_uname "Darwin"
+  mock_cmd "afplay"
+  mock_curl_response '' 1
+  with_mocks
+  run bash -c "echo hi | MINIMAX_API_KEY=k bash '$TTS_SCRIPT' default 1.0 0.5"
+  [ "$status" -eq 0 ]
+  ! mock_called "afplay"
+}
+
+@test "live: Linux routes decoded audio through the preferred player (pw-play)" {
+  mock_uname "Linux"
+  mock_cmd "pw-play"
+  mock_curl_response '{"data":{"audio":"6162","status":2},"base_resp":{"status_code":0}}'
+  with_mocks
+  echo "hi" | MINIMAX_API_KEY=k bash "$TTS_SCRIPT" default 1.0 0.5
+  mock_called "pw-play"
+}

--- a/uninstall.ps1
+++ b/uninstall.ps1
@@ -152,6 +152,20 @@ if (Test-Path $CursorHooksFile) {
     }
 }
 
+# --- Remove Grok Build hooks ---
+$GrokHooksFile = Join-Path $env:USERPROFILE ".grok\hooks\peon-ping.json"
+
+if (Test-Path $GrokHooksFile) {
+    Write-Host ""
+    Write-Host "Removing Grok Build hooks..."
+    try {
+        Remove-Item -Path $GrokHooksFile -Force
+        Write-Host "  Removed $GrokHooksFile" -ForegroundColor Green
+    } catch {
+        Write-Host "  Warning: Could not remove ${GrokHooksFile}: $_" -ForegroundColor Yellow
+    }
+}
+
 # --- Remove GitHub Copilot CLI hooks ---
 $CopilotHooksFile = Join-Path $env:USERPROFILE ".copilot\hooks\peon-ping.json"
 

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -185,6 +185,14 @@ _remove_copilot_hooks() {
   echo "Removed Copilot CLI hooks: $copilot_hooks"
 }
 
+# Remove Grok Build hooks if ~/.grok/hooks/peon-ping.json exists
+_remove_grok_hooks() {
+  local grok_hooks="$HOME/.grok/hooks/peon-ping.json"
+  [ -f "$grok_hooks" ] || return 0
+  rm -f "$grok_hooks"
+  echo "Removed Grok Build hooks: $grok_hooks"
+}
+
 # Remove Codex hooks managed by peon-ping in ~/.codex/config.toml
 _remove_codex_hooks() {
   local codex_config="$HOME/.codex/config.toml"
@@ -218,6 +226,10 @@ _remove_cursor_hooks
 # Remove Copilot CLI hooks
 echo "Removing Copilot CLI hooks..."
 _remove_copilot_hooks
+
+# Remove Grok Build hooks
+echo "Removing Grok Build hooks..."
+_remove_grok_hooks
 
 # Remove OpenAI Codex hooks
 echo "Removing Codex hooks..."


### PR DESCRIPTION
Not for merge. Final batch: the two PRs that add new surface rather than fix behaviour.

- **#572** Grok Build adapter. Grok ships Claude-style lifecycle hooks but the stdin envelope is camelCase (`hookEventName`, `sessionId`) with snake_case event values, so pointing them at `peon.sh` is silent. Adds `adapters/grok.{sh,ps1}`, installer and uninstaller wiring for `~/.grok`, a `grok-` session prefix so `peon packs ide-bind` works, and 17 bats tests plus Windows Pester coverage. Enforcement is thorough: README badge and IDE table, `README_ja/ko/zh`, `docs/public/llms.txt` with the full event mapping, CHANGELOG.
- **#563** MiniMax T2A speech backend, following the calling convention in `docs/adr/ADR-001-tts-backend-architecture.md`. Unix and PowerShell scripts, regional endpoint selection, JSON assembled via `python3` so arbitrary speech text escapes safely, and it always exits 0 so a missing credential degrades to silence rather than breaking a hook. 329 bats + 221 Pester lines of tests.

**One gap to note rather than block on:** #563 introduces `MINIMAX_API_KEY`, `PEON_MINIMAX_REGION`, and `PEON_MINIMAX_MODEL` and documents none of them. That is consistent with the existing state rather than an omission by this PR: there is no TTS backends section in `README.md` or `llms.txt` at all, and `tts-native` and `tts-elevenlabs` are equally undocumented. Worth a follow-up that documents the whole backend system at once, not a reason to hold this.