### PR TITLE
fix(win): write JSON as UTF-8 without a BOM

### DIFF
--- a/adapters/kilo.ps1
+++ b/adapters/kilo.ps1
@@ -67,7 +67,10 @@ $pluginContent = $pluginContent -replace 'OpenCode -> CESP', 'Kilo CLI -> CESP'
 $pluginContent = $pluginContent -replace 'Return OpenCode event hooks', 'Return Kilo event hooks'
 
 $pluginPath = Join-Path $PluginsDir "peon-ping.ts"
-Set-Content -Path $pluginPath -Value $pluginContent -Encoding UTF8
+# UTF-8 without a BOM: Set-Content -Encoding UTF8 writes one on Windows PowerShell
+# 5.1, and a BOM trips strict parsers reading these files back.
+$utf8NoBom = New-Object System.Text.UTF8Encoding $false
+[System.IO.File]::WriteAllText($pluginPath, $pluginContent, $utf8NoBom)
 Write-Host "> Plugin installed to $pluginPath"
 
 # Create default config
@@ -98,7 +101,7 @@ if (-not (Test-Path $configPath)) {
     $prevCulture = [System.Threading.Thread]::CurrentThread.CurrentCulture
     try {
         [System.Threading.Thread]::CurrentThread.CurrentCulture = [System.Globalization.CultureInfo]::InvariantCulture
-        $config | ConvertTo-Json -Depth 3 | Set-Content $configPath -Encoding UTF8
+        [System.IO.File]::WriteAllText($configPath, (($config | ConvertTo-Json -Depth 3) + [Environment]::NewLine), $utf8NoBom)
     } finally {
         [System.Threading.Thread]::CurrentThread.CurrentCulture = $prevCulture
     }

--- a/adapters/opencode.ps1
+++ b/adapters/opencode.ps1
@@ -82,7 +82,10 @@ if (-not (Test-Path $configPath)) {
     $prevCulture = [System.Threading.Thread]::CurrentThread.CurrentCulture
     try {
         [System.Threading.Thread]::CurrentThread.CurrentCulture = [System.Globalization.CultureInfo]::InvariantCulture
-        $config | ConvertTo-Json -Depth 3 | Set-Content $configPath -Encoding UTF8
+        # UTF-8 without a BOM: Set-Content -Encoding UTF8 writes one on Windows
+        # PowerShell 5.1, and a BOM trips strict JSON parsers.
+        $utf8NoBom = New-Object System.Text.UTF8Encoding $false
+        [System.IO.File]::WriteAllText($configPath, (($config | ConvertTo-Json -Depth 3) + [Environment]::NewLine), $utf8NoBom)
     } finally {
         [System.Threading.Thread]::CurrentThread.CurrentCulture = $prevCulture
     }

--- a/install.ps1
+++ b/install.ps1
@@ -326,13 +326,13 @@ if ($Updating -and (Test-Path $configPath)) {
     } catch {
         $raw = $raw -replace '"volume"\s*:\s*\r?\n(\s*)"', '"volume": 0.5,$1"'
     }
-    Set-Content -Path $configPath -Value $raw -Encoding UTF8
+    Write-PeonTextFile -Path $configPath -Content $raw
 }
 
 # --- Install state ---
 $statePath = Join-Path $InstallDir ".state.json"
 if (-not $Updating) {
-    Set-Content -Path $statePath -Value "{}" -Encoding UTF8
+    Write-PeonTextFile -Path $statePath -Content "{}"
 }
 
 # --- Install helper scripts ---
@@ -452,10 +452,45 @@ function Get-UnixTimeSeconds {
     return [int64]([Math]::Floor(((Get-Date).ToUniversalTime() - $epoch).TotalSeconds))
 }
 
-# Raw config read; repair is done at install/update time, so hook only needs plain read.
+# Strip a leading UTF-8 BOM (U+FEFF) from text read off disk, so a config written
+# by an older peon-ping (Set-Content -Encoding UTF8 under PS 5.1) is repaired by the
+# next write instead of carrying its BOM forever.
+function Remove-Utf8Bom {
+    param([AllowEmptyString()][AllowNull()][string]$Text)
+    if ($null -eq $Text) { return $Text }
+    return $Text.TrimStart([char]0xFEFF)
+}
+
+# Write text to a file as UTF-8 without a BOM, on every PowerShell version.
+# Windows PowerShell 5.1's `Set-Content -Encoding UTF8` emits a BOM (there is no
+# utf8NoBOM token before PowerShell 6) and strict JSON readers reject it, so every
+# file this hook writes goes through here.
+function Write-PeonTextFile {
+    param(
+        [Parameter(Mandatory = $true, Position = 0)][string]$Path,
+        [Parameter(Position = 1, ValueFromPipeline = $true)][AllowEmptyString()][AllowNull()][string[]]$Content,
+        [switch]$NoNewline
+    )
+    begin { $lines = New-Object System.Collections.Generic.List[string] }
+    process {
+        if ($null -ne $Content) {
+            foreach ($line in $Content) { $lines.Add([string]$line) }
+        }
+    }
+    end {
+        # Match Set-Content: join pipeline items with a newline, terminate the file
+        # with one.
+        $text = ($lines -join [Environment]::NewLine)
+        if (-not $NoNewline -and $text.Length -gt 0) { $text += [Environment]::NewLine }
+        [System.IO.File]::WriteAllText($Path, $text, (New-Object System.Text.UTF8Encoding $false))
+    }
+}
+
+# Raw config read; repair is done at install/update time, so hook only needs plain
+# read (minus any BOM an older install left behind).
 function Get-PeonConfigRaw {
     param([string]$Path)
-    return Get-Content $Path -Raw
+    return Remove-Utf8Bom (Get-Content $Path -Raw)
 }
 
 # Write a config object to a JSON file with culture-safe serialization.
@@ -466,7 +501,7 @@ function Set-PeonConfig {
     $prevCulture = [System.Threading.Thread]::CurrentThread.CurrentCulture
     try {
         [System.Threading.Thread]::CurrentThread.CurrentCulture = [System.Globalization.CultureInfo]::InvariantCulture
-        $Config | ConvertTo-Json -Depth 10 | Set-Content $Path -Encoding UTF8
+        $Config | ConvertTo-Json -Depth 10 | Write-PeonTextFile $Path
     } finally {
         [System.Threading.Thread]::CurrentThread.CurrentCulture = $prevCulture
     }
@@ -636,7 +671,7 @@ function Set-SelectedPack {
     $updated = $raw -replace '"default_pack"\s*:\s*"[^"]*"', "`"default_pack`": `"$PackName`""
     $updated = $updated -replace '"active_pack"\s*:\s*"[^"]*"', "`"active_pack`": `"$PackName`""
     if ($updated -ne $raw) {
-        Set-Content $ConfigPath -Value $updated -Encoding UTF8
+        Write-PeonTextFile $ConfigPath $updated
     }
 }
 
@@ -768,7 +803,7 @@ function Write-StateAtomic {
     $prevCulture = [System.Threading.Thread]::CurrentThread.CurrentCulture
     try {
         [System.Threading.Thread]::CurrentThread.CurrentCulture = [System.Globalization.CultureInfo]::InvariantCulture
-        $State | ConvertTo-Json -Depth 3 | Set-Content $tmp -Encoding UTF8
+        $State | ConvertTo-Json -Depth 3 | Write-PeonTextFile $tmp
         if ($PSVersionTable.PSVersion.Major -ge 7) {
             # PS 7+ / .NET Core: Move-Item -Force performs atomic overwrite (no delete gap).
             Move-Item -Path $tmp -Destination $Path -Force
@@ -961,7 +996,7 @@ function Invoke-TtsSpeak {
         -ArgumentList "-NoProfile", "-NonInteractive", "-Command",
             "[Text.Encoding]::UTF8.GetString([Convert]::FromBase64String('$b64')) | & '$scriptPath' -voice '$Voice' -rate $Rate -vol $Volume" `
         -WindowStyle Hidden -PassThru
-    $proc.Id | Set-Content $pidFile
+    Write-PeonTextFile $pidFile ([string]$proc.Id)
 }
 
 # --- CLI commands ---
@@ -982,7 +1017,7 @@ if ($Command) {
             $newState = -not $cfg.enabled
             $raw = Get-Content $ConfigPath -Raw
             $updated = $raw -replace '"enabled"\s*:\s*(true|false)', "`"enabled`": $($newState.ToString().ToLower())"
-            if ($updated -ne $raw) { Set-Content $ConfigPath -Value $updated -Encoding UTF8 }
+            if ($updated -ne $raw) { Write-PeonTextFile $ConfigPath $updated }
             $state = if ($newState) { "ENABLED" } else { "PAUSED" }
             Write-Host "peon-ping: $state" -ForegroundColor Cyan
             return
@@ -990,14 +1025,14 @@ if ($Command) {
         "^(--)?(pause|mute)$" {
             $raw = Get-Content $ConfigPath -Raw
             $updated = $raw -replace '"enabled"\s*:\s*(true|false)', '"enabled": false'
-            if ($updated -ne $raw) { Set-Content $ConfigPath -Value $updated -Encoding UTF8 }
+            if ($updated -ne $raw) { Write-PeonTextFile $ConfigPath $updated }
             Write-Host "peon-ping: PAUSED" -ForegroundColor Yellow
             return
         }
         "^(--)?(resume|unmute)$" {
             $raw = Get-Content $ConfigPath -Raw
             $updated = $raw -replace '"enabled"\s*:\s*(true|false)', '"enabled": true'
-            if ($updated -ne $raw) { Set-Content $ConfigPath -Value $updated -Encoding UTF8 }
+            if ($updated -ne $raw) { Write-PeonTextFile $ConfigPath $updated }
             Write-Host "peon-ping: ENABLED" -ForegroundColor Green
             return
         }
@@ -1725,7 +1760,7 @@ if ($Command) {
                 $volStr = $vol.ToString([System.Globalization.CultureInfo]::InvariantCulture)
                 $raw = Get-Content $ConfigPath -Raw
                 $updated = $raw -replace '"volume"\s*:\s*[\d.]+(,?)', "`"volume`": $volStr`$1"
-                if ($updated -ne $raw) { Set-Content $ConfigPath -Value $updated -Encoding UTF8 }
+                if ($updated -ne $raw) { Write-PeonTextFile $ConfigPath $updated }
                 Write-Host "peon-ping: volume set to $vol" -ForegroundColor Green
             } else {
                 $cfg = Get-PeonConfigRaw $ConfigPath | ConvertFrom-Json
@@ -1741,7 +1776,7 @@ if ($Command) {
                     $cfgObj | Add-Member -NotePropertyName 'debug' -NotePropertyValue $true -Force
                     $prevCulture = [System.Threading.Thread]::CurrentThread.CurrentCulture
                     [System.Threading.Thread]::CurrentThread.CurrentCulture = [System.Globalization.CultureInfo]::InvariantCulture
-                    $cfgObj | ConvertTo-Json -Depth 10 | Set-Content $ConfigPath -Encoding UTF8
+                    $cfgObj | ConvertTo-Json -Depth 10 | Write-PeonTextFile $ConfigPath
                     [System.Threading.Thread]::CurrentThread.CurrentCulture = $prevCulture
                     $logDir = Join-Path $InstallDir "logs"
                     Write-Host "peon-ping: debug logging enabled -- logs at $logDir" -ForegroundColor Green
@@ -1752,7 +1787,7 @@ if ($Command) {
                     $cfgObj | Add-Member -NotePropertyName 'debug' -NotePropertyValue $false -Force
                     $prevCulture = [System.Threading.Thread]::CurrentThread.CurrentCulture
                     [System.Threading.Thread]::CurrentThread.CurrentCulture = [System.Globalization.CultureInfo]::InvariantCulture
-                    $cfgObj | ConvertTo-Json -Depth 10 | Set-Content $ConfigPath -Encoding UTF8
+                    $cfgObj | ConvertTo-Json -Depth 10 | Write-PeonTextFile $ConfigPath
                     [System.Threading.Thread]::CurrentThread.CurrentCulture = $prevCulture
                     Write-Host "peon-ping: debug logging disabled" -ForegroundColor Yellow
                     return
@@ -1978,7 +2013,7 @@ if ($Command) {
                 $changed = $true
             }
             if ($changed) {
-                $cfgObj | ConvertTo-Json -Depth 10 | Set-Content $ConfigPath -Encoding UTF8
+                $cfgObj | ConvertTo-Json -Depth 10 | Write-PeonTextFile $ConfigPath
                 Write-Host "peon-ping: config migrated (active_pack -> default_pack, agentskill -> session_override, exclude_dirs, ide_rules, notification_title_ide)" -ForegroundColor Green
             }
             # Re-run install.ps1 from a temp directory. Download install-utils.ps1
@@ -3373,7 +3408,7 @@ if ($env:PEON_TEST -eq "1") {
         TTS_VOLUME       = $ttsVolume
         TTS_MODE         = $ttsMode
         TRAINER_TTS_TEXT = $trainerTtsText
-    } | ConvertTo-Json | Set-Content -Path $ttsLogPath -Encoding UTF8
+    } | ConvertTo-Json | Write-PeonTextFile -Path $ttsLogPath
 }
 
 # --- Desktop notification dispatch ---
@@ -3413,7 +3448,7 @@ exit 0
 '@
 
 $hookScriptPath = Join-Path $InstallDir "peon.ps1"
-Set-Content -Path $hookScriptPath -Value $hookScript -Encoding UTF8
+Write-PeonTextFile -Path $hookScriptPath -Content $hookScript
 Unblock-File -Path $hookScriptPath -ErrorAction SilentlyContinue
 
 # --- Install adapter scripts ---
@@ -3535,7 +3570,7 @@ $hookCmd = "powershell -NoProfile -NonInteractive -File `"$hookScriptPath`""
 $settings = [PSCustomObject]@{}
 if (Test-Path $SettingsFile) {
     try {
-        $settings = Get-Content $SettingsFile -Raw | ConvertFrom-Json
+        $settings = Remove-Utf8Bom (Get-Content $SettingsFile -Raw) | ConvertFrom-Json
     } catch {
         $settings = [PSCustomObject]@{}
     }
@@ -3595,7 +3630,7 @@ foreach ($evt in $events) {
     }
 }
 
-$settings | ConvertTo-Json -Depth 10 | Set-Content $SettingsFile -Encoding UTF8
+$settings | ConvertTo-Json -Depth 10 | Write-PeonTextFile $SettingsFile
 Write-Host "  Hooks registered for: $($events -join ', ')" -ForegroundColor Green
 
 # --- Register UserPromptSubmit hook for /peon-ping-use command ---
@@ -3606,7 +3641,7 @@ $beforeSubmitHookPath = Join-Path $InstallDir "scripts\hook-handle-use.ps1"
 $beforeSubmitCmd = "powershell -NoProfile -NonInteractive -File `"$beforeSubmitHookPath`""
 
 # Reload settings to ensure we have the latest
-$settings = Get-Content $SettingsFile -Raw | ConvertFrom-Json
+$settings = Remove-Utf8Bom (Get-Content $SettingsFile -Raw) | ConvertFrom-Json
 
 $beforeSubmitHook = [PSCustomObject]@{
     type = "command"
@@ -3653,7 +3688,7 @@ if ($settings.hooks | Get-Member -Name "beforeSubmitPrompt" -MemberType NoteProp
     $settings.hooks.PSObject.Properties.Remove("beforeSubmitPrompt")
 }
 
-$settings | ConvertTo-Json -Depth 10 | Set-Content $SettingsFile -Encoding UTF8
+$settings | ConvertTo-Json -Depth 10 | Write-PeonTextFile $SettingsFile
 Write-Host "  UserPromptSubmit hook registered for /peon-ping-use" -ForegroundColor Green
 } # end if ($ClaudeCodeDetected)
 
@@ -3673,7 +3708,7 @@ if ((-not $Local) -and (Test-Path $CursorDir)) {
     
     if (Test-Path $CursorHooksFile) {
         try {
-            $content = Get-Content $CursorHooksFile -Raw
+            $content = Remove-Utf8Bom (Get-Content $CursorHooksFile -Raw)
             if ($content) {
                 $cursorData = $content | ConvertFrom-Json
             }
@@ -3731,7 +3766,7 @@ if ((-not $Local) -and (Test-Path $CursorDir)) {
     # Ensure directory exists
     New-Item -ItemType Directory -Path $CursorDir -Force | Out-Null
     
-    $cursorData | ConvertTo-Json -Depth 10 | Set-Content $CursorHooksFile -Encoding UTF8
+    $cursorData | ConvertTo-Json -Depth 10 | Write-PeonTextFile $CursorHooksFile
     Write-Host "  Cursor beforeSubmitPrompt hook registered" -ForegroundColor Green
 }
 
@@ -3775,7 +3810,7 @@ if ((-not $Local) -and (Test-Path $CopilotDir)) {
     }
 
     New-Item -ItemType Directory -Path $CopilotHooksDir -Force | Out-Null
-    $copilotData | ConvertTo-Json -Depth 10 | Set-Content $CopilotHooksFile -Encoding UTF8
+    $copilotData | ConvertTo-Json -Depth 10 | Write-PeonTextFile $CopilotHooksFile
     Write-Host "  Copilot CLI hooks registered for: $($copilotEvents -join ', ')" -ForegroundColor Green
 }
 
@@ -3818,7 +3853,7 @@ if ((-not $Local) -and (Test-Path $GrokDir)) {
         }
 
         New-Item -ItemType Directory -Path $GrokHooksDir -Force | Out-Null
-        $grokData | ConvertTo-Json -Depth 10 | Set-Content $GrokHooksFile -Encoding UTF8
+        $grokData | ConvertTo-Json -Depth 10 | Write-PeonTextFile $GrokHooksFile
         Write-Host "  Grok Build hooks registered for: $($grokEvents -join ', ')" -ForegroundColor Green
         Write-Host "  Reload hooks in a running Grok session (/hooks then r) or start a new one." -ForegroundColor Yellow
     } else {
@@ -4103,7 +4138,7 @@ if ((-not $Local) -and (Test-Path $CodexDir)) {
         $tempPath = Join-Path $directory ".$leaf.peon-ping-$PID-$([guid]::NewGuid().ToString('N')).tmp"
         $backupPath = "$tempPath.backup"
         try {
-            Set-Content -Path $tempPath -Value $Content -Encoding UTF8
+            Write-PeonTextFile -Path $tempPath -Content $Content
             if (Test-Path $Path) {
                 [System.IO.File]::Replace($tempPath, $Path, $backupPath)
             } else {
@@ -4135,7 +4170,7 @@ if ((-not $Local) -and (Test-Path $CodexDir)) {
     $codexContent = ""
     $codexNewline = "`n"
     if (Test-Path $CodexConfigFile) {
-        $codexContent = Get-Content $CodexConfigFile -Raw
+        $codexContent = Remove-Utf8Bom (Get-Content $CodexConfigFile -Raw)
         if ($codexContent.Contains("`r`n")) { $codexNewline = "`r`n" }
     }
 
@@ -4184,7 +4219,7 @@ if ((-not $Local) -and (Test-Path $DeepagentsDir)) {
 
     # Load or create hooks.json
     if (Test-Path $DeepagentsHooksFile) {
-        $daData = Get-Content $DeepagentsHooksFile -Raw | ConvertFrom-Json
+        $daData = Remove-Utf8Bom (Get-Content $DeepagentsHooksFile -Raw) | ConvertFrom-Json
     } else {
         $daData = [PSCustomObject]@{ hooks = @() }
     }
@@ -4209,7 +4244,7 @@ if ((-not $Local) -and (Test-Path $DeepagentsDir)) {
     # Ensure directory exists
     New-Item -ItemType Directory -Path $DeepagentsDir -Force | Out-Null
 
-    $daData | ConvertTo-Json -Depth 10 | Set-Content $DeepagentsHooksFile -Encoding UTF8
+    $daData | ConvertTo-Json -Depth 10 | Write-PeonTextFile $DeepagentsHooksFile
     $daEvents = @("session.start", "session.end", "task.complete", "input.required", "task.error", "tool.error", "user.prompt", "permission.request", "compact")
     Write-Host "  Hooks registered for: $($daEvents -join ', ')" -ForegroundColor Green
 }

--- a/scripts/hook-handle-use.ps1
+++ b/scripts/hook-handle-use.ps1
@@ -154,8 +154,10 @@ try {
     $config | Add-Member -NotePropertyName "pack_rotation" -NotePropertyValue $packRotation -Force
     
     # Write updated config
-    $config | ConvertTo-Json -Depth 10 | Set-Content $configPath -NoNewline
-    Add-Content $configPath "`n"
+    # UTF-8 without a BOM in one write: Set-Content -Encoding UTF8 emits a BOM on
+    # Windows PowerShell 5.1 and strict JSON readers reject it.
+    $utf8NoBom = New-Object System.Text.UTF8Encoding $false
+    [System.IO.File]::WriteAllText($configPath, (($config | ConvertTo-Json -Depth 10) + "`n"), $utf8NoBom)
     
 } catch {
     Write-Response -Continue $false -Message "[X] Failed to update config: $_"
@@ -187,8 +189,8 @@ try {
     $state.session_packs | Add-Member -NotePropertyName $sessionId -NotePropertyValue $packData -Force
     
     # Write updated state
-    $state | ConvertTo-Json -Depth 10 | Set-Content $statePath -NoNewline
-    Add-Content $statePath "`n"
+    $utf8NoBom = New-Object System.Text.UTF8Encoding $false
+    [System.IO.File]::WriteAllText($statePath, (($state | ConvertTo-Json -Depth 10) + "`n"), $utf8NoBom)
     
 } catch {
     Write-Response -Continue $false -Message "[X] Failed to update state: $_"

--- a/scripts/install-utils.ps1
+++ b/scripts/install-utils.ps1
@@ -10,12 +10,49 @@ function Test-SafeSourceRef($n)   { $n -match '^[A-Za-z0-9._/-]+$' -and $n -notm
 function Test-SafeSourcePath($n)  { $n -match '^[A-Za-z0-9._/-]+$' -and $n -notmatch '\.\.' -and $n[0] -ne '/' }
 function Test-SafeFilename($n)    { $n -match '^[A-Za-z0-9._-]+$' }
 
+# Strip a leading UTF-8 BOM (U+FEFF) from text read off disk.
+# Older peon-ping versions wrote JSON with Set-Content -Encoding UTF8, which under
+# Windows PowerShell 5.1 means UTF-8 *with* BOM. Stripping on read means the next
+# write repairs the file instead of preserving the BOM forever.
+function Remove-Utf8Bom {
+    param([AllowEmptyString()][AllowNull()][string]$Text)
+    if ($null -eq $Text) { return $Text }
+    return $Text.TrimStart([char]0xFEFF)
+}
+
+# Write text to a file as UTF-8 without a BOM, on every PowerShell version.
+# Windows PowerShell 5.1's `Set-Content -Encoding UTF8` emits a BOM (there is no
+# utf8NoBOM token before PowerShell 6), and strict JSON readers reject it: a BOM on
+# ~/.claude/settings.json makes the Claude Desktop app log a SyntaxError and read
+# neither hooks nor permissions, with nothing on screen pointing at the encoding.
+# Every file peon-ping writes goes through here so no call site has to remember.
+function Write-PeonTextFile {
+    param(
+        [Parameter(Mandatory = $true, Position = 0)][string]$Path,
+        [Parameter(Position = 1, ValueFromPipeline = $true)][AllowEmptyString()][AllowNull()][string[]]$Content,
+        [switch]$NoNewline
+    )
+    begin { $lines = New-Object System.Collections.Generic.List[string] }
+    process {
+        if ($null -ne $Content) {
+            foreach ($line in $Content) { $lines.Add([string]$line) }
+        }
+    }
+    end {
+        # Set-Content joins pipeline items with a newline and terminates the file
+        # with one; match that so switching writers is not also a content change.
+        $text = ($lines -join [Environment]::NewLine)
+        if (-not $NoNewline -and $text.Length -gt 0) { $text += [Environment]::NewLine }
+        [System.IO.File]::WriteAllText($Path, $text, (New-Object System.Text.UTF8Encoding $false))
+    }
+}
+
 # Returns raw config JSON with locale-damaged decimals fixed (e.g. "volume": 0,5 -> 0.5).
 # Also repairs missing volume value (e.g. "volume":\n "pack_rotation_mode" from a failed write).
 # Use before ConvertFrom-Json so config parses on systems where decimal separator is comma.
 function Get-PeonConfigRaw {
     param([string]$Path)
-    $raw = Get-Content $Path -Raw
+    $raw = Remove-Utf8Bom (Get-Content $Path -Raw)
     $raw = $raw -replace '"volume"\s*:\s*(\d),(\d+)', '"volume": $1.$2'
     $raw = $raw -replace '"volume"\s*:\s*\r?\n(\s*)"', '"volume": 0.5,$1"'
     return $raw
@@ -29,7 +66,7 @@ function Set-PeonConfig {
     $prevCulture = [System.Threading.Thread]::CurrentThread.CurrentCulture
     try {
         [System.Threading.Thread]::CurrentThread.CurrentCulture = [System.Globalization.CultureInfo]::InvariantCulture
-        $Config | ConvertTo-Json -Depth 10 | Set-Content $Path -Encoding UTF8
+        $Config | ConvertTo-Json -Depth 10 | Write-PeonTextFile $Path
     } finally {
         [System.Threading.Thread]::CurrentThread.CurrentCulture = $prevCulture
     }

--- a/scripts/tts-minimax.ps1
+++ b/scripts/tts-minimax.ps1
@@ -76,7 +76,7 @@ begin {
         if (-not $script:TracePath) { return }
         try {
             $json = $Fields | ConvertTo-Json -Depth 6 -Compress
-            Set-Content -Path $script:TracePath -Value $json -Encoding UTF8
+            [System.IO.File]::WriteAllText($script:TracePath, ($json + [Environment]::NewLine), (New-Object System.Text.UTF8Encoding $false))
         } catch {
             Write-DebugLine "trace write failed: $_"
         }

--- a/scripts/tts-native.ps1
+++ b/scripts/tts-native.ps1
@@ -78,7 +78,7 @@ begin {
         if (-not $script:TracePath) { return }
         try {
             $json = $Fields | ConvertTo-Json -Depth 4 -Compress
-            Set-Content -Path $script:TracePath -Value $json -Encoding UTF8
+            [System.IO.File]::WriteAllText($script:TracePath, ($json + [Environment]::NewLine), (New-Object System.Text.UTF8Encoding $false))
         } catch {
             Write-DebugLine "trace write failed: $_"
         }

--- a/tests/adapters-windows.Tests.ps1
+++ b/tests/adapters-windows.Tests.ps1
@@ -1771,7 +1771,7 @@ Describe "Embedded peon.ps1 Hook Script" {
     }
 
     It "Invoke-TtsSpeak writes PID to .tts.pid" {
-        $script:peonHookContent | Should -Match '\$proc\.Id.*Set-Content.*\$pidFile'
+        $script:peonHookContent | Should -Match 'Write-PeonTextFile \$pidFile.*\$proc\.Id'
     }
 
     It "Invoke-TtsSpeak returns early on empty text" {
@@ -2539,7 +2539,7 @@ Describe "path_rules: CLI Commands - Structural" {
 
     It "bind writes path_rules to config.json" {
         $script:peonHookContent | Should -Match 'cfgObj\.path_rules = \$pathRules'
-        $script:peonHookContent | Should -Match 'ConvertTo-Json.*Set-Content'
+        $script:peonHookContent | Should -Match 'ConvertTo-Json.*Write-PeonTextFile'
     }
 
     It "bind updates existing rule for same pattern (upsert)" {
@@ -3044,7 +3044,7 @@ Describe "path_rules: CLI Commands - Structural" {
 
     It "bind writes path_rules to config.json" {
         $script:peonHookContent | Should -Match 'cfgObj\.path_rules = \$pathRules'
-        $script:peonHookContent | Should -Match 'ConvertTo-Json.*Set-Content'
+        $script:peonHookContent | Should -Match 'ConvertTo-Json.*Write-PeonTextFile'
     }
 
     It "bind updates existing rule for same pattern (upsert)" {

--- a/tests/cli-config-write.Tests.ps1
+++ b/tests/cli-config-write.Tests.ps1
@@ -427,3 +427,143 @@ Describe "CLI error handling for missing config" {
         $outputStr | Should -Match "not configured|not found"
     }
 }
+
+# ============================================================
+# Encoding: every file peon-ping writes must be UTF-8 with no BOM
+#
+# Windows PowerShell 5.1's `Set-Content -Encoding UTF8` writes a BOM, and a BOM
+# on ~/.claude/settings.json makes the Claude Desktop app log a SyntaxError and
+# read neither hooks nor permissions. These tests check the bytes on disk under
+# the shell that actually reproduces it (powershell.exe, 5.1), because a source
+# grep stops holding the moment someone adds a new writer.
+# ============================================================
+
+# Resolved at discovery time: -Skip: is evaluated before BeforeAll runs.
+$script:WinPS = (Get-Command powershell.exe -ErrorAction SilentlyContinue).Source
+$script:SkipNoWinPS = -not $script:WinPS
+
+Describe "UTF-8 encoding without BOM" {
+    BeforeAll {
+        # Re-resolved for the run phase; the discovery-time copy above only feeds -Skip:.
+        $script:WinPS = (Get-Command powershell.exe -ErrorAction SilentlyContinue).Source
+
+        function script:New-EncodingTestDir {
+            $dir = Join-Path ([System.IO.Path]::GetTempPath()) "peon-bom-$([guid]::NewGuid().ToString('N').Substring(0,8))"
+            New-Item -ItemType Directory -Path $dir -Force | Out-Null
+            return $dir
+        }
+
+        # Run a script under Windows PowerShell 5.1, where -Encoding UTF8 means
+        # "UTF-8 with BOM". Via -File so paths with spaces need no quoting dance.
+        function script:Invoke-WindowsPowerShellScript {
+            param([string]$Dir, [string]$Body)
+            $scriptPath = Join-Path $Dir "run-$([guid]::NewGuid().ToString('N').Substring(0,6)).ps1"
+            [System.IO.File]::WriteAllText($scriptPath, $Body, (New-Object System.Text.UTF8Encoding $false))
+            & $script:WinPS -NoProfile -NonInteractive -ExecutionPolicy Bypass -File $scriptPath 2>&1
+        }
+
+        function script:Test-HasUtf8Bom {
+            param([string]$Path)
+            $bytes = [System.IO.File]::ReadAllBytes($Path)
+            return ($bytes.Length -ge 3 -and $bytes[0] -eq 0xEF -and $bytes[1] -eq 0xBB -and $bytes[2] -eq 0xBF)
+        }
+
+        function script:Write-BomFile {
+            param([string]$Path, [string]$Text)
+            [System.IO.File]::WriteAllText($Path, $Text, (New-Object System.Text.UTF8Encoding $true))
+        }
+    }
+
+    Context "install-time writers (scripts/install-utils.ps1)" {
+        BeforeEach { $script:dir = New-EncodingTestDir }
+        AfterEach { Remove-Item -Path $script:dir -Recurse -Force -ErrorAction SilentlyContinue }
+
+        It "Set-PeonConfig writes config.json with no BOM under Windows PowerShell 5.1" -Skip:$script:SkipNoWinPS {
+            $target = Join-Path $script:dir "config.json"
+            $utils = Join-Path $script:RepoRoot "scripts\install-utils.ps1"
+            Invoke-WindowsPowerShellScript -Dir $script:dir -Body @"
+. '$utils'
+Set-PeonConfig ([PSCustomObject]@{ default_pack = 'peon'; volume = 0.5; enabled = `$true }) '$target'
+"@
+            Test-Path $target | Should -Be $true
+            Test-HasUtf8Bom $target | Should -Be $false
+        }
+
+        It "the settings.json writer used by install.ps1 leaves no BOM under Windows PowerShell 5.1" -Skip:$script:SkipNoWinPS {
+            # Exactly the expression install.ps1 uses to register hooks:
+            #   $settings | ConvertTo-Json -Depth 10 | Write-PeonTextFile $SettingsFile
+            $target = Join-Path $script:dir "settings.json"
+            $utils = Join-Path $script:RepoRoot "scripts\install-utils.ps1"
+            Invoke-WindowsPowerShellScript -Dir $script:dir -Body @"
+. '$utils'
+`$settings = [PSCustomObject]@{ hooks = [PSCustomObject]@{ SessionStart = @() } }
+`$settings | ConvertTo-Json -Depth 10 | Write-PeonTextFile '$target'
+"@
+            Test-Path $target | Should -Be $true
+            Test-HasUtf8Bom $target | Should -Be $false
+            (Get-Content $target -Raw | ConvertFrom-Json).hooks | Should -Not -BeNullOrEmpty
+        }
+
+        It "Write-PeonTextFile overwrites an existing BOM'd file without a BOM" -Skip:$script:SkipNoWinPS {
+            # Upgrade path: a settings.json left BOM'd by an older peon-ping must
+            # come back clean, not keep its BOM forever.
+            $target = Join-Path $script:dir "settings.json"
+            Write-BomFile -Path $target -Text '{ "hooks": {} }'
+            Test-HasUtf8Bom $target | Should -Be $true
+
+            $utils = Join-Path $script:RepoRoot "scripts\install-utils.ps1"
+            Invoke-WindowsPowerShellScript -Dir $script:dir -Body @"
+. '$utils'
+`$settings = Remove-Utf8Bom (Get-Content '$target' -Raw) | ConvertFrom-Json
+`$settings | ConvertTo-Json -Depth 10 | Write-PeonTextFile '$target'
+"@
+            Test-HasUtf8Bom $target | Should -Be $false
+        }
+
+        It "Remove-Utf8Bom strips a leading BOM and leaves clean text alone" {
+            . (Join-Path $script:RepoRoot "scripts\install-utils.ps1")
+            (Remove-Utf8Bom ([char]0xFEFF + '{}')) | Should -Be '{}'
+            (Remove-Utf8Bom '{}') | Should -Be '{}'
+            (Remove-Utf8Bom $null) | Should -BeNullOrEmpty
+        }
+    }
+
+    Context "runtime writers (the generated peon.ps1)" {
+        BeforeEach { $script:env = New-TestHookEnv -ConfigOverrides @{ enabled = $true } }
+        AfterEach { Remove-TestHookEnv -Dir $script:env.Dir }
+
+        It "--pause leaves config.json with no BOM under Windows PowerShell 5.1" -Skip:$script:SkipNoWinPS {
+            & $script:WinPS -NoProfile -NonInteractive -ExecutionPolicy Bypass -File $script:env.HookPath -Command "--pause" 2>&1 | Out-Null
+
+            Test-HasUtf8Bom $script:env.ConfigPath | Should -Be $false
+            (Get-Content $script:env.ConfigPath -Raw | ConvertFrom-Json).enabled | Should -Be $false
+        }
+
+        It "--volume repairs a config.json that already carries a BOM" -Skip:$script:SkipNoWinPS {
+            # The runtime hook re-wrote config.json on every peon command, so a
+            # user already in the broken state stays broken until a write repairs it.
+            $original = Get-Content $script:env.ConfigPath -Raw
+            Write-BomFile -Path $script:env.ConfigPath -Text $original
+            Test-HasUtf8Bom $script:env.ConfigPath | Should -Be $true
+
+            & $script:WinPS -NoProfile -NonInteractive -ExecutionPolicy Bypass -File $script:env.HookPath -Command "--volume" -Arg1 "0.3" 2>&1 | Out-Null
+
+            Test-HasUtf8Bom $script:env.ConfigPath | Should -Be $false
+            (Get-Content $script:env.ConfigPath -Raw | ConvertFrom-Json).volume | Should -Be 0.3
+        }
+    }
+
+    Context "source guard" {
+        # Secondary net only. The byte assertions above are what actually holds;
+        # this just makes an accidental reintroduction fail loudly and early.
+        It "no PowerShell writer uses Set-Content -Encoding UTF8" {
+            $offenders = @(
+                Get-ChildItem -Path $script:RepoRoot -Filter "*.ps1" -Recurse |
+                    Where-Object { $_.FullName -notmatch '[\\/]tests[\\/]' } |
+                    Where-Object { (Get-Content $_.FullName -Raw) -match '(?m)^[^#\r\n]*Set-Content[^\r\n]*-Encoding\s+UTF8' } |
+                    ForEach-Object { $_.FullName.Substring($script:RepoRoot.Length + 1) }
+            )
+            $offenders -join ", " | Should -BeExactly ""
+        }
+    }
+}

--- a/uninstall.ps1
+++ b/uninstall.ps1
@@ -9,6 +9,38 @@ param(
 
 $ErrorActionPreference = "Stop"
 
+# Strip a leading UTF-8 BOM (U+FEFF) from text read off disk. Older peon-ping
+# versions wrote JSON with Set-Content -Encoding UTF8, which under Windows
+# PowerShell 5.1 means UTF-8 *with* BOM; uninstalling should hand the file back
+# clean rather than preserve it.
+function Remove-Utf8Bom {
+    param([AllowEmptyString()][AllowNull()][string]$Text)
+    if ($null -eq $Text) { return $Text }
+    return $Text.TrimStart([char]0xFEFF)
+}
+
+# Write text to a file as UTF-8 without a BOM, on every PowerShell version.
+# `Set-Content -Encoding UTF8` writes a BOM on PS 5.1, and strict JSON readers
+# (the Claude Desktop settings loader among them) reject it outright.
+function Write-PeonTextFile {
+    param(
+        [Parameter(Mandatory = $true, Position = 0)][string]$Path,
+        [Parameter(Position = 1, ValueFromPipeline = $true)][AllowEmptyString()][AllowNull()][string[]]$Content,
+        [switch]$NoNewline
+    )
+    begin { $lines = New-Object System.Collections.Generic.List[string] }
+    process {
+        if ($null -ne $Content) {
+            foreach ($line in $Content) { $lines.Add([string]$line) }
+        }
+    }
+    end {
+        $text = ($lines -join [Environment]::NewLine)
+        if (-not $NoNewline -and $text.Length -gt 0) { $text += [Environment]::NewLine }
+        [System.IO.File]::WriteAllText($Path, $text, (New-Object System.Text.UTF8Encoding $false))
+    }
+}
+
 Write-Host "=== peon-ping uninstaller ===" -ForegroundColor Cyan
 Write-Host ""
 
@@ -38,7 +70,7 @@ if (Test-Path $SettingsFile) {
     Write-Host "Removing peon hooks from settings.json..."
 
     try {
-        $settingsObj = Get-Content $SettingsFile -Raw | ConvertFrom-Json
+        $settingsObj = Remove-Utf8Bom (Get-Content $SettingsFile -Raw) | ConvertFrom-Json
         $eventsChanged = @()
 
         if ($settingsObj.hooks) {
@@ -80,7 +112,7 @@ if (Test-Path $SettingsFile) {
             }
 
             $settingsObj.hooks = $hooksObj
-            $settingsObj | ConvertTo-Json -Depth 10 | Set-Content $SettingsFile -Encoding UTF8
+            $settingsObj | ConvertTo-Json -Depth 10 | Write-PeonTextFile $SettingsFile
 
             if ($eventsChanged.Count -gt 0) {
                 Write-Host "  Removed hooks for: $($eventsChanged -join ', ')" -ForegroundColor Green
@@ -102,7 +134,7 @@ if (Test-Path $CursorHooksFile) {
     Write-Host "Removing Cursor hooks..."
     
     try {
-        $cursorData = Get-Content $CursorHooksFile -Raw | ConvertFrom-Json
+        $cursorData = Remove-Utf8Bom (Get-Content $CursorHooksFile -Raw) | ConvertFrom-Json
         $eventsChanged = @()
         
         if ($cursorData.hooks) {
@@ -139,7 +171,7 @@ if (Test-Path $CursorHooksFile) {
                 }
                 $cursorData.hooks = $hooksObj
             }
-            $cursorData | ConvertTo-Json -Depth 10 | Set-Content $CursorHooksFile -Encoding UTF8
+            $cursorData | ConvertTo-Json -Depth 10 | Write-PeonTextFile $CursorHooksFile
             
             if ($eventsChanged.Count -gt 0) {
                 Write-Host "  Removed Cursor hooks for: $($eventsChanged -join ', ')" -ForegroundColor Green
@@ -437,7 +469,7 @@ function Set-PeonCodexConfigAtomic([string]$Path, [string]$Content) {
     $tempPath = Join-Path $directory ".$leaf.peon-ping-$PID-$([guid]::NewGuid().ToString('N')).tmp"
     $backupPath = "$tempPath.backup"
     try {
-        Set-Content -Path $tempPath -Value $Content -Encoding UTF8
+        Write-PeonTextFile -Path $tempPath -Content $Content
         if (Test-Path $Path) {
             [System.IO.File]::Replace($tempPath, $Path, $backupPath)
         } else {
@@ -453,7 +485,7 @@ if (Test-Path $CodexConfigFile) {
     Write-Host ""
     Write-Host "Removing Codex hooks..."
     try {
-        $codexContent = Get-Content $CodexConfigFile -Raw
+        $codexContent = Remove-Utf8Bom (Get-Content $CodexConfigFile -Raw)
         $originalCodexContent = $codexContent
         $codexNewline = if ($codexContent.Contains("`r`n")) { "`r`n" } else { "`n" }
 


### PR DESCRIPTION
Fixes #569. Implements what @garysheng laid out in https://github.com/PeonPing/peon-ping/issues/569#issuecomment-5426943077: a sweep rather than per-call-site fixes, a byte-level test, and idempotent repair on upgrade.

## The fix

Under Windows PowerShell 5.1 — the shell both `install.ps1` and the generated `peon.ps1` run under — `Set-Content -Encoding UTF8` means UTF-8 **with** BOM, and there is no BOM-less token before PowerShell 6. `#147` introduced `$utf8NoBom` for exactly this reason but applied it only to the `peon.cmd` / `peon.sh` wrappers; the JSON writers a few lines below were never converted.

Every writer now goes through one helper, so a new call site cannot reintroduce it:

```powershell
function Write-PeonTextFile {
    # ... [System.IO.File]::WriteAllText($Path, $text, (New-Object System.Text.UTF8Encoding $false))
}
```

It lives in `scripts/install-utils.ps1` for install time and is mirrored into the generated `peon.ps1` next to the other duplicated helpers (`Get-PeonConfigRaw`, `Set-PeonConfig`), because the runtime hook re-wrote `config.json` on every `peon` config/toggle command — fixing install alone would not have held. It reproduces `Set-Content`'s newline behaviour so swapping writers is not also a content change.

Converted, beyond the two `settings.json` writers:

- `install.ps1` — config normalize-on-update, `.state.json` seed, the generated `peon.ps1` itself, `Set-PeonConfig`, `Set-SelectedPack`, `Write-StateAtomic`, the `--toggle` / `--pause` / `--resume` / `--volume` / `debug` / migration CLI writers, the TTS PID file, and the Cursor / Copilot / Grok / Codex / deepagents adapter files
- `uninstall.ps1` — it rewrote `~/.claude/settings.json` on the way out, so uninstalling re-BOM'd the file this issue is about
- `adapters/kilo.ps1`, `adapters/opencode.ps1`, `scripts/hook-handle-use.ps1`, `scripts/tts-native.ps1`, `scripts/tts-minimax.ps1`

`scripts/hook-handle-use.ps1` also had a `Set-Content -NoNewline` with no `-Encoding` at all, which is ANSI on 5.1; that is now the same single UTF-8 write.

## Idempotent repair

`Remove-Utf8Bom` strips a leading BOM on the read side, so an upgrade repairs a `settings.json` or `config.json` an older version already BOM'd. Applied where the installer and uninstaller read an existing settings/hooks file, and in both copies of `Get-PeonConfigRaw`.

## Tests

`tests/cli-config-write.Tests.ps1` gains a `UTF-8 encoding without BOM` block that reads the first three bytes off disk and asserts they are not `EF BB BF`:

- the install-time writer (`Set-PeonConfig`, and the exact `ConvertTo-Json | Write-PeonTextFile` expression `install.ps1` uses for `settings.json`)
- the runtime hook's `--pause` write
- repair: a `settings.json` and a `config.json` seeded **with** a BOM come back clean after a write
- `Remove-Utf8Bom` unit coverage

The child processes run under `powershell.exe`, not `pwsh` — under PowerShell 7 `-Encoding UTF8` is already BOM-less, so a byte check there would pass with or without the fix. Verified the harness reproduces the bug: `'{}' | Set-Content x.json -Encoding UTF8` under 5.1 gives `EF BB BF`, so these assertions fail on `main`.

A source grep for `Set-Content ... -Encoding UTF8` is included as a secondary guard only — as you noted it stops holding the moment someone adds a new writer, which is why the byte assertions carry the weight.

Two structural assertions in `tests/adapters-windows.Tests.ps1` that pinned the old `Set-Content` idiom were updated to the new one.

## Verification

Full Pester suite on Windows: **924 passed**, 1 failure unrelated to this change (`peon-engine.Tests.ps1` "accepts StateOverrides" compares a local-time datetime against UTC and fails the same way on a clean `main` checkout in a non-UTC timezone).

No shell scripts touched, so the BATS job is unaffected. No `VERSION` / `CHANGELOG.md` bump — happy to add one if you want it in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
