### PR TITLE
fix(codex): greet when SessionStart is missed

### DIFF
--- a/adapters/codex.sh
+++ b/adapters/codex.sh
@@ -29,13 +29,58 @@ else
   CODEX_STDIN="$(cat)"
 fi
 
+# A restored Codex thread can reuse its session id while skipping SessionStart.
+# Prefer the current Codex process as the activation boundary so a relaunched
+# client can greet again without turning every prompt into a greeting. The env
+# override keeps the boundary deterministic for tests and unusual launchers.
+resolve_codex_activation_id() {
+  if [ "${PEON_CODEX_ACTIVATION_ID+x}" = "x" ]; then
+    printf '%s' "$PEON_CODEX_ACTIVATION_ID"
+    return
+  fi
+
+  local pid="$PPID"
+  local depth=0
+  local comm=""
+  local comm_base=""
+  local args=""
+  local started=""
+  local parent=""
+  while [ -n "$pid" ] && [ "$pid" -gt 1 ] 2>/dev/null && [ "$depth" -lt 12 ]; do
+    comm="$(ps -p "$pid" -o comm= 2>/dev/null | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' || true)"
+    args="$(ps -p "$pid" -o args= 2>/dev/null || true)"
+    comm_base="${comm##*/}"
+    if [ "$comm_base" = "codex" ] || [ "$comm_base" = "codex.exe" ] || [[ "$args" == *"@openai/codex"* ]]; then
+      started="$(ps -p "$pid" -o lstart= 2>/dev/null | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' || true)"
+      printf '%s|%s|%s' "$pid" "$started" "$comm"
+      return
+    fi
+    parent="$(ps -p "$pid" -o ppid= 2>/dev/null | tr -d '[:space:]')"
+    [ -n "$parent" ] || break
+    pid="$parent"
+    depth=$((depth + 1))
+  done
+}
+
+CODEX_ACTIVATION_ID="$(resolve_codex_activation_id)"
+
 # Map to a CESP payload. Silent events (PreToolUse, PostToolUse) print nothing,
 # so peon.sh is never invoked for per-tool-call chatter.
-MAPPED_JSON="$(_CODEX_EVENT="$CODEX_EVENT" _CODEX_STDIN="$CODEX_STDIN" python3 - <<'PY'
+MAPPED_JSON="$(_CODEX_EVENT="$CODEX_EVENT" \
+  _CODEX_STDIN="$CODEX_STDIN" \
+  _CODEX_ACTIVATION_ID="$CODEX_ACTIVATION_ID" \
+  _PEON_DIR="$PEON_DIR" \
+  _CODEX_ACTIVATION_TTL_SECONDS="${PEON_CODEX_ACTIVATION_TTL_SECONDS:-1800}" \
+  _CODEX_START_GRACE_SECONDS="${PEON_CODEX_START_GRACE_SECONDS:-3}" \
+  python3 - <<'PY'
+import fcntl
+import hashlib
 import json
 import os
 import re
 import sys
+import tempfile
+import time
 
 
 def first_non_empty(*values):
@@ -48,6 +93,121 @@ def first_non_empty(*values):
         else:
             return value
     return ""
+
+
+def positive_float(value, default):
+    try:
+        parsed = float(value)
+        return parsed if parsed > 0 else default
+    except (TypeError, ValueError):
+        return default
+
+
+def write_json_atomic(path, value):
+    directory = os.path.dirname(path)
+    descriptor, temporary_path = tempfile.mkstemp(prefix=".codex-activation.", dir=directory)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            json.dump(value, handle, separators=(",", ":"))
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.chmod(temporary_path, 0o600)
+        os.replace(temporary_path, path)
+    finally:
+        if os.path.exists(temporary_path):
+            os.unlink(temporary_path)
+
+
+def update_activation_state(mapped_event, session_id):
+    peon_dir = os.environ.get("_PEON_DIR", "").strip()
+    if not peon_dir or not session_id:
+        return "unchanged"
+
+    activation_id = os.environ.get("_CODEX_ACTIVATION_ID", "").strip()
+    activation_ttl = positive_float(
+        os.environ.get("_CODEX_ACTIVATION_TTL_SECONDS", ""), 1800
+    )
+    grace_seconds = positive_float(
+        os.environ.get("_CODEX_START_GRACE_SECONDS", ""), 3
+    )
+    now = time.time()
+    state_path = os.path.join(peon_dir, ".codex-activation-state.json")
+    lock_path = os.path.join(peon_dir, ".codex-activation-state.lock")
+    os.makedirs(peon_dir, exist_ok=True)
+
+    # When no Codex process can be found, the session id falls back to an
+    # inactivity lease instead of becoming a permanent lifetime marker.
+    boundary = activation_id or "inactivity-lease"
+    key = hashlib.sha256(f"{session_id}\0{boundary}".encode("utf-8")).hexdigest()
+
+    with open(lock_path, "a+", encoding="utf-8") as lock:
+        fcntl.flock(lock.fileno(), fcntl.LOCK_EX)
+        try:
+            try:
+                with open(state_path, encoding="utf-8") as handle:
+                    state = json.load(handle)
+            except (FileNotFoundError, json.JSONDecodeError, OSError):
+                state = {}
+            if not isinstance(state, dict):
+                state = {}
+            activations = state.get("activations", {})
+            if not isinstance(activations, dict):
+                activations = {}
+
+            # Keep the adapter-specific state bounded independently of peon.sh.
+            prune_before = now - 7 * 86400
+            activations = {
+                item_key: item
+                for item_key, item in activations.items()
+                if isinstance(item, dict)
+                and isinstance(item.get("last_seen"), (int, float))
+                and item["last_seen"] >= prune_before
+            }
+            record = activations.get(key)
+            if record and now - record.get("last_seen", 0) >= activation_ttl:
+                activations.pop(key, None)
+                record = None
+
+            action = "unchanged"
+            if mapped_event == "SessionStart":
+                greeted_at = record.get("greeted_at", 0) if record else 0
+                if record and now - greeted_at < grace_seconds:
+                    record["last_seen"] = now
+                    action = "suppress-start"
+                else:
+                    activations[key] = {
+                        "session_id": session_id,
+                        "activation_id": activation_id,
+                        "source": "SessionStart",
+                        "greeted_at": now,
+                        "last_seen": now,
+                    }
+                    action = "emit-start"
+            elif mapped_event == "UserPromptSubmit":
+                if record:
+                    record["last_seen"] = now
+                    action = "emit-prompt"
+                else:
+                    activations[key] = {
+                        "session_id": session_id,
+                        "activation_id": activation_id,
+                        "source": "UserPromptSubmit",
+                        "greeted_at": now,
+                        "last_seen": now,
+                    }
+                    action = "fallback-start"
+            elif mapped_event == "SessionEnd":
+                activations.pop(key, None)
+            elif record:
+                record["last_seen"] = now
+
+            state["version"] = 1
+            state["activations"] = activations
+            write_json_atomic(state_path, state)
+            return action
+        finally:
+            fcntl.flock(lock.fileno(), fcntl.LOCK_UN)
 
 
 raw_stdin = os.environ.get("_CODEX_STDIN", "").strip()
@@ -186,10 +346,29 @@ if mapped_event == "PostToolUseFailure":
         error = f"Codex event: {raw_event}"
     payload["error"] = str(error)[:180]
 
-print(json.dumps(payload))
+try:
+    activation_action = update_activation_state(mapped_event, session_id)
+except Exception:
+    # Sound integration state must never block a Codex hook.
+    activation_action = "unchanged"
+
+if mapped_event == "SessionStart" and activation_action == "suppress-start":
+    sys.exit(0)
+
+payloads = [payload]
+if mapped_event == "UserPromptSubmit" and activation_action == "fallback-start":
+    fallback = dict(payload)
+    fallback["hook_event_name"] = "SessionStart"
+    payloads.insert(0, fallback)
+
+for item in payloads:
+    print(json.dumps(item))
 PY
 )" || MAPPED_JSON=""
 
 if [ -n "$MAPPED_JSON" ]; then
-  printf '%s' "$MAPPED_JSON" | bash "$PEON_SH"
+  while IFS= read -r mapped_json; do
+    [ -n "$mapped_json" ] || continue
+    printf '%s' "$mapped_json" | bash "$PEON_SH"
+  done <<< "$MAPPED_JSON"
 fi

--- a/tests/codex.bats
+++ b/tests/codex.bats
@@ -6,6 +6,7 @@ setup() {
   setup_test_env
 
   CODEX_SH="${PEON_SH%/peon.sh}/adapters/codex.sh"
+  export PEON_CODEX_ACTIVATION_ID="activation-1"
 
   # Adapter resolves peon.sh via CLAUDE_PEON_DIR
   ln -sf "$PEON_SH" "$TEST_DIR/peon.sh"
@@ -144,10 +145,108 @@ assert last.get('cwd') == '/tmp/codex-proj', last
   ! afplay_was_called
 }
 
-@test "stable UserPromptSubmit plays no sound" {
+@test "first UserPromptSubmit without SessionStart plays one fallback greeting" {
   run_codex "" '{"hook_event_name":"UserPromptSubmit","session_id":"s1"}'
   [ "$CODEX_EXIT" -eq 0 ]
-  ! afplay_was_called
+  [ "$(afplay_call_count)" -eq 1 ]
+  sound=$(afplay_sound)
+  [[ "$sound" == *"/packs/peon/sounds/Hello"* ]]
+
+  # The original prompt still reaches peon.sh for status/spam bookkeeping.
+  "$PEON_PY" -c "
+import json
+state = json.load(open('$TEST_DIR/.state.json'))
+assert len(state.get('prompt_timestamps', {}).get('codex-s1', [])) == 1, state
+"
+}
+
+@test "additional prompts in the same activation do not replay the greeting" {
+  run_codex "" '{"hook_event_name":"UserPromptSubmit","session_id":"s1"}'
+  [ "$CODEX_EXIT" -eq 0 ]
+  [ "$(afplay_call_count)" -eq 1 ]
+
+  run_codex "" '{"hook_event_name":"UserPromptSubmit","session_id":"s1"}'
+  [ "$CODEX_EXIT" -eq 0 ]
+  [ "$(afplay_call_count)" -eq 1 ]
+}
+
+@test "real SessionStart followed by a prompt produces one greeting" {
+  run_codex "" '{"hook_event_name":"SessionStart","session_id":"s1"}'
+  [ "$CODEX_EXIT" -eq 0 ]
+  [ "$(afplay_call_count)" -eq 1 ]
+
+  run_codex "" '{"hook_event_name":"UserPromptSubmit","session_id":"s1"}'
+  [ "$CODEX_EXIT" -eq 0 ]
+  [ "$(afplay_call_count)" -eq 1 ]
+}
+
+@test "late SessionStart after a fallback does not duplicate the greeting" {
+  run_codex "" '{"hook_event_name":"UserPromptSubmit","session_id":"s1"}'
+  [ "$CODEX_EXIT" -eq 0 ]
+  [ "$(afplay_call_count)" -eq 1 ]
+
+  run_codex "" '{"hook_event_name":"SessionStart","session_id":"s1"}'
+  [ "$CODEX_EXIT" -eq 0 ]
+  [ "$(afplay_call_count)" -eq 1 ]
+}
+
+@test "concurrent fallback and SessionStart produce one greeting" {
+  printf '%s' '{"hook_event_name":"UserPromptSubmit","session_id":"s1"}' \
+    | bash "$CODEX_SH" >/dev/null 2>&1 &
+  prompt_pid=$!
+  printf '%s' '{"hook_event_name":"SessionStart","session_id":"s1"}' \
+    | bash "$CODEX_SH" >/dev/null 2>&1 &
+  start_pid=$!
+
+  wait "$prompt_pid"
+  wait "$start_pid"
+  [ "$(afplay_call_count)" -eq 1 ]
+}
+
+@test "same session id in a new activation gets one fallback greeting" {
+  run_codex "" '{"hook_event_name":"UserPromptSubmit","session_id":"s1"}'
+  [ "$CODEX_EXIT" -eq 0 ]
+  [ "$(afplay_call_count)" -eq 1 ]
+
+  export PEON_CODEX_ACTIVATION_ID="activation-2"
+  run_codex "" '{"hook_event_name":"UserPromptSubmit","session_id":"s1"}'
+  [ "$CODEX_EXIT" -eq 0 ]
+  [ "$(afplay_call_count)" -eq 2 ]
+}
+
+@test "expired activation marker allows one new fallback greeting" {
+  export PEON_CODEX_ACTIVATION_TTL_SECONDS=1
+  run_codex "" '{"hook_event_name":"UserPromptSubmit","session_id":"s1"}'
+  [ "$CODEX_EXIT" -eq 0 ]
+  [ "$(afplay_call_count)" -eq 1 ]
+
+  "$PEON_PY" -c "
+import json
+path = '$TEST_DIR/.codex-activation-state.json'
+state = json.load(open(path))
+for record in state.get('activations', {}).values():
+    record['last_seen'] -= 2
+json.dump(state, open(path, 'w'))
+"
+
+  run_codex "" '{"hook_event_name":"UserPromptSubmit","session_id":"s1"}'
+  [ "$CODEX_EXIT" -eq 0 ]
+  [ "$(afplay_call_count)" -eq 2 ]
+}
+
+@test "prompt bookkeeping is preserved after fallback" {
+  run_codex "" '{"hook_event_name":"UserPromptSubmit","session_id":"s1"}'
+  [ "$CODEX_EXIT" -eq 0 ]
+  run_codex "" '{"hook_event_name":"UserPromptSubmit","session_id":"s1"}'
+  [ "$CODEX_EXIT" -eq 0 ]
+  run_codex "" '{"hook_event_name":"UserPromptSubmit","session_id":"s1"}'
+  [ "$CODEX_EXIT" -eq 0 ]
+
+  "$PEON_PY" -c "
+import json
+state = json.load(open('$TEST_DIR/.state.json'))
+assert len(state.get('prompt_timestamps', {}).get('codex-s1', [])) == 3, state
+"
 }
 
 @test "stable PostCompact is silent" {


### PR DESCRIPTION
## Summary

- Add a Codex-only `SessionStart` fallback before the first `UserPromptSubmit` when the current activation has no greeting record.
- Track the activation with the Codex parent process and a 30-minute inactivity lease. File locking, atomic writes, and a 3-second grace window prevent duplicate greetings when a real `SessionStart` arrives near the fallback.

The adapter still forwards the original `UserPromptSubmit`, so status and rapid-prompt bookkeeping continue to work.

## Context

Codex can restore a previous thread without emitting `SessionStart` on the path tracked in openai/codex#24228. Codex reuses the thread's session ID on that path, so a permanent session marker would suppress the greeting after a client restart. The adapter combines that session ID with the Codex client process identity and expires the record after inactivity.

When the adapter receives a real `SessionStart`, it records that greeting first. If Codex fixes the upstream lifecycle bug, the normal `SessionStart` followed by `UserPromptSubmit` sequence still produces one greeting.

## Tests

- `bats tests/codex.bats`: 26 passed
- Concurrent fallback/real-start race: passed 10 consecutive runs
- `bats tests/`: the only failure was the unchanged `PEON_WSL_AUDIO_BACKEND=mediaplayer` test. Current `upstream/main` reproduces the same missing PowerShell log.
- `bash -n adapters/codex.sh`
- `git diff --check`

Fixes #575
