### PR TITLE
docs: use pkgs.stdenv.hostPlatform.system in Nix examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,13 +151,13 @@ For reproducible setups, use the Home Manager module:
 { inputs, pkgs, ... }:
 
 let
-  peonCursorAdapterPath = "${inputs.peon-ping.packages.${pkgs.system}.default}/share/peon-ping/adapters/cursor.sh";
+  peonCursorAdapterPath = "${inputs.peon-ping.packages.${pkgs.stdenv.hostPlatform.system}.default}/share/peon-ping/adapters/cursor.sh";
 in {
   imports = [ inputs.peon-ping.homeManagerModules.default ];
 
   programs.peon-ping = {
     enable = true;
-    package = inputs.peon-ping.packages.${pkgs.system}.default;
+    package = inputs.peon-ping.packages.${pkgs.stdenv.hostPlatform.system}.default;
     claudeCodeIntegration = true;
 
     settings = {
@@ -227,7 +227,7 @@ For packs listed on [openpeon.com](https://openpeon.com/), find the GitHub repos
 
 **Other IDE hooks**: adapters for other IDEs are still opt-in so the module does not overwrite unrelated IDE settings. peon-ping provides adapter scripts such as `cursor.sh` in [`adapters/`](https://github.com/PeonPing/peon-ping/tree/main/adapters), and you can wire them like this:
   ```sh
-  ${inputs.peon-ping.packages.${pkgs.system}.default}/share/peon-ping/adapters/$YOUR_IDE.sh EVENT_NAME
+  ${inputs.peon-ping.packages.${pkgs.stdenv.hostPlatform.system}.default}/share/peon-ping/adapters/$YOUR_IDE.sh EVENT_NAME
   ```
   See the Cursor example above.
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -125,13 +125,13 @@ nix develop  # or use direnv
 { inputs, pkgs, ... }:
 
 let
-  peonCursorAdapterPath = "${inputs.peon-ping.packages.${pkgs.system}.default}/share/peon-ping/adapters/cursor.sh";
+  peonCursorAdapterPath = "${inputs.peon-ping.packages.${pkgs.stdenv.hostPlatform.system}.default}/share/peon-ping/adapters/cursor.sh";
 in {
   imports = [ inputs.peon-ping.homeManagerModules.default ];
 
   programs.peon-ping = {
     enable = true;
-    package = inputs.peon-ping.packages.${pkgs.system}.default;
+    package = inputs.peon-ping.packages.${pkgs.stdenv.hostPlatform.system}.default;
     claudeCodeIntegration = true;
 
     settings = {
@@ -201,7 +201,7 @@ in {
 
 **その他の IDE フック**: peon-ping と無関係な IDE 設定を上書きしないよう、その他の IDE フックは引き続き任意です。peon-ping は [`adapters/`](https://github.com/PeonPing/peon-ping/tree/main/adapters) 配下に `cursor.sh` などのアダプタースクリプトを提供しており、次のように接続できます：
   ```sh
-  ${inputs.peon-ping.packages.${pkgs.system}.default}/share/peon-ping/adapters/$YOUR_IDE.sh EVENT_NAME
+  ${inputs.peon-ping.packages.${pkgs.stdenv.hostPlatform.system}.default}/share/peon-ping/adapters/$YOUR_IDE.sh EVENT_NAME
   ```
   上記の Cursor の例を参照してください
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -133,13 +133,13 @@ nix develop  # 或使用 direnv
 { inputs, pkgs, ... }:
 
 let
-  peonCursorAdapterPath = "${inputs.peon-ping.packages.${pkgs.system}.default}/share/peon-ping/adapters/cursor.sh";
+  peonCursorAdapterPath = "${inputs.peon-ping.packages.${pkgs.stdenv.hostPlatform.system}.default}/share/peon-ping/adapters/cursor.sh";
 in {
   imports = [ inputs.peon-ping.homeManagerModules.default ];
 
   programs.peon-ping = {
     enable = true;
-    package = inputs.peon-ping.packages.${pkgs.system}.default;
+    package = inputs.peon-ping.packages.${pkgs.stdenv.hostPlatform.system}.default;
     claudeCodeIntegration = true;
 
     settings = {
@@ -209,7 +209,7 @@ in {
 
 **其他 IDE 钩子**：为避免覆盖与 peon-ping 无关的 IDE 设置，其他 IDE 的钩子仍然是可选的。peon-ping 在 [`adapters/`](https://github.com/PeonPing/peon-ping/tree/main/adapters) 下提供如 `cursor.sh` 之类的适配器脚本，你可以这样接入：
   ```sh
-  ${inputs.peon-ping.packages.${pkgs.system}.default}/share/peon-ping/adapters/$YOUR_IDE.sh EVENT_NAME
+  ${inputs.peon-ping.packages.${pkgs.stdenv.hostPlatform.system}.default}/share/peon-ping/adapters/$YOUR_IDE.sh EVENT_NAME
   ```
   参见上方 Cursor 示例。
 


### PR DESCRIPTION
## What

The Nix snippets in the READMEs use `pkgs.system`, which is deprecated in nixpkgs. Copying them into a `home.nix` means every `home-manager switch` prints:

```
evaluation warning: 'system' has been renamed to/replaced by 'stdenv.hostPlatform.system'
```

This swaps the 9 occurrences over to `pkgs.stdenv.hostPlatform.system` — the Home Manager module example and the IDE adapter snippet, in `README.md`, `README_ja.md` and `README_zh.md`.

## Notes

- Docs only. No code or behaviour change — `pkgs.stdenv.hostPlatform.system` evaluates to the same string.
- Verified locally against a standalone Home Manager config using the module: with the old attribute `home-manager switch` warns; with the new one it evaluates cleanly and produces a byte-identical generation path.
- Translations included so the three READMEs stay in sync; only the code blocks changed, no prose was touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)